### PR TITLE
Lvm scripts and performance profiling

### DIFF
--- a/cmd/mithril/main.go
+++ b/cmd/mithril/main.go
@@ -3,6 +3,8 @@ package main
 import (
 	"context"
 	"flag"
+	"net/http"          // ← added
+	_ "net/http/pprof"  // ← added
 	"os"
 	"os/signal"
 
@@ -33,6 +35,15 @@ func init() {
 
 func main() {
 	mlog.Log.Infof("mithril verifying node\n")
+
+	// --- start pprof server on localhost:6060 ---
+	go func() {
+		if err := http.ListenAndServe("localhost:6060", nil); err != nil {
+			mlog.Log.Infof("pprof server stopped: %v", err) // changed Warnf → Infof
+		}
+	}()
+	// --------------------------------------------
+
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer cancel()
 	cobra.CheckErr(cmd.ExecuteContext(ctx))

--- a/pkg/accountsdb/accountsdb.go
+++ b/pkg/accountsdb/accountsdb.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Overclock-Validator/mithril/pkg/sbpf"
 	"github.com/Overclock-Validator/mithril/pkg/util"
 	"github.com/Overclock-Validator/sniper"
+	"github.com/Overclock-Validator/sniper/options"
 	bin "github.com/gagliardetto/binary"
 	"github.com/gagliardetto/solana-go"
 	"github.com/maypok86/otter"
@@ -79,9 +80,16 @@ func OpenDb(accountsDbDir string) (*AccountsDb, error) {
 		return nil, fmt.Errorf("only got %d bytes", bytesRead)
 	}
 
-	// attempt to open the index kv store
+	// configure Sniper to avoid huge chunk init in Go heap
 	indexDir := fmt.Sprintf("%s/index", accountsDbDir)
-	db, err := sniper.Open(sniper.Dir(indexDir), sniper.ChunksCollision(32))
+	// start from default options and tweak
+	opts := options.DefaultOptions
+	opts.ReadOnlyMMap = false               // keep index in OS, not Go heap
+	opts.TableLoadingMode = options.LoadToDisk // on-demand disk reads
+	opts.TableMaxOpenFiles = 4              // cap open SSTs
+
+	// open the index kv store with tuned options
+	db, err := sniper.Open(sniper.Dir(indexDir), sniper.ChunksCollision(32), opts)
 	if err != nil {
 		mlog.Log.Infof("failed to open database: %s\n", err)
 		return nil, err
@@ -163,7 +171,7 @@ func (accountsDb *AccountsDb) GetAccount(slot uint64, pubkey solana.PublicKey) (
 	appendVecFileName := fmt.Sprintf("%s/%d.%d", accountsDb.AcctsDir, acctIdxEntry.Slot, acctIdxEntry.FileId)
 	appendVecFile, err := os.Open(appendVecFileName)
 	if err != nil {
-		mlog.Log.Debugf("failed to open appendvec file %s")
+		mlog.Log.Debugf("failed to open appendvec file %s", appendVecFileName)
 		return nil, err
 	}
 
@@ -237,54 +245,3 @@ func (accountsDb *AccountsDb) StoreAccounts(accts []*accounts.Account, slot uint
 		err = accountsDb.IndexDb.SetIfSlotHigher(acct.Key[:], writer.Bytes(), 0)
 		if err != nil {
 			mlog.Log.Debugf("error calling SetIfSlotHigher on accountsdb for pubkey %s", acct.Key)
-			return err
-		}
-
-		msg := util.PrettyPrintAcct(acct)
-		mlog.Log.Debugf("SLOT %d - wrote account %s to %s in StoreAccounts: %s", slot, acct.Key, appendVecFileName, msg)
-
-		// marshal up the account as an appendvec style account and write it to the buffer
-		appendVecAcct := AppendVecAccount{DataLen: uint64(len(acct.Data)), Pubkey: acct.Key, Lamports: acct.Lamports,
-			RentEpoch: acct.RentEpoch, Owner: acct.Owner, Executable: acct.Executable, Data: acct.Data}
-
-		err = appendVecAcct.Marshal(appendVecAcctsBuf)
-		if err != nil {
-			return err
-		}
-	}
-
-	// write the appendvecs data into the file
-	n, err := appendVecFile.Write(appendVecAcctsBuf.Bytes())
-	if err != nil {
-		return err
-	} else if n != appendVecAcctsBuf.Len() {
-		return fmt.Errorf("only wrote %d appendvec account bytes, rather than %d", n, appendVecAcctsBuf.Len())
-	}
-
-	return nil
-}
-
-func (accountsDb *AccountsDb) KeysBetweenPrefixes(startPrefix uint64, endPrefix uint64) []solana.PublicKey {
-	keys := accountsDb.IndexDb.KeysBetweenPrefixes(startPrefix, endPrefix)
-
-	keyObjs := make([]solana.PublicKey, 0)
-	for _, key := range keys {
-		keyObject := solana.PublicKeyFromBytes(key)
-		keyObjs = append(keyObjs, keyObject)
-	}
-
-	return keyObjs
-}
-
-func (accountsDb *AccountsDb) AllKeys() [][]byte {
-	keys := accountsDb.IndexDb.AllKeys()
-	sort.SliceStable(keys, func(i, j int) bool {
-		return util.PubkeyCmpByteSlice(keys[i], keys[j])
-	})
-
-	return keys
-}
-
-func (accountsDb *AccountsDb) BankHash() [32]byte {
-	return accountsDb.BankHashBytes
-}

--- a/pkg/accountsdb/accountsdb.go
+++ b/pkg/accountsdb/accountsdb.go
@@ -63,6 +63,7 @@ func OpenDb(accountsDbDir string) (*AccountsDb, error) {
 
 	largestFileId := binary.LittleEndian.Uint64(largestFileIdBytes)
 
+	// attempt to open bank_hash file
 	bankHashFn := fmt.Sprintf("%s/bank_hash", accountsDbDir)
 	bhf, err := os.Open(bankHashFn)
 	if err != nil {
@@ -76,22 +77,25 @@ func OpenDb(accountsDbDir string) (*AccountsDb, error) {
 		mlog.Log.Infof("error reading %s: %s\n", bankHashFn, err)
 		return nil, err
 	} else if bytesRead != 32 {
-		mlog.Log.Infof("error reading %s: expected 8 bytes, got %d\n", bankHashFn, bytesRead)
+		mlog.Log.Infof("error reading %s: expected 32 bytes, got %d\n", bankHashFn, bytesRead)
 		return nil, fmt.Errorf("only got %d bytes", bytesRead)
 	}
 
-	// configure Sniper to avoid huge chunk init in Go heap
+	// configure Sniper options to reduce heap usage
 	indexDir := fmt.Sprintf("%s/index", accountsDbDir)
-	// start from default options and tweak
 	opts := options.DefaultOptions
-	opts.ReadOnlyMMap = false               // keep index in OS, not Go heap
-	opts.TableLoadingMode = options.LoadToDisk // on-demand disk reads
-	opts.TableMaxOpenFiles = 4              // cap open SSTs
+	opts.ReadOnlyMMap = false                // avoid loading all SSTs into Go heap
+	opts.TableLoadingMode = options.LoadToDisk // read-on-demand from disk (or use LoadToRAM)
+	opts.TableMaxOpenFiles = 4               // limit number of open SST files
 
 	// open the index kv store with tuned options
-	db, err := sniper.Open(sniper.Dir(indexDir), sniper.ChunksCollision(32), opts)
+	db, err := sniper.Open(
+		sniper.Dir(indexDir),
+		sniper.ChunksCollision(32),
+		opts,
+	)
 	if err != nil {
-		mlog.Log.Infof("failed to open database: %s\n", err)
+		mlog.Log.Infof("failed to open sniper store: %s\n", err)
 		return nil, err
 	}
 
@@ -109,29 +113,21 @@ func (accountsDb *AccountsDb) CloseDb() {
 func (accountsDb *AccountsDb) InitCaches() {
 	var err error
 	accountsDb.VoteAcctCache, err = otter.MustBuilder[solana.PublicKey, *accounts.Account](10_000).
-		Cost(func(key solana.PublicKey, acct *accounts.Account) uint32 {
-			return 1
-		}).
+		Cost(func(key solana.PublicKey, acct *accounts.Account) uint32 { return 1 }).
 		Build()
 	if err != nil {
 		panic(err)
 	}
 
-	// TODO: review size of program cache
 	accountsDb.ProgramCache, err = otter.MustBuilder[solana.PublicKey, *sbpf.Program](10_000).
-		Cost(func(key solana.PublicKey, prog *sbpf.Program) uint32 {
-			return 1
-		}).
+		Cost(func(key solana.PublicKey, prog *sbpf.Program) uint32 { return 1 }).
 		Build()
 	if err != nil {
 		panic(err)
 	}
 
-	// TODO: review size of common accounts cache
 	accountsDb.CommonAcctCache, err = otter.MustBuilder[solana.PublicKey, *accounts.Account](250_000).
-		Cost(func(key solana.PublicKey, acct *accounts.Account) uint32 {
-			return 1
-		}).
+		Cost(func(key solana.PublicKey, acct *accounts.Account) uint32 { return 1 }).
 		Build()
 	if err != nil {
 		panic(err)
@@ -147,101 +143,107 @@ func (accountsDb *AccountsDb) AddProgramToCache(pubkey solana.PublicKey, program
 }
 
 func (accountsDb *AccountsDb) GetAccount(slot uint64, pubkey solana.PublicKey) (*accounts.Account, error) {
-	cachedAcct, hasAcct := accountsDb.VoteAcctCache.Get(pubkey)
-	if hasAcct {
-		return cachedAcct, nil
+	if acct, ok := accountsDb.VoteAcctCache.Get(pubkey); ok {
+		return acct, nil
+	}
+	if acct, ok := accountsDb.CommonAcctCache.Get(pubkey); ok {
+		return acct, nil
 	}
 
-	cachedAcct, hasAcct = accountsDb.CommonAcctCache.Get(pubkey)
-	if hasAcct {
-		return cachedAcct, nil
-	}
-
-	acctIdxEntryBytes, err := accountsDb.IndexDb.Get(pubkey[:])
+	entryBytes, err := accountsDb.IndexDb.Get(pubkey[:])
 	if err != nil {
-		mlog.Log.Debugf("no account found in accountsdb for pubkey %s: %s", pubkey, err)
+		mlog.Log.Debugf("no account in index for %s: %v", pubkey, err)
 		return nil, ErrNoAccount
 	}
-
-	acctIdxEntry, err := unmarshalAcctIdxEntry(acctIdxEntryBytes)
+	idxEntry, err := unmarshalAcctIdxEntry(entryBytes)
 	if err != nil {
-		panic("failed to unmarshal AccountIndexEntry from index kv database")
+		panic("invalid account index entry")
 	}
 
-	appendVecFileName := fmt.Sprintf("%s/%d.%d", accountsDb.AcctsDir, acctIdxEntry.Slot, acctIdxEntry.FileId)
-	appendVecFile, err := os.Open(appendVecFileName)
+	fileName := fmt.Sprintf("%s/%d.%d", accountsDb.AcctsDir, idxEntry.Slot, idxEntry.FileId)
+	f, err := os.Open(fileName)
 	if err != nil {
-		mlog.Log.Debugf("failed to open appendvec file %s", appendVecFileName)
 		return nil, err
 	}
+	defer f.Close()
 
-	offset, err := appendVecFile.Seek(int64(acctIdxEntry.Offset), 0)
+	if _, err := f.Seek(int64(idxEntry.Offset), 0); err != nil {
+		panic(err)
+	}
+	acct, err := unmarshalAcctFromAppendVecAcctHeader(f)
 	if err != nil {
-		panic(fmt.Sprintf("file seek failed: %s\n", err))
+		panic(err)
 	}
-	if offset != int64(acctIdxEntry.Offset) {
-		panic(fmt.Sprintf("file seek gave wrong idx (%d)\n", offset))
-	}
-
-	acct, err := unmarshalAcctFromAppendVecAcctHeader(appendVecFile)
-	if err != nil {
-		panic(fmt.Sprintf("failed to unmarshal account from appendvec file %s: %s", appendVecFileName, err))
-	}
+	acct.Slot = idxEntry.Slot
 
 	if acct.Key != pubkey {
-		panic(fmt.Sprintf("account unmarshaled from appendvec file %s has the wrong pubkey", appendVecFileName))
+		panic("pubkey mismatch after unmarshal")
 	}
-
-	acct.Slot = acctIdxEntry.Slot
-
-	msg := util.PrettyPrintAcct(acct)
-	mlog.Log.Debugf("SLOT %d - accountsdb.Get() found acct in %s for %s: %s", slot, appendVecFileName, pubkey, msg)
-
-	appendVecFile.Close()
-
-	return acct, err
+	return acct, nil
 }
 
 var voteAcct = solana.MustPublicKeyFromBase58("Vote111111111111111111111111111111111111111")
 
 func (accountsDb *AccountsDb) StoreAccounts(accts []*accounts.Account, slot uint64) error {
 	fileId := accountsDb.LargestFileId.Add(1)
-
-	appendVecFileName := fmt.Sprintf("%s/%d.%d", accountsDb.AcctsDir, slot, fileId)
-	appendVecFile, err := os.OpenFile(appendVecFileName, os.O_RDWR|os.O_CREATE, 0666)
-	if err != nil {
-		mlog.Log.Debugf("unable to open appendvec file %s for writing to accountsdb", appendVecFileName)
-		return err
-	}
-	defer appendVecFile.Close()
-
-	appendVecAcctsBuf := new(bytes.Buffer)
-	writer := new(bytes.Buffer)
-
+	buf := new(bytes.Buffer)
 	for _, acct := range accts {
 		acct.Slot = slot
-
-		// if vote account, do not serialize up and write into accountsdb - just save it in cache.
 		if solana.PublicKeyFromBytes(acct.Owner[:]) == voteAcct {
 			accountsDb.VoteAcctCache.Set(acct.Key, acct)
 			continue
 		}
-
 		accountsDb.CommonAcctCache.Set(acct.Key, acct)
 
-		// create index entry, encode it and write it to the index kv store
-		// offset field is specified as the current num of bytes written to the appendvec buffer.
-		writer.Reset()
-		encoder := bin.NewBinEncoder(writer)
+		// index entry
+		buf.Reset()
+		enc := bin.NewBinEncoder(buf)
+		entry := AccountIndexEntry{Slot: slot, FileId: fileId, Offset: uint64(buf.Len())}
+		entry.MarshalWithEncoder(enc)
+		accountsDb.IndexDb.SetIfSlotHigher(acct.Key[:], buf.Bytes(), 0)
 
-		indexEntry := AccountIndexEntry{Slot: slot, FileId: fileId, Offset: uint64(appendVecAcctsBuf.Len())}
-
-		err = indexEntry.MarshalWithEncoder(encoder)
-		if err != nil {
-			mlog.Log.Debugf("error marshaling in Set on accountsdb for pubkey %s", acct.Key)
-			return err
+		// appendvec
+		raw := AppendVecAccount{
+			DataLen:   uint64(len(acct.Data)),
+			Pubkey:    acct.Key,
+			Lamports:  acct.Lamports,
+			RentEpoch: acct.RentEpoch,
+			Owner:     acct.Owner,
+			Executable: acct.Executable,
+			Data:      acct.Data,
 		}
+		raw.Marshal(buf)
+	}
 
-		err = accountsDb.IndexDb.SetIfSlotHigher(acct.Key[:], writer.Bytes(), 0)
-		if err != nil {
-			mlog.Log.Debugf("error calling SetIfSlotHigher on accountsdb for pubkey %s", acct.Key)
+	outFile := fmt.Sprintf("%s/%d.%d", accountsDb.AcctsDir, slot, fileId)
+	f, err := os.OpenFile(outFile, os.O_CREATE|os.O_WRONLY, 0o666)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	if _, err := f.Write(buf.Bytes()); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (accountsDb *AccountsDb) KeysBetweenPrefixes(startPrefix uint64, endPrefix uint64) []solana.PublicKey {
+	keys := accountsDb.IndexDb.KeysBetweenPrefixes(startPrefix, endPrefix)
+	out := make([]solana.PublicKey, len(keys))
+	for i, k := range keys {
+		out[i] = solana.PublicKeyFromBytes(k)
+	}
+	return out
+}
+
+func (accountsDb *AccountsDb) AllKeys() [][]byte {
+	keys := accountsDb.IndexDb.AllKeys()
+	sort.Slice(keys, func(i, j int) bool {
+		return util.PubkeyCmpByteSlice(keys[i], keys[j])
+	})
+	return keys
+}
+
+func (accountsDb *AccountsDb) BankHash() [32]byte {
+	return accountsDb.BankHashBytes
+}

--- a/pkg/accountsdb/accountsdb.go
+++ b/pkg/accountsdb/accountsdb.go
@@ -14,10 +14,11 @@ import (
 	"github.com/Overclock-Validator/mithril/pkg/sbpf"
 	"github.com/Overclock-Validator/mithril/pkg/util"
 	"github.com/Overclock-Validator/sniper"
-	"github.com/Overclock-Validator/sniper/options"
 	bin "github.com/gagliardetto/binary"
 	"github.com/gagliardetto/solana-go"
 	"github.com/maypok86/otter"
+	"runtime"
+	"runtime/debug"
 )
 
 type AccountsDb struct {
@@ -31,107 +32,77 @@ type AccountsDb struct {
 	ProgramCache    otter.Cache[solana.PublicKey, *sbpf.Program]
 }
 
-var (
-	ErrNoAccount = errors.New("ErrNoAccount")
-)
+var ErrNoAccount = errors.New("ErrNoAccount")
 
-func OpenDb(accountsDbDir string) (*AccountsDb, error) {
-	// check for existence of the 'accounts' directory, which holds the appendvecs
-	appendVecsDir := fmt.Sprintf("%s/accounts", accountsDbDir)
-	_, err := os.Stat(appendVecsDir)
-	if err != nil {
+// -----------------------------------------------------------------------------
+// Open existing AccountsDB
+// -----------------------------------------------------------------------------
+func OpenDb(dir string) (*AccountsDb, error) {
+	// ensure append‑vec folder exists
+	avecs := fmt.Sprintf("%s/accounts", dir)
+	if _, err := os.Stat(avecs); err != nil {
 		return nil, err
 	}
 
-	// attempt to open largest_file_id file
-	largestFileIdFn := fmt.Sprintf("%s/largest_file_id", accountsDbDir)
-	lfi, err := os.Open(largestFileIdFn)
-	if err != nil {
-		mlog.Log.Infof("failed to open %s\n", largestFileIdFn)
-		return nil, err
+	// read largest_file_id
+	lfiPath := fmt.Sprintf("%s/largest_file_id", dir)
+	lfi, err := os.ReadFile(lfiPath)
+	if err != nil || len(lfi) != 8 {
+		return nil, fmt.Errorf("cannot read %s: %v", lfiPath, err)
+	}
+	largest := binary.LittleEndian.Uint64(lfi)
+
+	// read bank_hash
+	bhPath := fmt.Sprintf("%s/bank_hash", dir)
+	bh, err := os.ReadFile(bhPath)
+	if err != nil || len(bh) != 32 {
+		return nil, fmt.Errorf("cannot read %s: %v", bhPath, err)
 	}
 
-	largestFileIdBytes := make([]byte, 8)
-	bytesRead, err := lfi.Read(largestFileIdBytes)
-	if err != nil {
-		mlog.Log.Infof("error reading %s: %s\n", largestFileIdFn, err)
-		return nil, err
-	} else if bytesRead != 8 {
-		mlog.Log.Infof("error reading %s: expected 8 bytes, got %d\n", largestFileIdFn, bytesRead)
-		return nil, fmt.Errorf("only got %d bytes", bytesRead)
-	}
-
-	largestFileId := binary.LittleEndian.Uint64(largestFileIdBytes)
-
-	// attempt to open bank_hash file
-	bankHashFn := fmt.Sprintf("%s/bank_hash", accountsDbDir)
-	bhf, err := os.Open(bankHashFn)
-	if err != nil {
-		mlog.Log.Infof("failed to open %s\n", bankHashFn)
-		return nil, err
-	}
-
-	bankHashBytes := make([]byte, 32)
-	bytesRead, err = bhf.Read(bankHashBytes)
-	if err != nil {
-		mlog.Log.Infof("error reading %s: %s\n", bankHashFn, err)
-		return nil, err
-	} else if bytesRead != 32 {
-		mlog.Log.Infof("error reading %s: expected 32 bytes, got %d\n", bankHashFn, bytesRead)
-		return nil, fmt.Errorf("only got %d bytes", bytesRead)
-	}
-
-	// configure Sniper options to reduce heap usage
-	indexDir := fmt.Sprintf("%s/index", accountsDbDir)
-	opts := options.DefaultOptions
-	opts.ReadOnlyMMap = false                // avoid loading all SSTs into Go heap
-	opts.TableLoadingMode = options.LoadToDisk // read-on-demand from disk (or use LoadToRAM)
-	opts.TableMaxOpenFiles = 4               // limit number of open SST files
-
-	// open the index kv store with tuned options
+	// open sniper index – default options
+	indexDir := fmt.Sprintf("%s/index", dir)
 	db, err := sniper.Open(
 		sniper.Dir(indexDir),
 		sniper.ChunksCollision(32),
-		opts,
 	)
 	if err != nil {
-		mlog.Log.Infof("failed to open sniper store: %s\n", err)
-		return nil, err
+		return nil, fmt.Errorf("sniper.Open: %w", err)
 	}
 
-	accountsDb := &AccountsDb{IndexDb: db, AcctsDir: appendVecsDir, IndexDir: indexDir}
-	accountsDb.LargestFileId.Store(largestFileId)
-	copy(accountsDb.BankHashBytes[:], bankHashBytes)
+	// ---- GC away Sniper chunk structs --------------------------------------
+	runtime.GC()         // sweep now‑unreferenced chunks
+	debug.FreeOSMemory() // madvise; RSS drops immediately
+	// ------------------------------------------------------------------------
 
-	return accountsDb, nil
+	adb := &AccountsDb{
+		IndexDb:  db,
+		AcctsDir: avecs,
+		IndexDir: indexDir,
+	}
+	adb.LargestFileId.Store(largest)
+	copy(adb.BankHashBytes[:], bh)
+	return adb, nil
 }
 
-func (accountsDb *AccountsDb) CloseDb() {
-	accountsDb.IndexDb.Close()
-}
+func (a *AccountsDb) CloseDb() { a.IndexDb.Close() }
 
-func (accountsDb *AccountsDb) InitCaches() {
-	var err error
-	accountsDb.VoteAcctCache, err = otter.MustBuilder[solana.PublicKey, *accounts.Account](10_000).
-		Cost(func(key solana.PublicKey, acct *accounts.Account) uint32 { return 1 }).
-		Build()
-	if err != nil {
-		panic(err)
+// -----------------------------------------------------------------------------
+// Caches
+// -----------------------------------------------------------------------------
+func (a *AccountsDb) InitCaches() {
+	buildAcct := func(cap int) otter.Cache[solana.PublicKey, *accounts.Account] {
+		c, err := otter.MustBuilder[solana.PublicKey, *accounts.Account](cap).
+			Cost(func(_ solana.PublicKey, _ *accounts.Account) uint32 { return 1 }).Build()
+		if err != nil { panic(err) }
+		return c
 	}
+	a.VoteAcctCache   = buildAcct(4_000)
+	a.CommonAcctCache = buildAcct(250_000)
 
-	accountsDb.ProgramCache, err = otter.MustBuilder[solana.PublicKey, *sbpf.Program](10_000).
-		Cost(func(key solana.PublicKey, prog *sbpf.Program) uint32 { return 1 }).
-		Build()
-	if err != nil {
-		panic(err)
-	}
-
-	accountsDb.CommonAcctCache, err = otter.MustBuilder[solana.PublicKey, *accounts.Account](250_000).
-		Cost(func(key solana.PublicKey, acct *accounts.Account) uint32 { return 1 }).
-		Build()
-	if err != nil {
-		panic(err)
-	}
+	p, err := otter.MustBuilder[solana.PublicKey, *sbpf.Program](10_000).
+		Cost(func(_ solana.PublicKey, _ *sbpf.Program) uint32 { return 1 }).Build()
+	if err != nil { panic(err) }
+	a.ProgramCache = p
 }
 
 func (accountsDb *AccountsDb) MaybeGetProgramFromCache(pubkey solana.PublicKey) (*sbpf.Program, bool) {

--- a/scripts/lvm_setup/README.md
+++ b/scripts/lvm_setup/README.md
@@ -1,0 +1,101 @@
+# LVM Setup and Mithril Workflow with Snapshots
+
+This document outlines the steps to set up LVM thin provisioning on a dedicated NVMe drive, build a Solana accounts database using Mithril, and then use LVM snapshots to run subsequent Mithril processes without modifying the original database.
+
+**Assumes:**
+* You have two bash scripts saved: `setup_mithril_lvm.sh` (for infrastructure) and `manage_mithril_snapshot.sh` (for snapshot operations).
+* You have a Python 3 script `snapshot-finder.py` designed to find and download a suitable Solana snapshot `.tar.zst` file.
+* You have the `mithril` binary (likely at `~/mithril/mithril`).
+* You have necessary permissions (most commands require `sudo`).
+* You have LVM tools (`lvm2`), filesystem tools (`e2fsprogs`), and other Linux utilities installed.
+
+**IMPORTANT CONFIGURATION:** ⚠️
+* **BEFORE STARTING:** Edit **both** `setup_mithril_lvm.sh` and `manage_mithril_snapshot.sh` to ensure the configuration variables match your environment, especially:
+    * `DEVICE`: The target NVMe drive (e.g., `/dev/nvme1n1`). **Verify this carefully!**
+    * `VG_NAME`: Volume group name (e.g., `accounts_vg_run`). Must match in both scripts.
+    * `MASTER_LV_NAME`: Name for the original LV (e.g., `accounts_master`). Must match in both scripts.
+    * `LVM_PCT`: Percentage of disk for LVM in `setup_mithril_lvm.sh`. This controls the size trade-off between the accounts DB partition (`/mnt/accounts_master`) and the partition for other data/downloads (`/var/lib/mithril`).
+        > **Disk Space Warning:** You need enough space on the partition mounted at `/var/lib/mithril` (size determined by `100 - LVM_PCT`) to hold the downloaded `.tar.zst` file (e.g., ~95GiB+). You *also* need enough space in the thin pool (size determined by `LVM_PCT`) to hold the *uncompressed* accounts database built on `/mnt/accounts_master` (which can easily exceed 700GiB). If your disk isn't large enough for both, consider setting `LVM_PCT` high (e.g., 95) and modifying Step 3/4 to download/read the `.tar.zst` from a *different disk* entirely. `LVM_PCT=80` (giving ~179G for downloads and ~713G for the DB pool) is a starting point only if your disk is sufficiently large (e.g., 1TB+).
+    * `SNAPSHOTS_DIR_OWNER`: User:group for the `/var/lib/mithril/snapshots` directory in `setup_mithril_lvm.sh` (e.g., `ubuntu:ubuntu`).
+    * `SNAPSHOT_MOUNT_BASE`: Base path for snapshot mounts in `manage_mithril_snapshot.sh` (e.g., `/mnt`).
+
+---
+
+## Workflow Steps
+
+1.  **Wipe Disk (Optional - Use with extreme caution!)** ⚠️
+
+    * This step completely erases the target NVMe drive specified in the script. Only run this if you are starting fresh or need to reset everything on that disk.
+    ```bash
+    # Make sure DEVICE in setup_mithril_lvm.sh points to the correct NVMe drive!
+    sudo ./setup_mithril_lvm.sh wipe
+    # Follow prompts - requires typing 'yes'
+    ```
+
+2.  **Setup LVM Infrastructure**
+
+    * This partitions the disk, creates the LVM Volume Group, Thin Pool, the master Logical Volume (`accounts_master`), formats filesystems, mounts `/mnt/accounts_master` & `/var/lib/mithril`, creates `/var/lib/mithril/snapshots` subdir, and sets up `/etc/fstab` for auto-mounting.
+    * > **ℹ️ Note:** Ensure `LVM_PCT` in the script provides enough space for `/var/lib/mithril` (for Step 3) *and* for `/mnt/accounts_master` (for Step 4), considering the **Disk Space Warning** above.
+    ```bash
+    sudo ./setup_mithril_lvm.sh setup
+    # Verify mounts after completion, e.g., with 'df -h /mnt/accounts_master /var/lib/mithril'
+    ```
+
+3.  **Download Solana Snapshot (`.tar.zst`)**
+
+    * Use your python script (or another method) to find and download the desired Solana network snapshot file into the designated directory created by the setup script.
+    * > **ℹ️ Note:** This requires `/var/lib/mithril` (Partition 2) to have sufficient space (e.g., ~95GiB+). Verify the `LVM_PCT` setting provides this.
+    ```bash
+    # Example using your python script
+    python3 snapshot-finder.py --snapshot_path /var/lib/mithril/snapshots --version 2. --max_latency 150
+    # Make note of the exact filename downloaded (e.g., snapshot-XYZ.tar.zst) for the next step
+    ```
+
+4.  **Build Initial AccountsDB on Master LV** ✅
+
+    * Run the Mithril verifier in snapshot mode to unpack the downloaded `.tar.zst` file and build the accounts database onto the persistent `accounts_master` LVM volume.
+    * > **⚠️ Warning:** This process writes the *uncompressed* database. Ensure the thin pool (Partition 1, size set by `LVM_PCT`) is large enough, otherwise you will get "no space left on device" errors.
+    * > **ℹ️ Note:** This command likely requires `sudo` to write to `/mnt/accounts_master`.
+    ```bash
+    # Replace <downloaded_snapshot_filename.tar.zst> with the actual filename from Step 3
+    # Replace <YOUR_API_KEY> with your actual Helius API key
+    sudo ~/mithril/mithril verifier \
+      --snapshot \
+      --path /var/lib/mithril/snapshots/<downloaded_snapshot_filename.tar.zst> \
+      --out /mnt/accounts_master \
+      --rpc [https://mainnet.helius-rpc.com/?api-key=](https://mainnet.helius-rpc.com/?api-key=)<YOUR_API_KEY>
+    ```
+
+5.  **Create Temporary LVM Snapshot**
+
+    * Use the snapshot management script to create a point-in-time LVM snapshot of the `accounts_master` volume (which now contains the built database). This snapshot will be mounted read-write for the next step.
+    * `<name>` (e.g., `run1`) determines the snapshot LV name and default mount point (`/mnt/<name>`).
+    ```bash
+    # Creates snapshot 'run1', activates it, checks filesystem, mounts it at /mnt/run1
+    sudo ./manage_mithril_snapshot.sh snapshot run1
+    ```
+
+6.  **Run Mithril Process on LVM Snapshot**
+
+    * Run your Mithril process (e.g., verifying block ranges) against the *LVM snapshot's mount point* (`/mnt/run1` in this example). Any changes made by Mithril will be written only to the snapshot, leaving `/mnt/accounts_master` untouched.
+    * > **ℹ️ Note:** This command might require `sudo` depending on permissions and Mithril's requirements.
+    ```bash
+    # Replace <YOUR_API_KEY> and adjust slots as needed
+    sudo ~/mithril/mithril verifier \
+      --accountsdb \
+      --path /mnt/run1 \
+      --startslot 337648943 \
+      --endslot   337648953 \
+      --rpc [https://mainnet.helius-rpc.com/?api-key=](https://mainnet.helius-rpc.com/?api-key=)<YOUR_API_KEY>
+    ```
+
+7.  **Clean Up LVM Snapshot** ✅
+
+    * Once your Mithril run is complete, remove the temporary LVM snapshot using the management script. This frees up space within the thin pool that was consumed by the changes written during Step 6.
+    ```bash
+    sudo ./manage_mithril_snapshot.sh remove_snapshot run1
+    ```
+
+---
+
+**Repeating Runs:** For subsequent runs against the same base `accounts_master` database, repeat **Steps 5, 6, and 7**. You only need to perform Steps 1-4 again if you need to completely reset the disk or build the accounts database from a newer Solana network snapshot.

--- a/scripts/lvm_setup/manage_mithril_snapshot.sh
+++ b/scripts/lvm_setup/manage_mithril_snapshot.sh
@@ -1,0 +1,238 @@
+#!/usr/bin/env bash
+# Purpose: Script to create, mount, and remove LVM snapshots for Mithril runs.
+# Assumes LVM infrastructure (VG, Thin Pool, Master LV) was created by setup_mithril_lvm.sh
+set -euo pipefail
+
+### CONFIGURATION ###
+# --- LVM Naming (MUST MATCH setup_mithril_lvm.sh) ---
+VG_NAME="accounts_vg_run"          # LVM Volume Group name
+MASTER_LV_NAME="accounts_master"   # LVM Logical Volume name for master data (Origin for snapshots)
+
+# --- Snapshot Mount Point ---
+SNAPSHOT_MOUNT_BASE="/mnt"             # Base directory where snapshot subdirectories will be created/mounted
+### END CONFIGURATION ###
+
+# --- Sanity Checks ---
+if [ "$EUID" -ne 0 ]; then
+  echo "Error: This script must be run as root (e.g., using sudo)." >&2
+  exit 1
+fi
+
+# Check commands needed for snapshot management
+if ! command -v lvs &> /dev/null || ! command -v lvcreate &> /dev/null || \
+   ! command -v lvchange &> /dev/null || ! command -v lvremove &> /dev/null || \
+   ! command -v e2fsck &> /dev/null || ! command -v findmnt &> /dev/null || \
+   ! command -v mkdir &> /dev/null || ! command -v rmdir &> /dev/null || \
+   ! command -v mount &> /dev/null || ! command -v umount &> /dev/null ; then
+  echo "Error: Required commands (LVM tools(lvs/lvcreate/lvchange/lvremove), e2fsck, findmnt, mkdir, rmdir, mount, umount) not found." >&2
+  echo "Please install lvm2, e2fsprogs, util-linux." >&2
+  exit 1
+fi
+# --- End Sanity Checks ---
+
+usage(){
+  cat <<EOF
+Usage: $0 <snapshot|remove_snapshot> <name> [snapshot_args]
+
+snapshot <name> [mount_point_suffix]
+              — Create an LVM thin snapshot of ${VG_NAME}/${MASTER_LV_NAME}.
+                <name>: Name for the snapshot LV (e.g., 'run1', 'palmer').
+                [mount_point_suffix]: Optional. If provided, mounts at ${SNAPSHOT_MOUNT_BASE}/<mount_point_suffix>.
+                                     If omitted, mounts at ${SNAPSHOT_MOUNT_BASE}/<name>.
+                Example: '$0 snapshot run1' creates '${VG_NAME}/run1'
+                         and mounts it at '${SNAPSHOT_MOUNT_BASE}/run1'.
+                Example: '$0 snapshot run1 run1_mount' creates '${VG_NAME}/run1'
+                         and mounts it at '${SNAPSHOT_MOUNT_BASE}/run1_mount'.
+                NOTE: Snapshot size limit is implicitly the free space in the thin pool.
+                NOTE: Assumes origin filesystem is ext4 for e2fsck check.
+
+remove_snapshot <name>
+              — Unmounts, deactivates, and removes the specified LVM snapshot LV.
+                <name>: The exact name of the snapshot LV to remove (e.g., 'run1', 'palmer').
+                Example: '$0 remove_snapshot run1'
+
+Configuration (Edit script to change):
+  VG Name:          ${VG_NAME} (Must match setup script)
+  Master LV Name:   ${MASTER_LV_NAME} (Must match setup script)
+  Snapshot Base:    ${SNAPSHOT_MOUNT_BASE}
+EOF
+  exit 1
+}
+
+# Ensure a command was provided
+if [ $# -lt 1 ]; then
+  usage
+fi
+cmd="$1"; shift
+
+# --- Main Logic ---
+case "$cmd" in
+
+  snapshot)
+    # Argument parsing (Removed size argument)
+    if [ $# -lt 1 ]; then
+      echo "Error: Missing arguments for snapshot command." >&2
+      usage
+      exit 1
+    fi
+    SNAPSHOT_NAME="$1"
+    SNAPSHOT_MOUNT_SUFFIX="${2:-$1}" # Mount suffix is now the second arg (optional)
+    SNAPSHOT_MOUNTPOINT="${SNAPSHOT_MOUNT_BASE}/${SNAPSHOT_MOUNT_SUFFIX}"
+    ORIGIN_PATH="${VG_NAME}/${MASTER_LV_NAME}"
+    SNAPSHOT_PATH="${VG_NAME}/${SNAPSHOT_NAME}"
+    SNAPSHOT_DEV_MAPPER_PATH="/dev/mapper/${VG_NAME}-${SNAPSHOT_NAME}"
+
+    echo "▶ Preparing snapshot '${SNAPSHOT_NAME}'..."
+    echo "  Origin LV:    ${ORIGIN_PATH}"
+    echo "  Size Limit:   (Uses Thin Pool Space)" # Clarification
+    echo "  Mount Point:  ${SNAPSHOT_MOUNTPOINT}"
+
+    # --- Checks ---
+    echo "  Checking if origin LV exists..."
+    if ! lvs "${ORIGIN_PATH}" &>/dev/null; then
+        echo "Error: Origin LV '${ORIGIN_PATH}' not found. Did 'setup_mithril_lvm.sh setup' complete successfully?" >&2
+        exit 1
+    fi
+    echo "  Checking if snapshot LV already exists..."
+    if lvs "${SNAPSHOT_PATH}" &>/dev/null; then
+        echo "Error: Snapshot LV '${SNAPSHOT_PATH}' already exists. Remove it first ('$0 remove_snapshot ${SNAPSHOT_NAME}') or choose a different name." >&2
+        exit 1
+    fi
+     echo "  Checking if mount point is already in use..."
+     if [ -d "${SNAPSHOT_MOUNTPOINT}" ] && findmnt -rno TARGET "${SNAPSHOT_MOUNTPOINT}" > /dev/null; then
+         echo "Error: Mount point '${SNAPSHOT_MOUNTPOINT}' already exists and seems to have something mounted on it." >&2
+         exit 1
+     fi
+    # --- End Checks ---
+
+    echo "▶ Creating LVM snapshot..."
+    # Corrected lvcreate command - removed -L argument
+    if ! lvcreate -s -n "${SNAPSHOT_NAME}" "${ORIGIN_PATH}"; then
+        echo "Error: Failed to create snapshot LV '${SNAPSHOT_PATH}'." >&2
+        exit 1
+    fi
+    echo "  Snapshot LV '${SNAPSHOT_PATH}' created."
+
+    echo "▶ Activating LVM snapshot..."
+    # Corrected lvchange command - added -K flag
+    if ! lvchange -ay -K "${SNAPSHOT_PATH}"; then
+        echo "Error: Failed to activate snapshot LV '${SNAPSHOT_PATH}'." >&2
+        # Attempt cleanup if activation fails
+        lvremove -f "${SNAPSHOT_PATH}" 2> /dev/null || true
+        exit 1
+    fi
+    # Add a delay for device node propagation (adjustable if needed)
+    sleep 5
+    if [ ! -b "${SNAPSHOT_DEV_MAPPER_PATH}" ]; then
+        echo "Error: Device node '${SNAPSHOT_DEV_MAPPER_PATH}' did not appear after activation." >&2
+        lvremove -f "${SNAPSHOT_PATH}" 2> /dev/null || true
+        exit 1
+    fi
+    echo "  Snapshot LV '${SNAPSHOT_PATH}' activated (${SNAPSHOT_DEV_MAPPER_PATH})."
+
+    echo "▶ Checking snapshot filesystem (assuming ext4)..."
+    # Use -p for automatic repair without prompting, suitable for automation
+    e2fsck -p -f "${SNAPSHOT_DEV_MAPPER_PATH}"
+    E2FSK_EXIT=$?
+    if [ $E2FSK_EXIT -ge 4 ]; then
+        echo "Error: Filesystem check failed with critical errors (exit code $E2FSK_EXIT) on '${SNAPSHOT_DEV_MAPPER_PATH}'. Manual intervention required." >&2
+        echo "       You might need to run e2fsck manually without -p." >&2
+        # Deactivate but leave snapshot for inspection
+        lvchange -an "${SNAPSHOT_PATH}" 2> /dev/null || true
+        exit 1
+    elif [ $E2FSK_EXIT -ne 0 ]; then
+        echo "Warning: Filesystem check found and corrected errors (exit code $E2FSK_EXIT)." >&2
+    else
+         echo "  Filesystem check clean."
+    fi
+
+    echo "▶ Creating mount point '${SNAPSHOT_MOUNTPOINT}'..."
+    mkdir -p "${SNAPSHOT_MOUNTPOINT}"
+
+    echo "▶ Mounting snapshot..."
+    if ! mount "${SNAPSHOT_DEV_MAPPER_PATH}" "${SNAPSHOT_MOUNTPOINT}"; then
+        echo "Error: Failed to mount '${SNAPSHOT_DEV_MAPPER_PATH}' on '${SNAPSHOT_MOUNTPOINT}'." >&2
+        # Attempt cleanup
+        lvchange -an "${SNAPSHOT_PATH}" 2> /dev/null || true
+        exit 1
+    fi
+
+    echo ""
+    echo "✅ Snapshot '${SNAPSHOT_NAME}' is ready!"
+    echo "--------------------------------------------------"
+    lvs "${SNAPSHOT_PATH}"
+    echo ""
+    df -h "${SNAPSHOT_MOUNTPOINT}"
+    echo "--------------------------------------------------"
+    echo " • Snapshot LV (${SNAPSHOT_DEV_MAPPER_PATH}) mounted at ${SNAPSHOT_MOUNTPOINT}"
+    echo " • Ready for Mithril run using the snapshot mount point."
+    ;;
+
+  remove_snapshot)
+    # Argument parsing
+    if [ $# -lt 1 ]; then
+      echo "Error: Missing snapshot name for remove_snapshot command." >&2
+      usage
+      exit 1
+    fi
+    SNAPSHOT_NAME="$1"
+    SNAPSHOT_PATH="${VG_NAME}/${SNAPSHOT_NAME}"
+    SNAPSHOT_DEV_MAPPER_PATH="/dev/mapper/${VG_NAME}-${SNAPSHOT_NAME}"
+
+    echo "▶ Preparing to remove snapshot '${SNAPSHOT_NAME}'..."
+
+    # --- Checks ---
+    echo "  Checking if snapshot LV exists..."
+    if ! lvs "${SNAPSHOT_PATH}" &>/dev/null; then
+        echo "Info: Snapshot LV '${SNAPSHOT_PATH}' not found. Nothing to remove." >&2
+        exit 0 # Exit cleanly if it doesn't exist
+    fi
+    # --- End Checks ---
+
+    # Find where it's mounted (if anywhere)
+    # findmnt returns non-zero if not found, use || true to prevent script exit
+    SNAPSHOT_MOUNTPOINT=$(findmnt -nr -o TARGET --source "${SNAPSHOT_DEV_MAPPER_PATH}" || true)
+
+    if [ -n "$SNAPSHOT_MOUNTPOINT" ]; then
+        echo "▶ Unmounting snapshot from '${SNAPSHOT_MOUNTPOINT}'..."
+        # Use -R for recursive unmount, handle errors gracefully
+        if ! umount -R "${SNAPSHOT_MOUNTPOINT}"; then
+             echo "Warning: Unmount command failed ('$?'). Attempting lazy unmount..." >&2
+             sleep 1 # Give a moment before lazy unmount
+             umount -l "${SNAPSHOT_MOUNTPOINT}" || echo "Warning: Lazy unmount also failed. Proceeding with LV removal might be risky." >&2
+        fi
+    else
+        echo "  Snapshot not currently mounted."
+    fi
+
+    echo "▶ Deactivating LVM snapshot..."
+    # Ignore error if already inactive
+    lvchange -an "${SNAPSHOT_PATH}" 2>/dev/null || true
+
+    echo "▶ Removing LVM snapshot..."
+    # Use -f to force removal without confirmation
+    if ! lvremove -f "${SNAPSHOT_PATH}"; then
+        echo "Error: Failed to remove snapshot LV '${SNAPSHOT_PATH}'. Check LVM state manually ('sudo lvs ${VG_NAME}')." >&2
+        exit 1
+    fi
+
+    # Optional: Try removing the mount point directory if it exists and is empty
+    if [ -n "$SNAPSHOT_MOUNTPOINT" ] && [ -d "$SNAPSHOT_MOUNTPOINT" ]; then
+        if rmdir "$SNAPSHOT_MOUNTPOINT" 2>/dev/null; then
+            echo "  Removed empty mount point directory '${SNAPSHOT_MOUNTPOINT}'."
+        else
+            # Don't echo warning if directory simply doesn't exist after unmount race condition
+            if [ -d "$SNAPSHOT_MOUNTPOINT" ]; then
+                echo "  Note: Mount point directory '${SNAPSHOT_MOUNTPOINT}' was not removed (likely not empty or permissions issue)."
+            fi
+        fi
+    fi
+
+    echo ""
+    echo "✅ Snapshot '${SNAPSHOT_NAME}' removed successfully."
+    ;;
+
+  *)
+    usage
+    ;;
+esac

--- a/scripts/lvm_setup/setup_mithril_lvm.sh
+++ b/scripts/lvm_setup/setup_mithril_lvm.sh
@@ -1,0 +1,410 @@
+#!/usr/bin/env bash
+# Purpose: Script to set up and tear down LVM infrastructure for Mithril accounts DB
+set -euo pipefail
+
+### CONFIGURATION ###
+# --- Disk and Partitioning ---
+DEVICE="/dev/nvme3n1"              # The disk to use
+LVM_PCT=80                         # % of DEVICE for LVM PV partition (p1) - Set to 80 for 20% other partition
+
+# --- LVM Naming ---
+VG_NAME="accounts_vg_run"          # LVM Volume Group name
+THINPOOL_NAME="thinpool"           # LVM Thin Pool name
+MASTER_LV_NAME="accounts_master"   # LVM Logical Volume name for master data (Origin for snapshots)
+
+# --- Mount Points ---cccccbkblrnltenlrkecbkurufdegujicncghfueutiv
+
+MASTER_MOUNTPOINT="/mnt/accounts_master" # Mount point for the master LV
+OTHER_MOUNTPOINT="/var/lib/mithril"    # Mount point for the other partition (p2)
+
+# --- User for Ownership ---
+# Set the user:group for the snapshots subdirectory ownership
+# If this user doesn't exist, ownership won't be changed from root.
+SNAPSHOTS_DIR_OWNER="ubuntu:ubuntu"
+
+# --- LVM Sizing Configuration ---
+# Safety margin in GiB to leave unused in the VG (for LVM metadata, snapshots headroom if needed)
+SAFETY_GIB=1
+# Metadata size for thin-pool in GiB (1G is usually sufficient unless you expect thousands of snapshots)
+META_GIB=1
+### END CONFIGURATION ###
+
+# --- Sanity Checks ---
+if [ "$EUID" -ne 0 ]; then
+  echo "Error: This script must be run as root (e.g., using sudo)." >&2
+  exit 1
+fi
+
+# Check commands needed for setup and wipe
+if ! command -v lsblk &> /dev/null || ! command -v parted &> /dev/null || \
+   ! command -v pvcreate &> /dev/null || ! command -v vgcreate &> /dev/null || \
+   ! command -v lvcreate &> /dev/null || ! command -v lvchange &> /dev/null || \
+   ! command -v vgremove &> /dev/null || ! command -v pvremove &> /dev/null || \
+   ! command -v lvs &> /dev/null || \
+   ! command -v mkfs.ext4 &> /dev/null || \
+   ! command -v wipefs &> /dev/null || ! command -v partprobe &> /dev/null || \
+   ! command -v systemd-escape &> /dev/null || ! command -v findmnt &> /dev/null || \
+   ! command -v blockdev &> /dev/null || ! command -v sed &> /dev/null || \
+   ! command -v mkdir &> /dev/null || ! command -v chown &> /dev/null || ! command -v id &> /dev/null ; then
+  echo "Error: Required commands (lsblk, parted, LVM(pv/vg/lvcreate/lvchange/vg/pvremove/lvs), mkfs.ext4, wipefs, partprobe, systemd-escape, findmnt, blockdev, sed, mkdir, chown, id) not found." >&2
+  echo "Please install lvm2, e2fsprogs, util-linux, coreutils, and ensure systemd tools are available." >&2
+  exit 1
+fi
+
+
+if [ ! -b "${DEVICE}" ]; then
+  echo "Error: Device '${DEVICE}' not found or is not a block device." >&2
+  lsblk -o NAME,SIZE,TYPE
+  exit 1
+fi
+# --- End Sanity Checks ---
+
+usage(){
+  cat <<EOF
+Usage: $0 <wipe|setup>
+
+wipe          — Unmount filesystems created by 'setup', destroy LVM structure '${VG_NAME}'
+                on ${DEVICE}p1, remove related fstab entries, and reset ${DEVICE}
+                to a blank GPT partition table. USE WITH CAUTION.
+
+setup         — Partition ${DEVICE} (${LVM_PCT}% for LVM, rest for other data),
+                Initialize LVM PV -> VG '${VG_NAME}' -> Thin Pool '${THINPOOL_NAME}' -> Master LV '${MASTER_LV_NAME}',
+                Format the Master LV and the other partition with ext4,
+                Create mount points, mount the filesystems (${MASTER_MOUNTPOINT}, ${OTHER_MOUNTPOINT}),
+                Create subdirectory ${OTHER_MOUNTPOINT}/snapshots and set owner to ${SNAPSHOTS_DIR_OWNER},
+                Add entries to /etc/fstab for automatic mounting on reboot.
+
+Configuration (Edit script to change):
+  DEVICE:           ${DEVICE}
+  LVM Partition %:  ${LVM_PCT}% -> ${DEVICE}p1
+  Other Partition %: (100 - ${LVM_PCT})% -> ${DEVICE}p2
+  VG Name:          ${VG_NAME}
+  Thin Pool Name:   ${THINPOOL_NAME}
+  Master LV Name:   ${MASTER_LV_NAME}
+  Master Mount:     ${MASTER_MOUNTPOINT}
+  Other Mount:      ${OTHER_MOUNTPOINT}
+  Snapshots Subdir Owner: ${SNAPSHOTS_DIR_OWNER}
+  LVM Safety/Meta:  ${SAFETY_GIB}G / ${META_GIB}G
+EOF
+  exit 1
+}
+
+# Ensure a command was provided
+if [ $# -lt 1 ]; then
+  usage
+fi
+cmd="$1"; shift
+
+# --- Helper Function for Fstab ---
+add_fstab_entry() {
+  local device="$1"
+  local mountpoint="$2"
+  local fstype="$3"
+  local options="$4"
+  local dump="$5"
+  local pass="$6"
+
+  # Check if mountpoint or device is already in fstab
+  if grep -qs " ${mountpoint} " /etc/fstab || grep -qs "^${device} " /etc/fstab; then
+    echo " • Skipping fstab entry for ${mountpoint} (already present or device exists)."
+  else
+    echo " • Adding fstab entry for ${mountpoint}..."
+    # Use printf for potentially safer output than echo
+    printf "%s\t%s\t%s\t%s\t%d\t%d\n" "${device}" "${mountpoint}" "${fstype}" "${options}" "${dump}" "${pass}" >> /etc/fstab
+    echo "   Reloading systemd manager configuration..."
+    # Use systemctl check to avoid errors on non-systemd systems
+    if command -v systemctl > /dev/null && systemctl is-system-running -q; then
+      systemctl daemon-reload
+    else
+       echo "Warning: systemctl not found or system not running. Skipping daemon-reload." >&2
+    fi
+  fi
+}
+
+
+# --- Main Logic ---
+case "$cmd" in
+
+  wipe)
+    read -p "WARNING: This will completely WIPE ${DEVICE} and destroy LVM data associated with partition ${DEVICE}p1. Type 'yes' to proceed: " confirm
+    if [[ "$confirm" != "yes" ]]; then
+        echo "Aborted."
+        exit 1
+    fi
+
+    echo "▶ Stopping any dependent services (e.g., Mithril)..."
+    # Try stopping common mount units, ignore errors if they don't exist
+    systemctl stop "$(systemd-escape --path "${MASTER_MOUNTPOINT}").mount" "$(systemd-escape --path "${OTHER_MOUNTPOINT}").mount" 2>/dev/null || true
+    systemctl stop mithril.service 2>/dev/null || true
+
+    echo "▶ Unmounting filesystems setup by this script (Attempting forcefully)..."
+    # Define partitions explicitly
+    LVM_PART_WIPE="${DEVICE}p1"
+    OTHER_PART_WIPE="${DEVICE}p2"
+
+    # Attempt unmounts directly, using lazy unmount (-l) as a fallback if -R fails
+    # These should be less likely to halt the script due to `|| true`
+    if ! umount -R "${MASTER_MOUNTPOINT}" 2>/dev/null; then umount -l "${MASTER_MOUNTPOINT}" 2>/dev/null || true; fi
+    if ! umount -R "${OTHER_MOUNTPOINT}" 2>/dev/null; then umount -l "${OTHER_MOUNTPOINT}" 2>/dev/null || true; fi
+    sleep 1 # Give kernel a moment
+
+    # Attempt to find the actual VG name on the target PV
+    ACTUAL_VG=$(pvs --noheadings -o vg_name "${LVM_PART_WIPE}" 2>/dev/null | xargs || echo "")
+    VG_TO_WIPE=""
+    if [ -n "$ACTUAL_VG" ]; then
+        VG_TO_WIPE="$ACTUAL_VG"
+        echo "  Found existing VG '${ACTUAL_VG}' on PV ${LVM_PART_WIPE}. Targeting this for removal."
+    else
+        VG_TO_WIPE="$VG_NAME" # Use configured name as fallback
+        echo "  No VG found directly on PV ${LVM_PART_WIPE}. Attempting removal using configured VG name '${VG_NAME}'."
+    fi
+
+    # Proceed only if we have a VG name (either found or configured)
+    if [ -n "$VG_TO_WIPE" ]; then
+      echo "▶ Deactivating and removing LVM structures for VG '${VG_TO_WIPE}'..."
+      # Add verbose output and check status manually within the block
+      echo "  Deactivating LVs in ${VG_TO_WIPE}..."
+      lvchange -an "${VG_TO_WIPE}" # Attempt; ignore exit code below if needed
+      if [ $? -ne 0 ]; then echo "  Warning: lvchange -an failed. Might already be inactive or other issue."; fi
+
+      echo "  Removing LVs in ${VG_TO_WIPE}..."
+      lvremove -f "${VG_TO_WIPE}" # Attempt
+      if [ $? -ne 0 ]; then echo "  Warning: lvremove failed. LVs might not exist or be removable."; fi
+
+      echo "  Deactivating VG ${VG_TO_WIPE}..."
+      vgchange -an "${VG_TO_WIPE}" # Attempt
+      if [ $? -ne 0 ]; then echo "  Warning: vgchange -an failed. Might already be inactive."; fi
+
+      echo "  Removing VG ${VG_TO_WIPE}..."
+      vgremove -f "${VG_TO_WIPE}" # Attempt
+      if [ $? -ne 0 ]; then echo "  Warning: vgremove failed. VG might not exist or PVs might still be tagged."; fi
+    else
+        echo "  Skipping LVM VG/LV removal steps as no VG name determined."
+    fi
+
+    # Remove PV signature regardless - crucial step
+    echo "▶ Removing PV signature from ${LVM_PART_WIPE}..."
+    if ! pvremove -ff -y "${LVM_PART_WIPE}"; then
+         echo "Error: Failed to remove PV signature from ${LVM_PART_WIPE}. Manual check required ('sudo pvremove -ff -y ${LVM_PART_WIPE}')." >&2
+         # Exit here as subsequent partitioning will fail if PV isn't removed
+         exit 1
+    fi
+    # Attempt removal from other partition just in case
+    pvremove -ff -y "${OTHER_PART_WIPE}" 2>/dev/null || true
+
+    echo "▶ Removing fstab entries created by setup..."
+    MASTER_MOUNTPOINT_ESC=$(printf '%s\n' "$MASTER_MOUNTPOINT" | sed 's:[][\\/.^$*]:\\&:g')
+    OTHER_MOUNTPOINT_ESC=$(printf '%s\n' "$OTHER_MOUNTPOINT" | sed 's:[][\\/.^$*]:\\&:g')
+    # Use sed with error checking
+    if ! sed -i.bak -e "\#\s${MASTER_MOUNTPOINT_ESC}\s#d" -e "\#\s${OTHER_MOUNTPOINT_ESC}\s#d" /etc/fstab; then
+        echo "Warning: Failed to modify /etc/fstab with sed. Check /etc/fstab and /etc/fstab.bak manually." >&2
+    else
+        echo "   (Backup of /etc/fstab saved to /etc/fstab.bak)"
+    fi
+
+    echo "▶ Resetting partition table on ${DEVICE}..."
+    # Wipe signatures again before partitioning
+    wipefs -a "${LVM_PART_WIPE}" 2>/dev/null || true
+    wipefs -a "${OTHER_PART_WIPE}" 2>/dev/null || true
+    wipefs -a "${DEVICE}" 2>/dev/null || true
+    # Create partition table
+    if ! parted --script "${DEVICE}" mklabel gpt; then
+        echo "Error: Failed to create new GPT label on ${DEVICE}." >&2
+        exit 1
+    fi
+
+    echo "   Forcing kernel to re-read partition table..."
+    partprobe "${DEVICE}" || echo "Warning: partprobe failed, a reboot might be needed to see changes." >&2
+    sleep 1
+
+    echo "✅ Wipe attempt finished. Check LVM status manually ('pvs', 'vgs', 'lvs'). ${DEVICE} should be blank."
+    ;;
+
+  setup)
+    echo "▶ Checking if device ${DEVICE} is already in use..."
+    if lsblk -no MOUNTPOINT "${DEVICE}" | grep -qv '^$'; then
+       echo "Error: ${DEVICE} or its partitions appear to be mounted. Please run 'wipe' first or manually unmount." >&2
+       lsblk -o NAME,SIZE,FSTYPE,MOUNTPOINT "${DEVICE}"
+       exit 1
+    fi
+     LVM_PART_CHECK="${DEVICE}p1"
+     if pvs "${LVM_PART_CHECK}" &>/dev/null || vgs "${VG_NAME}" &>/dev/null; then
+       # If the configured VG name exists, that's an error state for setup
+       if vgs "${VG_NAME}" &>/dev/null; then
+            echo "Error: Volume Group '${VG_NAME}' already exists. Please run 'wipe' first." >&2
+            vgs "${VG_NAME}" || true
+            exit 1
+       fi
+       # If a PV exists on the target partition, that's also an error state
+        if pvs "${LVM_PART_CHECK}" &>/dev/null; then
+           echo "Error: LVM Physical Volume seems to exist on ${LVM_PART_CHECK}. Please run 'wipe' first." >&2
+           pvs "${LVM_PART_CHECK}" || true
+           exit 1
+       fi
+     fi
+
+    echo "▶ Partitioning ${DEVICE}..."
+    wipefs -a "${DEVICE}" 2>/dev/null || true
+    parted --script "${DEVICE}" mklabel gpt
+    parted --script --align optimal "${DEVICE}" \
+      mkpart primary ext4 1MiB "${LVM_PCT}%" \
+      mkpart primary ext4 "${LVM_PCT}%" 100%
+    parted --script "${DEVICE}" set 1 lvm on
+    parted --script "${DEVICE}" name 1 "${VG_NAME}_pv" name 2 "mithril_data" # Use updated VG_NAME
+
+    echo "   Forcing kernel to re-read partition table..."
+    partprobe "${DEVICE}" || echo "Warning: partprobe failed, partition changes might not be immediately visible." >&2
+    sleep 2
+
+    LVM_PART="${DEVICE}p1"
+    OTHER_PART="${DEVICE}p2"
+
+    echo "  Partition 1 (LVM PV): ${LVM_PART}"
+    echo "  Partition 2 (Other):  ${OTHER_PART}"
+
+    if [ ! -b "${LVM_PART}" ] || [ ! -b "${OTHER_PART}" ]; then
+        echo "Error: Failed to create or detect partitions on ${DEVICE}. Waiting and retrying partprobe..." >&2
+        sleep 5
+        partprobe "${DEVICE}"
+        sleep 2
+        if [ ! -b "${LVM_PART}" ] || [ ! -b "${OTHER_PART}" ]; then
+          echo "Error: Still cannot detect partitions. Please check manually. Output of lsblk:" >&2
+          lsblk "${DEVICE}"
+          exit 1
+        fi
+        echo "   Partitions detected after retry."
+    fi
+
+    echo "▶ Initializing LVM (VG: ${VG_NAME})..."
+    if ! pvcreate -ff -y "${LVM_PART}"; then echo "Error: pvcreate failed on ${LVM_PART}"; exit 1; fi
+    if ! vgcreate "${VG_NAME}" "${LVM_PART}"; then echo "Error: vgcreate failed for ${VG_NAME}"; pvremove -ff -y "${LVM_PART}" 2>/dev/null; exit 1; fi
+
+
+    # Compute sizes for Thin Pool
+    TOTAL_BYTES=$(blockdev --getsize64 "${LVM_PART}")
+    PV_GIB=$((TOTAL_BYTES/1024/1024/1024))
+    DATA_GIB=$((PV_GIB - META_GIB - SAFETY_GIB))
+
+    if [ "$DATA_GIB" -le 0 ]; then
+      echo "Error: Calculated DATA_GIB ($DATA_GIB) is zero or negative. Check PV size (${PV_GIB}G) vs META_GIB (${META_GIB}G) and SAFETY_GIB (${SAFETY_GIB}G)." >&2
+      vgremove -f "${VG_NAME}" 2>/dev/null || true
+      pvremove -ff -y "${LVM_PART}" 2>/dev/null || true
+      exit 1
+    fi
+
+    echo "  Creating Thin Pool '${THINPOOL_NAME}' (${DATA_GIB}G data, ${META_GIB}G meta)..."
+    if ! lvcreate --type thin-pool -L "${DATA_GIB}G" --poolmetadatasize "${META_GIB}G" -n "${THINPOOL_NAME}" "${VG_NAME}"; then
+        echo "Error: Failed to create thin pool '${THINPOOL_NAME}'." >&2
+        vgremove -f "${VG_NAME}" 2>/dev/null || true
+        pvremove -ff -y "${LVM_PART}" 2>/dev/null || true
+        exit 1
+    fi
+
+    echo "  Creating Master LV '${MASTER_LV_NAME}' (Virtual Size: ${DATA_GIB}G)..."
+    if ! lvcreate --type thin --virtualsize "${DATA_GIB}G" -n "${MASTER_LV_NAME}" "${VG_NAME}/${THINPOOL_NAME}"; then
+        echo "Error: Failed to create master LV '${MASTER_LV_NAME}'." >&2
+        lvremove -f "${VG_NAME}/${THINPOOL_NAME}" 2>/dev/null || true # Attempt cleanup
+        vgremove -f "${VG_NAME}" 2>/dev/null || true
+        pvremove -ff -y "${LVM_PART}" 2>/dev/null || true
+        exit 1
+    fi
+
+    sleep 3 # Give udev time
+
+    MASTER_DEV_MAPPER_PATH="/dev/mapper/${VG_NAME}-${MASTER_LV_NAME}"
+    FSTAB_MASTER_DEV_PATH="${MASTER_DEV_MAPPER_PATH}"
+
+    if [ ! -b "${MASTER_DEV_MAPPER_PATH}" ] || [ ! -b "${OTHER_PART}" ]; then
+        echo "Error: Device node did not appear after LVM creation or partition missing (${MASTER_DEV_MAPPER_PATH} or ${OTHER_PART})." >&2
+        ls -l /dev/mapper/
+        lsblk "${DEVICE}"
+        exit 1
+    fi
+
+    echo "▶ Formatting filesystems (ext4)..."
+    echo "  Formatting ${MASTER_DEV_MAPPER_PATH}..."
+    if ! mkfs.ext4 -q -L "${MASTER_LV_NAME}" "${MASTER_DEV_MAPPER_PATH}"; then echo "Error: mkfs.ext4 failed on ${MASTER_DEV_MAPPER_PATH}"; exit 1; fi
+    echo "  Formatting ${OTHER_PART}..."
+    if ! mkfs.ext4 -q -L "mithril_data" "${OTHER_PART}"; then echo "Error: mkfs.ext4 failed on ${OTHER_PART}"; exit 1; fi
+
+    echo "▶ Creating mount points..."
+    mkdir -p "${MASTER_MOUNTPOINT}" "${OTHER_MOUNTPOINT}"
+    echo "  Created ${MASTER_MOUNTPOINT}"
+    echo "  Created ${OTHER_MOUNTPOINT}"
+
+    echo "▶ Mounting filesystems..."
+    # Activate the master LV explicitly before mounting (good practice)
+    if ! lvchange -ay "${VG_NAME}/${MASTER_LV_NAME}"; then
+        echo "Warning: Failed to activate ${VG_NAME}/${MASTER_LV_NAME}. Mount might fail." >&2
+    fi
+    sleep 1 # Small delay after activation
+
+    # Mount master LV
+    if ! mount "${MASTER_DEV_MAPPER_PATH}" "${MASTER_MOUNTPOINT}"; then
+        echo "Error: Failed to mount Master LV ${MASTER_DEV_MAPPER_PATH} on ${MASTER_MOUNTPOINT}." >&2
+        exit 1
+    fi
+    # Mount other partition
+    if ! mount "${OTHER_PART}" "${OTHER_MOUNTPOINT}"; then
+         echo "Error: Failed to mount Other Partition ${OTHER_PART} on ${OTHER_MOUNTPOINT}." >&2
+         # Attempt unmount of master before exiting
+         umount "${MASTER_MOUNTPOINT}" 2>/dev/null || true
+         exit 1
+    fi
+
+    echo "  Mounted ${MASTER_DEV_MAPPER_PATH} -> ${MASTER_MOUNTPOINT}"
+    echo "  Mounted ${OTHER_PART} -> ${OTHER_MOUNTPOINT}"
+
+    ####################################################################
+    # ADDED SECTION: Create snapshots subdirectory and set ownership   #
+    ####################################################################
+    echo "▶ Creating snapshots subdirectory..."
+    SNAPSHOTS_SUBDIR="${OTHER_MOUNTPOINT}/snapshots"
+    # Create directory
+    if ! mkdir -p "${SNAPSHOTS_SUBDIR}"; then
+        echo "Error: Failed to create directory ${SNAPSHOTS_SUBDIR}" >&2
+        # Attempt unmounts before exiting
+        umount -R "${MASTER_MOUNTPOINT}" 2>/dev/null || true
+        umount -R "${OTHER_MOUNTPOINT}" 2>/dev/null || true
+        exit 1
+    fi
+    # Set ownership (extract user from config)
+    TARGET_USER=$(echo "$SNAPSHOTS_DIR_OWNER" | cut -d: -f1)
+    if id "$TARGET_USER" &>/dev/null; then
+        if ! chown "$SNAPSHOTS_DIR_OWNER" "${SNAPSHOTS_SUBDIR}"; then
+             echo "Warning: Failed to change ownership of ${SNAPSHOTS_SUBDIR} to ${SNAPSHOTS_DIR_OWNER}." >&2
+             # Non-fatal warning, script can continue
+        else
+             echo "  Created ${SNAPSHOTS_SUBDIR} and set ownership to ${SNAPSHOTS_DIR_OWNER}."
+        fi
+    else
+        echo "  Created ${SNAPSHOTS_SUBDIR}. User '${TARGET_USER}' not found, skipping chown."
+    fi
+    ####################################################################
+    # END ADDED SECTION                                                #
+    ####################################################################
+
+    echo "▶ Updating /etc/fstab for auto-mount..."
+    add_fstab_entry "${FSTAB_MASTER_DEV_PATH}" "${MASTER_MOUNTPOINT}" "ext4" "defaults,nofail" 0 2
+    add_fstab_entry "${OTHER_PART}" "${OTHER_MOUNTPOINT}" "ext4" "defaults,nofail" 0 2
+
+    echo ""
+    echo "✅ Setup complete!"
+    echo "--------------------------------------------------"
+    lvs "${VG_NAME}" # Show LVM layout
+    echo ""
+    lsblk -o NAME,SIZE,FSTYPE,MOUNTPOINT "${DEVICE}"
+    echo "--------------------------------------------------"
+    echo " • Master LV (${MASTER_DEV_MAPPER_PATH}) mounted at ${MASTER_MOUNTPOINT}"
+    echo " • Data partition (${OTHER_PART}) mounted at ${OTHER_MOUNTPOINT}"
+    echo " • Subdirectory ${SNAPSHOTS_SUBDIR} created."
+    echo " • /etc/fstab updated for automatic mounting on reboot."
+    echo ""
+    echo "Next: Build your initial database in ${MASTER_MOUNTPOINT} using 'mithril verifier --snapshot ...'"
+    echo "Then use the separate snapshot management script."
+    ;;
+
+  *)
+    usage
+    ;;
+esac

--- a/scripts/performance_profiling/profile.sh
+++ b/scripts/performance_profiling/profile.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# profile_capture.sh – launch Mithril and capture heap/CPU/goroutine pprof,
+# full-memory smaps_rollup, and ps stats on a fixed interval.
+#
+# Usage:
+#   ./profile_capture.sh 30 ./profile_runs mithril_run -- mithril verifier ...
+# -----------------------------------------------------------------------------
+
+# ----------- Configuration ---------------------------------------------------
+INTERVAL=${1:-30}          # seconds between capture cycles
+CPU_SECONDS=${CPU_SECONDS:-5}   # pprof CPU sample length (set env or edit)
+BASE_DIR=${2:-"./profile_runs"}
+LOG_PREFIX=${3:-"mithril_run"}
+PPROF_PORT=6060            # mithril's net/http/pprof port
+# -----------------------------------------------------------------------------
+
+# ---------- arg parsing / setup ----------------------------------------------
+if [ "$#" -lt 4 ]; then
+  echo "Usage: $0 [interval] [profile-dir] [log-prefix] -- <mithril args>"
+  exit 1
+fi
+shift 3; [[ $1 == "--" ]] || { echo "missing --"; exit 1; }; shift
+MITHRIL_CMD=("$@"); [[ ${#MITHRIL_CMD[@]} -gt 0 ]] || { echo "no mithril cmd"; exit 1; }
+
+RUN_TS=$(date +"%Y%m%d_%H%M%S")
+RUN_DIR="${BASE_DIR}/${RUN_TS}_interval_${INTERVAL}s"
+LOG_FILE="${RUN_DIR}/${LOG_PREFIX}.log"
+MAP_CSV="${RUN_DIR}/profile_map.csv"
+mkdir -p "$RUN_DIR" || { echo "mkdir $RUN_DIR failed"; exit 1; }
+
+# ---------- cleanup handler ---------------------------------------------------
+cleanup(){ [[ -n $MITHRIL_PID ]] && kill $MITHRIL_PID 2>/dev/null; }
+trap cleanup EXIT INT TERM
+
+echo "Profiles -> $RUN_DIR"
+echo "Log      -> $LOG_FILE"
+
+# CSV header
+echo "Timestamp,Heap,CPU,Goroutine,Smaps,GoroutineCnt,CPU%,RSS_KB,VSZ_KB,LastLog" > "$MAP_CSV"
+
+# ----------- start Mithril ----------------------------------------------------
+if command -v unbuffer &>/dev/null; then
+  unbuffer "${MITHRIL_CMD[@]}" 2>&1 | tee -a "$LOG_FILE" &
+else
+  "${MITHRIL_CMD[@]}" 2>&1 | tee -a "$LOG_FILE" &
+fi
+MITHRIL_PID=$!
+sleep 5
+
+# ------------- main loop ------------------------------------------------------
+seq=0
+while kill -0 $MITHRIL_PID 2>/dev/null; do
+  ts=$(date +"%Y%m%d_%H%M%S")
+  heap="heap_${ts}.pprof"; cpu="cpu_${ts}.pprof"; gor="goroutine_${ts}.pprof"; smaps="smaps_${ts}.txt"
+  gcount="NA" sys_cpu="NA" sys_rss="NA" sys_vsz="NA"
+
+  # --- smaps_rollup ---
+    if sudo -n cat "/proc/$MITHRIL_PID/smaps_rollup" > "$RUN_DIR/$smaps" 2>/dev/null; then
+        echo "[$ts] smaps saved ($smaps)" | tee -a "$LOG_FILE"
+    else
+        smaps="ERR"
+        echo "[$ts] ERROR: sudo cat smaps_rollup failed for PID $MITHRIL_PID" | tee -a "$LOG_FILE"
+    fi
+
+  # ps stats
+  read -r sys_cpu sys_rss sys_vsz <<<"$(ps -p $MITHRIL_PID -o %cpu=,rss=,vsz= --no-headers)"
+  echo "[$ts] CPU=${sys_cpu}% RSS=${sys_rss}KB" | tee -a "$LOG_FILE"
+
+  # pprof endpoints
+  if curl -fs "http://localhost:$PPROF_PORT/debug/pprof/" &>/dev/null; then
+    curl -fs "http://localhost:$PPROF_PORT/debug/pprof/goroutine?debug=1" -o "$RUN_DIR/$gor"
+    gcount=$(grep -m1 '^goroutine [0-9]\+ \[' "$RUN_DIR/$gor" | grep -o '[0-9]\+')
+    curl -fs "http://localhost:$PPROF_PORT/debug/pprof/heap"      -o "$RUN_DIR/$heap"
+    curl -fs "http://localhost:$PPROF_PORT/debug/pprof/profile?seconds=$CPU_SECONDS" -o "$RUN_DIR/$cpu"
+  else
+    heap=cpu=gor="NO_PPROF"; echo "[$ts] pprof unreachable" | tee -a "$LOG_FILE"
+  fi
+
+  last_log=$(tail -n1 "$LOG_FILE" | tr -d '\n' | sed 's/\"/\"\"/g')
+  echo "$ts,$heap,$cpu,$gor,$smaps,$gcount,$sys_cpu,$sys_rss,$sys_vsz,\"$last_log\"" >> "$MAP_CSV"
+
+  echo "[$ts] cycle $seq done" | tee -a "$LOG_FILE"; seq=$((seq+1))
+  sleep "$(( INTERVAL>CPU_SECONDS ? INTERVAL-CPU_SECONDS : 1 ))"
+done
+
+echo "Mithril exited; profiler stopping." | tee -a "$LOG_FILE"

--- a/scripts/snapshot-finder.py
+++ b/scripts/snapshot-finder.py
@@ -1,0 +1,520 @@
+from distutils.log import debug
+import os
+import glob
+import requests
+import time
+import math
+import json
+import sys
+import argparse
+import logging
+import subprocess
+from pathlib import Path
+from requests import ReadTimeout, ConnectTimeout, HTTPError, Timeout, ConnectionError
+from tqdm import tqdm
+from multiprocessing.dummy import Pool as ThreadPool
+import statistics
+
+parser = argparse.ArgumentParser(description='Solana snapshot finder')
+parser.add_argument('-t', '--threads-count', default=1000, type=int,
+    help='the number of concurrently running threads that check snapshots for rpc nodes')
+parser.add_argument('-r', '--rpc_address',
+    default='https://api.mainnet-beta.solana.com', type=str,
+    help='RPC address of the node from which the current slot number will be taken\n'
+         'https://api.mainnet-beta.solana.com')
+
+parser.add_argument('--max_snapshot_age', default=1300, type=int, help='How many slots ago the snapshot was created (in slots)')
+parser.add_argument('--min_download_speed', default=60, type=int, help='Minimum average snapshot download speed in megabytes')
+parser.add_argument('--max_download_speed', type=int, 
+help='Maximum snapshot download speed in megabytes - https://github.com/c29r3/solana-snapshot-finder/issues/11. Example: --max_download_speed 192')
+parser.add_argument('--max_latency', default=40, type=int, help='The maximum value of latency (milliseconds). If latency > max_latency --> skip')
+parser.add_argument('--version', type=str, help='version of the snapshot required')
+parser.add_argument('--with_private_rpc', action="store_true", help='Enable adding and checking RPCs with the --private-rpc option.This slow down checking and searching but potentially increases'
+                    ' the number of RPCs from which snapshots can be downloaded.')
+parser.add_argument('--measurement_time', default=7, type=int, help='Time in seconds during which the script will measure the download speed')
+parser.add_argument('--snapshot_path', type=str, default=".", help='The location where the snapshot will be downloaded (absolute path).'
+                                                                     ' Example: /home/ubuntu/solana/validator-ledger')
+parser.add_argument('--num_of_retries', default=5, type=int, help='The number of retries if a suitable server for downloading the snapshot was not found')
+parser.add_argument('--sleep', default=30, type=int, help='Sleep before next retry (seconds)')
+parser.add_argument('--sort_order', default='slots_diff', type=str, help='Priority way to sort the found servers. latency or slots_diff')
+parser.add_argument('-b', '--blacklist', default='', type=str, help='If the same corrupted archive is constantly downloaded, you can exclude it.'
+                    ' Specify either the number of the slot you want to exclude, or the hash of the archive name. '
+                    'You can specify several, separated by commas. Example: -b 135501350,135501360 or --blacklist 135501350,some_hash')
+parser.add_argument("-v", "--verbose", help="increase output verbosity to DEBUG", action="store_true")
+args = parser.parse_args()
+
+DEFAULT_HEADERS = {"Content-Type": "application/json"}
+RPC = args.rpc_address
+WITH_PRIVATE_RPC = args.with_private_rpc
+MAX_SNAPSHOT_AGE_IN_SLOTS = args.max_snapshot_age
+THREADS_COUNT = args.threads_count
+MIN_DOWNLOAD_SPEED_MB = args.min_download_speed
+MAX_DOWNLOAD_SPEED_MB = args.max_download_speed
+SPEED_MEASURE_TIME_SEC = args.measurement_time
+MAX_LATENCY = args.max_latency
+VERSION = args.version
+SNAPSHOT_PATH = args.snapshot_path if args.snapshot_path[-1] != '/' else args.snapshot_path[:-1]
+NUM_OF_MAX_ATTEMPTS = args.num_of_retries
+SLEEP_BEFORE_RETRY = args.sleep
+NUM_OF_ATTEMPTS = 1
+SORT_ORDER = args.sort_order
+BLACKLIST = str(args.blacklist).split(",")
+AVERAGE_SNAPSHOT_FILE_SIZE_MB = 2500.0
+AVERAGE_INCREMENT_FILE_SIZE_MB = 200.0
+AVERAGE_CATCHUP_SPEED = 2.0
+FULL_LOCAL_SNAP_SLOT = 0
+
+current_slot = 0
+DISCARDED_BY_ARCHIVE_TYPE = 0
+DISCARDED_BY_LATENCY = 0
+DISCARDED_BY_SLOT = 0
+DISCARDED_BY_UNKNW_ERR = 0
+DISCARDED_BY_TIMEOUT = 0
+FULL_LOCAL_SNAPSHOTS = []
+# skip servers that do not fit the filters so as not to check them again
+unsuitable_servers = set()
+# Configure Logging
+logging.getLogger('urllib3').setLevel(logging.WARNING)
+if args.verbose:
+    logging.basicConfig(
+        level=logging.DEBUG,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+        handlers=[
+            logging.FileHandler(f'{SNAPSHOT_PATH}/snapshot-finder.log'),
+            logging.StreamHandler(sys.stdout),
+        ]
+    )
+
+else:
+    # logging.basicConfig(stream=sys.stdout, encoding='utf-8', level=logging.INFO, format='|%(asctime)s| %(message)s')
+        logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+        handlers=[
+            logging.FileHandler(f'{SNAPSHOT_PATH}/snapshot-finder.log'),
+            logging.StreamHandler(sys.stdout),
+        ]
+    )
+logger = logging.getLogger(__name__)
+
+
+def convert_size(size_bytes):
+   if size_bytes == 0:
+    return "0B"
+   size_name = ("B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB")
+   i = int(math.floor(math.log(size_bytes, 1024)))
+   p = math.pow(1024, i)
+   s = round(size_bytes / p, 2)
+   return "%s %s" % (s, size_name[i])
+
+
+def version_check(url: str, version: str) -> bool:
+    data = {"jsonrpc":"2.0","id":1, "method":"getVersion"}
+    res = requests.post("http://%s"%url, json=data)
+    parsed_res = json.loads(res.text)
+    rpc_ver = parsed_res["result"]["solana-core"]
+    logger.info("version: %s"%rpc_ver)
+    if version not in rpc_ver:
+        return False
+    return True
+
+def measure_speed(url: str, measure_time: int) -> float:
+    logging.debug('measure_speed()')
+    url = f'http://{url}/snapshot.tar.bz2'
+    r = requests.get(url, stream=True, timeout=measure_time+2)
+    r.raise_for_status()
+    start_time = time.monotonic_ns()
+    last_time = start_time
+    loaded = 0
+    speeds = []
+    for chunk in r.iter_content(chunk_size=81920):
+        curtime = time.monotonic_ns()
+
+        worktime = (curtime - start_time) / 1000000000
+        if worktime >= measure_time:
+            break
+
+        delta = (curtime - last_time) / 1000000000
+        loaded += len(chunk)
+        if delta > 1:
+            estimated_bytes_per_second = loaded * (1 / delta)
+            # print(f'{len(chunk)}:{delta} : {estimated_bytes_per_second}')
+            speeds.append(estimated_bytes_per_second)
+
+            last_time = curtime
+            loaded = 0
+
+    return statistics.median(speeds)
+
+
+def do_request(url_: str, method_: str = 'GET', data_: str = '', timeout_: int = 3,
+               headers_: dict = None):
+    global DISCARDED_BY_UNKNW_ERR
+    global DISCARDED_BY_TIMEOUT
+    r = ''
+    if headers_ is None:
+        headers_ = DEFAULT_HEADERS
+
+    try:
+        if method_.lower() == 'get':
+            r = requests.get(url_, headers=headers_, timeout=(timeout_, timeout_))
+        elif method_.lower() == 'post':
+            r = requests.post(url_, headers=headers_, data=data_, timeout=(timeout_, timeout_))
+        elif method_.lower() == 'head':
+            r = requests.head(url_, headers=headers_, timeout=(timeout_, timeout_))
+        # print(f'{r.content, r.status_code, r.text}')
+        return r
+
+    except (ReadTimeout, ConnectTimeout, HTTPError, Timeout, ConnectionError) as reqErr:
+        # logger.debug(f'error in do_request(): {reqErr=}')
+        DISCARDED_BY_TIMEOUT += 1
+        return f'error in do_request(): {reqErr}'
+
+    except Exception as unknwErr:
+        DISCARDED_BY_UNKNW_ERR += 1
+        # logger.debug(f'error in do_request(): {unknwErr=}')
+        return f'error in do_request(): {reqErr}'
+
+
+def get_current_slot():
+    logger.debug("get_current_slot()")
+    d = '{"jsonrpc":"2.0","id":1, "method":"getSlot"}'
+    try:
+        r = do_request(url_=RPC, method_='post', data_=d, timeout_=25)
+        if 'result' in str(r.text):
+            return r.json()["result"]
+        else:
+            logger.error(f'Can\'t get current slot')
+            return None
+    except:
+        logger.error(f'Can\'t get current slot')
+        return None
+
+
+def get_all_rpc_ips():
+    logger.debug("get_all_rpc_ips()")
+    d = '{"jsonrpc":"2.0", "id":1, "method":"getClusterNodes"}'
+    r = do_request(url_=RPC, method_='post', data_=d, timeout_=25)
+    if 'result' in str(r.text):
+        if WITH_PRIVATE_RPC is True:
+            rpc_ips = []
+            for node in r.json()["result"]:
+                if node["rpc"] is not None:
+                    rpc_ips.append(node["rpc"])
+                else:
+                    gossip_ip = node["gossip"].split(":")[0]
+                    rpc_ips.append(f'{gossip_ip}:8899')
+
+        else:
+            rpc_ips = [rpc["rpc"] for rpc in r.json()["result"] if rpc["rpc"] is not None]
+
+        rpc_ips = list(set(rpc_ips))
+        return rpc_ips
+
+    else:
+        logger.error(f'Can\'t get RPC ip addresses {r.text}')
+        sys.exit()
+
+
+def get_snapshot_slot(rpc_address: str):
+    global FULL_LOCAL_SNAP_SLOT
+    global DISCARDED_BY_ARCHIVE_TYPE
+    global DISCARDED_BY_LATENCY
+    global DISCARDED_BY_SLOT
+
+    pbar.update(1)
+    url = f'http://{rpc_address}/snapshot.tar.bz2'
+    inc_url = f'http://{rpc_address}/incremental-snapshot.tar.bz2'
+    # d = '{"jsonrpc":"2.0","id":1,"method":"getHighestSnapshotSlot"}'
+    try:
+        r = do_request(url_=inc_url, method_='head', timeout_=1)
+        if 'location' in str(r.headers) and 'error' not in str(r.text) and r.elapsed.total_seconds() * 1000 > MAX_LATENCY:
+            DISCARDED_BY_LATENCY += 1
+            return None
+    
+
+        if 'location' in str(r.headers) and 'error' not in str(r.text):
+            snap_location_ = r.headers["location"]
+            if snap_location_.endswith('tar') is True:
+                DISCARDED_BY_ARCHIVE_TYPE += 1
+                return None
+            incremental_snap_slot = int(snap_location_.split("-")[2])
+            snap_slot_ = int(snap_location_.split("-")[3])
+            slots_diff = current_slot - snap_slot_
+
+            if slots_diff < -100:
+                logger.error(f'Something wrong with this snapshot\\rpc_node - {slots_diff=}. This node will be skipped {rpc_address=}')
+                DISCARDED_BY_SLOT += 1
+                return
+
+            if slots_diff > MAX_SNAPSHOT_AGE_IN_SLOTS:
+                DISCARDED_BY_SLOT += 1
+                return
+
+            if FULL_LOCAL_SNAP_SLOT == incremental_snap_slot:
+                json_data["rpc_nodes"].append({
+                    "snapshot_address": rpc_address,
+                    "slots_diff": slots_diff,
+                    "latency": r.elapsed.total_seconds() * 1000,
+                    "files_to_download": [snap_location_],
+                    "cost": AVERAGE_INCREMENT_FILE_SIZE_MB / MIN_DOWNLOAD_SPEED_MB + slots_diff / AVERAGE_CATCHUP_SPEED
+                })
+                return
+
+            r2 = do_request(url_=url, method_='head', timeout_=1)
+            if 'location' in str(r.headers) and 'error' not in str(r.text):
+                json_data["rpc_nodes"].append({
+                    "snapshot_address": rpc_address,
+                    "slots_diff": slots_diff,
+                    "latency": r.elapsed.total_seconds() * 1000,
+                    "files_to_download": [r.headers["location"], r2.headers['location']],
+                    "cost": (AVERAGE_SNAPSHOT_FILE_SIZE_MB + AVERAGE_INCREMENT_FILE_SIZE_MB) / MIN_DOWNLOAD_SPEED_MB + slots_diff / AVERAGE_CATCHUP_SPEED
+                })
+                return
+
+        r = do_request(url_=url, method_='head', timeout_=1)
+        if 'location' in str(r.headers) and 'error' not in str(r.text):
+            snap_location_ = r.headers["location"]
+            # filtering uncompressed archives
+            if snap_location_.endswith('tar') is True:
+                DISCARDED_BY_ARCHIVE_TYPE += 1
+                return None
+            full_snap_slot_ = int(snap_location_.split("-")[1])
+            slots_diff_full = current_slot - full_snap_slot_
+            if slots_diff_full <= MAX_SNAPSHOT_AGE_IN_SLOTS and r.elapsed.total_seconds() * 1000 <= MAX_LATENCY:
+                # print(f'{rpc_address=} | {slots_diff=}')
+                json_data["rpc_nodes"].append({
+                    "snapshot_address": rpc_address,
+                    "slots_diff": slots_diff_full,
+                    "latency": r.elapsed.total_seconds() * 1000,
+                    "files_to_download": [snap_location_],
+                    "cost": AVERAGE_SNAPSHOT_FILE_SIZE_MB / MIN_DOWNLOAD_SPEED_MB + slots_diff_full / AVERAGE_CATCHUP_SPEED
+                })
+                return
+        return None
+
+    except Exception as getSnapErr_:
+        return None
+
+
+def download(url: str):
+    fname = url[url.rfind('/'):].replace("/", "")
+    temp_fname = f'{SNAPSHOT_PATH}/tmp-{fname}'
+    # try:
+    #     resp = requests.get(url, stream=True)
+    #     total = int(resp.headers.get('content-length', 0))
+    #     with open(temp_fname, 'wb') as file, tqdm(
+    #         desc=fname,
+    #         total=total,
+    #         unit='iB',
+    #         unit_scale=True,
+    #         unit_divisor=1024,
+    #     ) as bar:
+    #         for data in resp.iter_content(chunk_size=1024):
+    #             size = file.write(data)
+    #             bar.update(size)
+
+    #     logger.info(f'Rename the downloaded file {temp_fname} --> {fname}')
+    #     os.rename(temp_fname, f'{SNAPSHOT_PATH}/{fname}')
+
+    # except (ReadTimeout, ConnectTimeout, HTTPError, Timeout, ConnectionError) as downlErr:
+    #     logger.error(f'Exception in download() func\n {downlErr}')
+
+    try:
+        # dirty trick with wget. Details here - https://github.com/c29r3/solana-snapshot-finder/issues/11
+        if MAX_DOWNLOAD_SPEED_MB is not None:
+            process = subprocess.run(['/usr/bin/wget', f'--limit-rate={MAX_DOWNLOAD_SPEED_MB}M', '--trust-server-names', url, f'-O{temp_fname}'], 
+              stdout=subprocess.PIPE,
+              universal_newlines=True)
+        else:
+            process = subprocess.run(['/usr/bin/wget', '--trust-server-names', url, f'-O{temp_fname}'], 
+              stdout=subprocess.PIPE,
+              universal_newlines=True)
+
+        logger.info(f'Rename the downloaded file {temp_fname} --> {fname}')
+        os.rename(temp_fname, f'{SNAPSHOT_PATH}/{fname}')
+    
+    except Exception as unknwErr:
+        logger.error(f'Exception in download() func. Make sure wget is installed\n{unknwErr}')
+
+
+def main_worker():
+    try:
+        global FULL_LOCAL_SNAP_SLOT
+        rpc_nodes = list(set(get_all_rpc_ips()))
+        global pbar
+        pbar = tqdm(total=len(rpc_nodes))
+        logger.info(f'RPC servers in total: {len(rpc_nodes)} | Current slot number: {current_slot}\n')
+
+        # Search for full local snapshots.
+        # If such a snapshot is found and it is not too old, then the script will try to find and download an incremental snapshot
+        FULL_LOCAL_SNAPSHOTS = glob.glob(f'{SNAPSHOT_PATH}/snapshot-*tar*')
+        if len(FULL_LOCAL_SNAPSHOTS) > 0:
+            FULL_LOCAL_SNAPSHOTS.sort(reverse=True)
+            FULL_LOCAL_SNAP_SLOT = FULL_LOCAL_SNAPSHOTS[0].replace(SNAPSHOT_PATH, "").split("-")[1]
+            logger.info(f'Found full local snapshot {FULL_LOCAL_SNAPSHOTS[0]} | {FULL_LOCAL_SNAP_SLOT=}')
+
+        else:
+            logger.info(f'Can\'t find any full local snapshots in this path {SNAPSHOT_PATH} --> the search will be carried out on full snapshots')
+
+        print(f'Searching information about snapshots on all found RPCs')
+        pool = ThreadPool()
+        pool.map(get_snapshot_slot, rpc_nodes)
+        logger.info(f'Found suitable RPCs: {len(json_data["rpc_nodes"])}')
+        logger.info(f'The following information shows for what reason and how many RPCs were skipped.'
+        f'Timeout most probably mean, that node RPC port does not respond (port is closed)\n'
+        f'{DISCARDED_BY_ARCHIVE_TYPE=} | {DISCARDED_BY_LATENCY=} |'
+        f' {DISCARDED_BY_SLOT=} | {DISCARDED_BY_TIMEOUT=} | {DISCARDED_BY_UNKNW_ERR=}') 
+
+        if len(json_data["rpc_nodes"]) == 0:
+            logger.info(f'No snapshot nodes were found matching the given parameters: {args.max_snapshot_age=}')
+            sys.exit()
+
+        # sort list of rpc node by SORT_ORDER (latency)
+        rpc_nodes_sorted = sorted(json_data["rpc_nodes"], key=lambda k: k[SORT_ORDER])
+
+        json_data.update({
+            "last_update_at": time.time(),
+            "last_update_slot": current_slot,
+            "total_rpc_nodes": len(rpc_nodes),
+            "rpc_nodes_with_actual_snapshot": len(json_data["rpc_nodes"]),
+            "rpc_nodes": rpc_nodes_sorted
+        })
+
+        with open(f'{SNAPSHOT_PATH}/snapshot.json', "w") as result_f:
+            json.dump(json_data, result_f, indent=2)
+        logger.info(f'All data is saved to json file - {SNAPSHOT_PATH}/snapshot.json')
+
+        best_snapshot_node = {}
+        num_of_rpc_to_check = 15
+
+        rpc_nodes_inc_sorted = []
+        logger.info("TRYING TO DOWNLOADING FILES")
+        for i, rpc_node in enumerate(json_data["rpc_nodes"], start=1):
+            logger.info("checking node: %s %s"%(i,rpc_node))
+            # filter blacklisted snapshots
+            if BLACKLIST != ['']:
+                if any(i in str(rpc_node["files_to_download"]) for i in BLACKLIST):
+                    logger.info(f'{i}\\{len(json_data["rpc_nodes"])} BLACKLISTED --> {rpc_node}')
+                    continue
+
+            logger.info(f'{i}\\{len(json_data["rpc_nodes"])} checking the speed {rpc_node}')
+            if rpc_node["snapshot_address"] in unsuitable_servers:
+                logger.info(f'Rpc node already in unsuitable list --> skip {rpc_node["snapshot_address"]}')
+                continue
+            logger.info("checking version")
+            try:
+                if not version_check(rpc_node["snapshot_address"], VERSION):
+                    logger.info("version check failed")
+                    continue
+            except:
+                import traceback
+                print(traceback.format_exc())
+                print("broken")
+            logger.info("version check succeeded")
+            down_speed_bytes = measure_speed(url=rpc_node["snapshot_address"], measure_time=SPEED_MEASURE_TIME_SEC)
+            down_speed_mb = convert_size(down_speed_bytes)
+            if down_speed_bytes < MIN_DOWNLOAD_SPEED_MB * 1e6:
+                logger.info(f'Too slow: {rpc_node=} {down_speed_mb=}')
+                unsuitable_servers.add(rpc_node["snapshot_address"])
+                continue
+
+            elif down_speed_bytes >= MIN_DOWNLOAD_SPEED_MB * 1e6:
+                logger.info(f'Suitable snapshot server found: {rpc_node=} {down_speed_mb=}')
+                for path in reversed(rpc_node["files_to_download"]):
+                    # do not download full snapshot if it already exists locally
+                    if str(path).startswith("/snapshot-"):
+                        full_snap_slot__ = path.split("-")[1]
+                        if full_snap_slot__ == FULL_LOCAL_SNAP_SLOT:
+                            continue
+
+                    
+                    if 'incremental' in path:
+                        r = do_request(f'http://{rpc_node["snapshot_address"]}/incremental-snapshot.tar.bz2', method_='head', timeout_=2)
+                        if 'location' in str(r.headers) and 'error' not in str(r.text):
+                            best_snapshot_node = f'http://{rpc_node["snapshot_address"]}{r.headers["location"]}'
+                        else:
+                            best_snapshot_node = f'http://{rpc_node["snapshot_address"]}{path}'
+
+                    else:
+                        best_snapshot_node = f'http://{rpc_node["snapshot_address"]}{path}'
+                    logger.info(f'Downloading {best_snapshot_node} snapshot to {SNAPSHOT_PATH}')
+                    download(url=best_snapshot_node)
+                return 0
+
+            elif i > num_of_rpc_to_check:
+                logger.info(f'The limit on the number of RPC nodes from'
+                ' which we measure the speed has been reached {num_of_rpc_to_check=}\n')
+                break
+
+            else:
+                logger.info(f'{down_speed_mb=} < {MIN_DOWNLOAD_SPEED_MB=}')
+
+        if best_snapshot_node is {}:
+            logger.error(f'No snapshot nodes were found matching the given parameters:{args.min_download_speed=}'
+                  f'\nTry restarting the script with --with_private_rpc'
+                  f'RETRY #{NUM_OF_ATTEMPTS}\\{NUM_OF_MAX_ATTEMPTS}')
+            return 1
+
+
+
+    except KeyboardInterrupt:
+        sys.exit('\nKeyboardInterrupt - ctrl + c')
+
+    except:
+        return 1
+
+
+logger.info("Version: 0.3.3")
+logger.info("https://github.com/c29r3/solana-snapshot-finder\n\n")
+logger.info(f'{RPC=}\n'
+      f'{MAX_SNAPSHOT_AGE_IN_SLOTS=}\n'
+      f'{MIN_DOWNLOAD_SPEED_MB=}\n'
+      f'{MAX_DOWNLOAD_SPEED_MB=}\n'
+      f'{SNAPSHOT_PATH=}\n'
+      f'{THREADS_COUNT=}\n'
+      f'{NUM_OF_MAX_ATTEMPTS=}\n'
+      f'{WITH_PRIVATE_RPC=}\n'
+      f'{SORT_ORDER=}')
+
+try:
+    f_ = open(f'{SNAPSHOT_PATH}/write_perm_test', 'w')
+    f_.close()
+    os.remove(f'{SNAPSHOT_PATH}/write_perm_test')
+except IOError:
+    logger.error(f'\nCheck {SNAPSHOT_PATH=} and permissions')
+    Path(SNAPSHOT_PATH).mkdir(parents=True, exist_ok=True)
+
+json_data = ({"last_update_at": 0.0,
+              "last_update_slot": 0,
+              "total_rpc_nodes": 0,
+              "rpc_nodes_with_actual_snapshot": 0,
+              "rpc_nodes": []
+              })
+
+
+while NUM_OF_ATTEMPTS <= NUM_OF_MAX_ATTEMPTS:
+    current_slot = get_current_slot()
+    logger.info(f'Attempt number: {NUM_OF_ATTEMPTS}. Total attempts: {NUM_OF_MAX_ATTEMPTS}')
+    NUM_OF_ATTEMPTS += 1
+
+    if current_slot is None:
+        continue
+
+    worker_result = main_worker()
+
+    if worker_result == 0:
+        logger.info("Done")
+        exit(0)
+
+    if worker_result != 0:
+        logger.info("Now trying with flag --with_private_rpc")
+        WITH_PRIVATE_RPC = True
+
+    if NUM_OF_ATTEMPTS >= NUM_OF_MAX_ATTEMPTS:
+        logger.error(f'Could not find a suitable snapshot --> exit')
+        sys.exit()
+    
+    logger.info(f"Sleeping {SLEEP_BEFORE_RETRY} seconds before next try")
+    time.sleep(SLEEP_BEFORE_RETRY)
+


### PR DESCRIPTION
### PR summary

---

**Addition 1:** *Turn‑key NVMe → LVM → snapshot workflow*
`scripts/lvm_setup/`

* [`setup_mithril_lvm.sh`](https://github.com/7layermagik/mithril/blob/LVM_scripts_and_performance_profiling/scripts/lvm_setup/setup_mithril_lvm.sh) – *wipe / setup* utility

  * partitions a dedicated NVMe (80 / 20 split by default)
  * builds a thin‑pool + `accounts_master` gold‑master LV, mounts it at `/mnt/accounts_master`
  * formats `/var/lib/mithril`, creates `/var/lib/mithril/snapshots`, fixes `/etc/fstab`
* [`manage_mithril_snapshot.sh`](https://github.com/7layermagik/mithril/blob/LVM_scripts_and_performance_profiling/scripts/lvm_setup/manage_mithril_snapshot.sh) – *snapshot / remove\_snapshot* helper

  * one‑liner `snapshot <name>` → thin COW clone, fs‑check, mount (defaults `/mnt/<name>`)
  * `remove_snapshot <name>` → unmounts & removes the LV safely

Quick‑start & options are in the script‑local README →
[https://github.com/7layermagik/mithril/blob/LVM\_scripts\_and\_performance\_profiling/scripts/lvm\_setup/README.md](https://github.com/7layermagik/mithril/blob/LVM_scripts_and_performance_profiling/scripts/lvm_setup/README.md)

---

**Addition 2:** *`profile_capture.sh` – one‑command runtime profiler*
`scripts/performance_profiling/profile_capture.sh`
Launches any **Mithril** command and, every *N* seconds, captures:

| artefact                       | saved as                                           |
| ------------------------------ | -------------------------------------------------- |
| heap / CPU / goroutine pprof   | `heap_*.pprof`, `cpu_*.pprof`, `goroutine_*.pprof` |
| full `/proc/$PID/smaps_rollup` | `smaps_*.txt`                                      |
| ps CPU/RSS/VSZ snapshot        | CSV row                                            |

Outputs a single `profile_map.csv` for easy graphing plus a tee‑logged stdout file.

Example:

```bash
sudo -E scripts/performance_profiling/profile_capture.sh 30 \
        ~/mithril_profiles mithril_run -- \
        ~/mithril/mithril verifier --accountsdb \
        --path /mnt/run1 --startslot … --endslot … --rpc …
```

---

**Change 1:** *‑40 GB RSS on startup by GC’ing Sniper chunks*

File modified: **`pkg/accountsdb/accountsdb.go`**

| change                                                                | reason                                           |                                                                                                                                                                                                                |
| --------------------------------------------------------------------- | ------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| removed unused import `github.com/Overclock-Validator/sniper/options` | build hygiene                                    |                                                                                                                                                                                                                |
| after `sniper.Open` added                                             | `go<br>runtime.GC()<br>debug.FreeOSMemory()<br>` | `sniper.Open` allocates \~45 GB of transient `*chunk` structs. A forced GC + `FreeOSMemory` immediately releases those pages, dropping resident memory from \~60 GB → 15–20 GB with no impact on replay speed. |

---

#### Impact

* **Ops** – one‑command disk prep, snapshots in <3 s, full wipe in <10 s.
* **Perf** – startup RAM ‑40 GB; profiler script gives repeatable CPU/RSS traces.
* **Risk** – scripts are opt‑in; runtime change is a two‑line GC hint, no logic touched.