### PR TITLE
feat: Integrate solana-snapshot-finder-go for intelligent snapshot source discovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,13 @@ fixtures/.DS_Store
 pkg/.DS_Store
 .DS_Store
 mithril.toml
+
+# Local development files
+go.work
+go.work.sum
+
+# AI handoff documents (not part of the repo)
+docs/snapshot-integration-handoff*.txt
+
+# Claude Code settings
+.claude/

--- a/cmd/mithril/node/node.go
+++ b/cmd/mithril/node/node.go
@@ -340,6 +340,91 @@ func initConfigAndBindFlags(cmd *cobra.Command) error {
 	return nil
 }
 
+// buildSnapshotConfig creates a snapshotdl.SnapshotConfig from the mithril config.
+// It starts with defaults and overrides with any values set in the TOML file.
+func buildSnapshotConfig() snapshotdl.SnapshotConfig {
+	cfg := snapshotdl.DefaultSnapshotConfig()
+
+	// Override with TOML values if set
+	if config.IsSet("snapshot.verbose") {
+		cfg.Verbose = config.GetBool("snapshot.verbose")
+	}
+	if config.IsSet("snapshot.save_to_disk") {
+		cfg.SaveToDisk = config.GetBool("snapshot.save_to_disk")
+	}
+	if config.IsSet("snapshot.download_path") {
+		cfg.DownloadPath = config.GetString("snapshot.download_path")
+	}
+	if config.IsSet("snapshot.stage1_warm_kib") {
+		cfg.Stage1WarmKiB = config.GetInt64("snapshot.stage1_warm_kib")
+	}
+	if config.IsSet("snapshot.stage1_window_kib") {
+		cfg.Stage1WindowKiB = config.GetInt64("snapshot.stage1_window_kib")
+	}
+	if config.IsSet("snapshot.stage1_windows") {
+		cfg.Stage1Windows = config.GetInt("snapshot.stage1_windows")
+	}
+	if config.IsSet("snapshot.stage1_timeout_ms") {
+		cfg.Stage1TimeoutMS = config.GetInt64("snapshot.stage1_timeout_ms")
+	}
+	if config.IsSet("snapshot.stage1_concurrency") {
+		cfg.Stage1Concurrency = config.GetInt("snapshot.stage1_concurrency")
+	}
+	if config.IsSet("snapshot.stage2_top_k") {
+		cfg.Stage2TopK = config.GetInt("snapshot.stage2_top_k")
+	}
+	if config.IsSet("snapshot.stage2_warm_sec") {
+		cfg.Stage2WarmSec = config.GetInt("snapshot.stage2_warm_sec")
+	}
+	if config.IsSet("snapshot.stage2_measure_sec") {
+		cfg.Stage2MeasureSec = config.GetInt("snapshot.stage2_measure_sec")
+	}
+	if config.IsSet("snapshot.stage2_min_ratio") {
+		cfg.Stage2MinRatio = config.GetFloat64("snapshot.stage2_min_ratio")
+	}
+	if config.IsSet("snapshot.stage2_min_abs_mbs") {
+		cfg.Stage2MinAbsMBs = config.GetFloat64("snapshot.stage2_min_abs_mbs")
+	}
+	if config.IsSet("snapshot.max_rtt_ms") {
+		cfg.MaxRTTMs = config.GetInt("snapshot.max_rtt_ms")
+	}
+	if config.IsSet("snapshot.tcp_timeout_ms") {
+		cfg.TCPTimeoutMs = config.GetInt("snapshot.tcp_timeout_ms")
+	}
+	if config.IsSet("snapshot.min_node_version") {
+		cfg.MinNodeVersion = config.GetString("snapshot.min_node_version")
+	}
+	if config.IsSet("snapshot.allowed_node_versions") {
+		cfg.AllowedNodeVersions = config.GetStringSlice("snapshot.allowed_node_versions")
+	}
+	if config.IsSet("snapshot.full_threshold") {
+		cfg.FullThreshold = config.GetInt("snapshot.full_threshold")
+	}
+	if config.IsSet("snapshot.incremental_threshold") {
+		cfg.IncrementalThreshold = config.GetInt("snapshot.incremental_threshold")
+	}
+	if config.IsSet("snapshot.safety_margin_slots") {
+		cfg.SafetyMarginSlots = config.GetInt("snapshot.safety_margin_slots")
+	}
+	if config.IsSet("snapshot.max_full_snapshots") {
+		cfg.MaxFullSnapshots = config.GetInt("snapshot.max_full_snapshots")
+	}
+	if config.IsSet("snapshot.delete_old_snapshots") {
+		cfg.DeleteOldSnapshots = config.GetBool("snapshot.delete_old_snapshots")
+	}
+	if config.IsSet("snapshot.worker_count") {
+		cfg.WorkerCount = config.GetInt("snapshot.worker_count")
+	}
+	if config.IsSet("snapshot.max_snapshot_url_attempts") {
+		cfg.MaxSnapshotURLAttempts = config.GetInt("snapshot.max_snapshot_url_attempts")
+	}
+	if config.IsSet("snapshot.min_incremental_speed_mbs") {
+		cfg.MinIncrementalSpeedMBs = config.GetFloat64("snapshot.min_incremental_speed_mbs")
+	}
+
+	return cfg
+}
+
 func runVerifyRange(c *cobra.Command, args []string) {
 	ctx := c.Context()
 	if pprofPort != -1 {
@@ -406,8 +491,9 @@ func runVerifyRange(c *cobra.Command, args []string) {
 
 		mlog.Log.Infof("downloading snapshot...")
 
+		snapCfg := buildSnapshotConfig()
 		var dlPath string
-		dlPath, _, _, err = snapshotdl.DownloadSnapshot(rpcEndpoints[0], snapshotDlPath)
+		dlPath, _, _, err = snapshotdl.DownloadSnapshotWithConfig(rpcEndpoints[0], snapshotDlPath, snapCfg)
 		if err != nil {
 			klog.Fatalf("error downloading snapshot: %s", err)
 		}
@@ -515,14 +601,15 @@ func runVerifyLive(c *cobra.Command, args []string) {
 		rpcEndpoints = []string{"https://api.mainnet-beta.solana.com"}
 	}
 
+	snapCfg := buildSnapshotConfig()
 	mlog.Log.Infof("using RPC endpoint: %s", rpcEndpoints[0])
-	mlog.Log.Infof("downloading full snapshot...")
+	mlog.Log.Infof("discovering best snapshot source...")
 	fullSnapshotDlStart := time.Now()
-	fullSnapshotPath, _, fullSnapshotSlot, err := snapshotdl.DownloadSnapshot(rpcEndpoints[0], snapshotDownloadPath)
+	fullSnapshotURL, _, fullSnapshotSlot, err := snapshotdl.GetSnapshotURL(rpcEndpoints[0], snapCfg)
 	if err != nil {
-		klog.Fatalf("error downloading snapshot: %s", err)
+		klog.Fatalf("error getting snapshot URL: %s", err)
 	}
-	mlog.Log.Infof("finished downloading full snapshot in %s to %s", time.Since(fullSnapshotDlStart), fullSnapshotPath)
+	mlog.Log.Infof("found snapshot URL in %s: %s", time.Since(fullSnapshotDlStart), fullSnapshotURL)
 
 	// Pass overcast endpoint if using overcast, otherwise empty string for RPC mode
 	var overcastAddr string
@@ -530,7 +617,7 @@ func runVerifyLive(c *cobra.Command, args []string) {
 		overcastAddr = overcastEndpoint
 	}
 
-	accountsDb, manifest, err := snapshot.BuildAccountsDbWithIncr(ctx, fullSnapshotPath, snapshotDownloadPath, fullSnapshotSlot, fullSnapshotSlot, accountsPath, rpcEndpoints, ledgerPath, overcastAddr)
+	accountsDb, manifest, err := snapshot.BuildAccountsDbWithIncr(ctx, fullSnapshotURL, snapshotDownloadPath, fullSnapshotSlot, fullSnapshotSlot, accountsPath, rpcEndpoints, ledgerPath, overcastAddr, snapCfg)
 	if err != nil {
 		klog.Fatalf("failed to populate new accounts db from snapshot %s: %s", snapshotArchivePath, err)
 	}

--- a/cmd/testzst/main.go
+++ b/cmd/testzst/main.go
@@ -21,7 +21,7 @@ func main() {
 		mlog.Log.Errorf("opening zstdFilename=%s: %v", *zstdFilename, err)
 		os.Exit(1)
 	}
-	bmr, err := snapshot.NewBufMonReader(file)
+	bmr, err := snapshot.NewBufMonReaderFromFile(file)
 	if err != nil {
 		mlog.Log.Errorf("making BufMonReader: %v", err)
 		os.Exit(1)

--- a/docs/snapshot.md
+++ b/docs/snapshot.md
@@ -1,0 +1,389 @@
+# Mithril Snapshot Integration
+
+This document describes the snapshot download and streaming integration in Mithril, which uses the `solana-snapshot-finder-go` library for intelligent node discovery and selection.
+
+## Overview
+
+Mithril can bootstrap from Solana snapshots in two modes:
+
+1. **HTTP Streaming** (default): Stream snapshots directly from network to processing pipeline, optionally saving to disk while streaming
+2. **Disk Download**: Download snapshots to disk first, then process from disk
+
+The integration automatically discovers the fastest RPC nodes with recent snapshots using a two-stage speed testing algorithm.
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                        mithril/cmd/mithril                       │
+│                     (verify-live, node commands)                 │
+└─────────────────────────────────┬───────────────────────────────┘
+                                  │
+┌─────────────────────────────────▼───────────────────────────────┐
+│                     pkg/snapshotdl                               │
+│  - SnapshotConfig (all tuning parameters)                        │
+│  - GetSnapshotURL() → HTTP URL for full snapshot                 │
+│  - GetIncrementalSnapshotURL() → HTTP URL for incremental        │
+│  - DownloadSnapshot() → disk path (if disk download needed)      │
+└─────────────────────────────────┬───────────────────────────────┘
+                                  │
+┌─────────────────────────────────▼───────────────────────────────┐
+│                     pkg/snapshot                                 │
+│  - BuildAccountsDbWithIncr() → main entry point                  │
+│  - newSnapshotReaderWithSave() → HTTP or file reader             │
+│  - readTarWithSave() / readTarIncrWithSave() → tar processing    │
+│  - Cleanup logic for partial downloads                           │
+└─────────────────────────────────┬───────────────────────────────┘
+                                  │
+┌─────────────────────────────────▼───────────────────────────────┐
+│               solana-snapshot-finder-go (library)                │
+│  - rpc.FetchClusterNodes() → discover RPC nodes                  │
+│  - rpc.EvaluateNodesWithVersionsAndStats() → two-stage testing   │
+│  - rpc.SortBestNodesWithStats() → rank by speed                  │
+│  - snapshot.GetSnapshotURL() → get HTTP URL from node            │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## Two-Stage Node Discovery Algorithm
+
+The snapshot finder uses a two-stage algorithm to efficiently find the fastest nodes:
+
+### Stage 1: Fast Parallel Triage
+
+- Downloads a small amount of data from many nodes in parallel
+- Quickly eliminates slow nodes to reduce the candidate pool
+- Configuration:
+  - `stage1_warm_kib`: Warmup data before timing (default: 512 KiB)
+  - `stage1_window_kib`: Size of each measurement window (default: 512 KiB)
+  - `stage1_windows`: Number of measurement windows (default: 4)
+  - `stage1_timeout_ms`: Timeout per node (default: 3000 ms)
+  - `stage1_concurrency`: Parallel downloads (default: 0 = auto, uses CPU cores)
+
+### Stage 2: Sustained Speed Test
+
+- Takes top candidates from stage 1
+- Measures sustained download speed over longer period
+- Detects nodes that start fast but slow down
+- Configuration:
+  - `stage2_top_k`: Number of candidates to test (default: 8)
+  - `stage2_warm_sec`: Warmup duration (default: 2 seconds)
+  - `stage2_measure_sec`: Measurement duration (default: 2 seconds)
+  - `stage2_min_ratio`: Speed collapse threshold (default: 0.6)
+  - `stage2_min_abs_mbs`: Minimum absolute speed (default: 0.0, disabled)
+
+### Node Filtering
+
+Before speed testing, nodes are filtered by:
+
+- **Version**: `min_node_version` (default: "2.2.0"), `allowed_node_versions` (optional whitelist)
+- **RTT**: `max_rtt_ms` (default: 200 ms)
+- **TCP Connectivity**: `tcp_timeout_ms` (default: 1000 ms)
+- **Snapshot Age**: `full_threshold` (default: 100000 slots), `incremental_threshold` (default: 200 slots)
+
+## Full Snapshot Selection Flow
+
+```
+1. Get reference slot from RPC endpoint
+2. Discover all RPC nodes from cluster (getClusterNodes)
+3. Filter nodes by version, RTT, snapshot age
+4. Run two-stage speed test on remaining nodes
+5. Rank nodes by measured download speed
+6. Try ranked nodes in order until one succeeds:
+   a. Get HTTP URL for snapshot
+   b. Verify snapshot exists and is accessible
+   c. Return URL for streaming (or download to disk)
+```
+
+**Fallback Resilience**: If the #1 fastest node's HTTP endpoint is down or snapshot was deleted, the system automatically tries the next best nodes. Configure with `max_snapshot_url_attempts` (default: 3).
+
+## Incremental Snapshot Selection Flow
+
+Incremental snapshots must match the base slot of the full snapshot. The selection strategy differs from full snapshots:
+
+```
+1. Try same source as full snapshot first (fastest, most likely match)
+   └─ Check if incremental base slot == full snapshot slot
+
+2. If that fails, search cluster for matching incrementals:
+   a. Evaluate all nodes (same two-stage algorithm)
+   b. Filter to nodes with incremental base slot matching full snapshot
+   c. Filter by minimum speed (min_incremental_speed_mbs, default: 2 MB/s)
+   d. Sort by freshness (highest end slot first), then by speed
+   e. Try ranked nodes until one succeeds
+```
+
+**Key Difference**: For incrementals, freshness (end slot) is prioritized over pure speed, since we want the most recent incremental that matches the base slot.
+
+## HTTP Streaming vs Disk Download
+
+### Streaming Mode (Default)
+
+When `save_to_disk = false` (default):
+- Snapshot data streams directly from HTTP to processing pipeline
+- No disk space required for snapshot files
+- Cannot resume if interrupted
+- Fastest overall time-to-ready
+
+### Streaming + Save Mode
+
+When `save_to_disk = true` and `download_path` is set:
+- Uses `io.TeeReader` to write to disk while streaming
+- Processing happens in parallel with disk write
+- Snapshot files are saved for potential reuse
+- Slightly higher memory usage
+
+### Disk Download Mode
+
+When using `DownloadSnapshot()` instead of `GetSnapshotURL()`:
+- Downloads complete snapshot to disk first
+- Then processes from disk
+- Useful for debugging or when you need the file
+
+## Retry and Cleanup Behavior
+
+### Partial Download Cleanup
+
+If a download fails mid-way or is cancelled (Ctrl+C):
+- Partial download files are automatically deleted
+- Full snapshot: partial file deleted on cancellation
+- Incremental: partial incremental deleted, full snapshot preserved (already complete)
+
+### Incremental Retry with Re-Discovery
+
+If an incremental download fails mid-way (not due to Ctrl+C):
+1. Partial file is deleted
+2. Source discovery runs again (cluster state may have changed)
+3. Fresh sources are ranked and tried
+4. Retry up to 3 times before failing
+
+This handles cases where a source stops serving mid-download - the re-discovery may find newer/fresher incrementals from different nodes.
+
+## Configuration Reference
+
+All configuration options can be set in `config.toml` under the `[snapshot]` section:
+
+```toml
+[snapshot]
+    # Path to download snapshot to (only used if save_to_disk = true)
+    # download_path = ""
+
+    # Save snapshots to disk while streaming (requires download_path)
+    # When true: streams from network while saving to disk and processing (parallel)
+    # When false: streams from network and processes without saving (saves disk space)
+    # save_to_disk = false
+
+    # Enable verbose output showing detailed node discovery statistics
+    # verbose = false
+
+    # -------------------------------------------------------------------------
+    # Stage 1: Fast Parallel Triage
+    # -------------------------------------------------------------------------
+
+    # Warmup data before timing (KiB)
+    # stage1_warm_kib = 512
+
+    # Size of each measurement window (KiB)
+    # stage1_window_kib = 512
+
+    # Number of measurement windows (total data = windows * window_kib)
+    # stage1_windows = 4
+
+    # Timeout for stage 1 testing per node (milliseconds)
+    # stage1_timeout_ms = 3000
+
+    # Number of concurrent downloads in stage 1 (0 = auto, uses CPU cores)
+    # stage1_concurrency = 0
+
+    # -------------------------------------------------------------------------
+    # Stage 2: Sustained Speed Test
+    # -------------------------------------------------------------------------
+
+    # Number of top candidates from stage 1 to test in stage 2
+    # stage2_top_k = 8
+
+    # Warmup duration before measurement (seconds)
+    # stage2_warm_sec = 2
+
+    # Measurement duration (seconds)
+    # stage2_measure_sec = 2
+
+    # Minimum speed ratio (collapse if speed drops below this * peak)
+    # stage2_min_ratio = 0.6
+
+    # Minimum absolute speed (MB/s, 0 = disabled)
+    # stage2_min_abs_mbs = 0.0
+
+    # -------------------------------------------------------------------------
+    # Node Filtering
+    # -------------------------------------------------------------------------
+
+    # Maximum RTT to consider a node (milliseconds, 0 = disabled)
+    # max_rtt_ms = 200
+
+    # TCP connection timeout for pre-check (milliseconds)
+    # tcp_timeout_ms = 1000
+
+    # Minimum Solana version required (e.g., "2.2.0", empty = no filter)
+    # min_node_version = "2.2.0"
+
+    # Allowed Solana versions (empty = all versions allowed)
+    # allowed_node_versions = []
+
+    # -------------------------------------------------------------------------
+    # Snapshot Age Thresholds
+    # -------------------------------------------------------------------------
+
+    # Maximum age for full snapshots (slots)
+    # full_threshold = 100000
+
+    # Maximum age for incremental snapshots (slots)
+    # incremental_threshold = 200
+
+    # Safety margin - warn if snapshot is this close to expiration (slots)
+    # safety_margin_slots = 5000
+
+    # -------------------------------------------------------------------------
+    # Snapshot Retention
+    # -------------------------------------------------------------------------
+
+    # Maximum number of full snapshots to keep (0 = unlimited)
+    # max_full_snapshots = 2
+
+    # Automatically delete old snapshots based on age thresholds
+    # delete_old_snapshots = false
+
+    # -------------------------------------------------------------------------
+    # Performance
+    # -------------------------------------------------------------------------
+
+    # Number of concurrent workers for node evaluation
+    # worker_count = 100
+
+    # -------------------------------------------------------------------------
+    # Fallback Resilience
+    # -------------------------------------------------------------------------
+
+    # Maximum number of ranked snapshot sources to try before giving up
+    # This is a resilience mechanism - if the #1 fastest node's HTTP endpoint
+    # is down or snapshot was deleted, we try the next best ranked nodes.
+    # Set to 0 to try all available nodes.
+    # max_snapshot_url_attempts = 3
+
+    # -------------------------------------------------------------------------
+    # Incremental Snapshot Selection
+    # -------------------------------------------------------------------------
+
+    # Minimum download speed for incremental snapshot sources (MB/s)
+    # Incrementals are ~1GB, so this filters out nodes that would take too long.
+    # At 2 MB/s: ~8 minutes for 1GB (acceptable)
+    # Set to 0 to disable speed filtering.
+    # min_incremental_speed_mbs = 2.0
+```
+
+## Default Values
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `save_to_disk` | `false` | Stream-only by default |
+| `verbose` | `false` | Quiet logging |
+| `stage1_warm_kib` | `512` | 512 KiB warmup |
+| `stage1_window_kib` | `512` | 512 KiB windows |
+| `stage1_windows` | `4` | 4 windows = 2 MiB total |
+| `stage1_timeout_ms` | `3000` | 3 second timeout |
+| `stage1_concurrency` | `0` | Auto (CPU cores) |
+| `stage2_top_k` | `8` | Test top 8 candidates |
+| `stage2_warm_sec` | `2` | 2 second warmup |
+| `stage2_measure_sec` | `2` | 2 second measurement |
+| `stage2_min_ratio` | `0.6` | 60% speed collapse threshold |
+| `stage2_min_abs_mbs` | `0.0` | Disabled |
+| `max_rtt_ms` | `200` | 200ms max RTT |
+| `tcp_timeout_ms` | `1000` | 1 second TCP check |
+| `min_node_version` | `"2.2.0"` | Minimum Agave 2.2.0 |
+| `full_threshold` | `100000` | ~11 hours old |
+| `incremental_threshold` | `200` | ~80 seconds old |
+| `safety_margin_slots` | `5000` | Warn if close to expiration |
+| `max_full_snapshots` | `2` | Keep last 2 |
+| `worker_count` | `100` | 100 concurrent workers |
+| `max_snapshot_url_attempts` | `3` | Try top 3 nodes |
+| `min_incremental_speed_mbs` | `2.0` | Minimum 2 MB/s |
+
+## Verbose Mode Output
+
+Enable `verbose = true` to see detailed statistics:
+
+```
+=== Snapshot Node Discovery Statistics ===
+Total nodes discovered: 1847
+TCP connectivity passed: 1623
+Nodes with any snapshot: 892
+Nodes with incremental: 445 (usable: 312)
+After version filter: 756
+After RTT filter (<200ms): 234
+After age filters (full<100000, incr<200 slots): full=198, incr=156
+Final eligible nodes: 156
+==========================================
+```
+
+## Error Handling
+
+The integration handles several failure modes:
+
+1. **No nodes available**: Returns error with count of nodes tried
+2. **All nodes too slow**: Falls back to slower nodes rather than failing
+3. **Source stops mid-download**:
+   - Deletes partial file
+   - Re-runs discovery (may find fresher snapshots)
+   - Retries up to 3 times
+4. **Context cancellation (Ctrl+C)**:
+   - Deletes partial download files
+   - Exits immediately without retry
+
+## Usage Examples
+
+### Basic verify-live with defaults
+
+```bash
+mithril verify-live --rpc https://api.mainnet-beta.solana.com
+```
+
+### With custom config file
+
+```bash
+mithril verify-live --config my-config.toml
+```
+
+### Save snapshots while streaming
+
+```toml
+[snapshot]
+    save_to_disk = true
+    download_path = "/data/snapshots"
+```
+
+### High-speed network tuning
+
+```toml
+[snapshot]
+    # Test more candidates in stage 2
+    stage2_top_k = 16
+
+    # Longer measurement for more accurate speeds
+    stage2_measure_sec = 5
+
+    # Stricter speed requirement
+    stage2_min_abs_mbs = 50.0
+
+    # More retry attempts for resilience
+    max_snapshot_url_attempts = 5
+```
+
+### Low-latency network (nearby nodes only)
+
+```toml
+[snapshot]
+    # Only consider very low latency nodes
+    max_rtt_ms = 50
+
+    # Faster triage with shorter timeout
+    stage1_timeout_ms = 1500
+```

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,6 @@ require (
 	github.com/mr-tron/base58 v1.2.0
 	github.com/novifinancial/serde-reflection/serde-generate/runtime/golang v0.0.0-20220519162058-e5cd3c3b3f3a
 	github.com/prometheus/client_golang v1.20.4
-	github.com/prometheus/common v0.67.4
 	github.com/segmentio/textio v1.2.0
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.11.1
@@ -50,6 +49,7 @@ require (
 	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/onsi/gomega v1.27.6 // indirect
+	github.com/prometheus/common v0.67.4 // indirect
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	github.com/zeebo/assert v1.3.0 // indirect
@@ -108,7 +108,7 @@ require (
 require (
 	filippo.io/edwards25519 v1.0.0
 	github.com/Overclock-Validator/bgls v0.0.0-20250309141600-b7db1bfbf3fa
-	github.com/Overclock-Validator/solana-snapshot-finder-go v0.0.0-20251214224939-3d8fd6b99fd2
+	github.com/Overclock-Validator/solana-snapshot-finder-go v0.0.0-20251226044135-bdeaafa5ef54
 	github.com/Overclock-Validator/wide v0.0.0-20250221123529-f80959d02044
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d // indirect
 	github.com/andres-erbsen/clock v0.0.0-20160526145045-9e14626cd129 // indirect

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,8 @@ github.com/Overclock-Validator/frand v0.0.0-20251113191226-96ce04ddc1a8 h1:Q7QbI
 github.com/Overclock-Validator/frand v0.0.0-20251113191226-96ce04ddc1a8/go.mod h1:SvoqQH599ARmAzX0za/ZNvb2+2qt47ZpslDYFf4oaK0=
 github.com/Overclock-Validator/gnark-crypto v0.0.0-20250309203346-2a67ed08a105 h1:mP6FWHZ8ddcmbE8UTrVVI2Mi2c24aqX/8p12Vn6zokQ=
 github.com/Overclock-Validator/gnark-crypto v0.0.0-20250309203346-2a67ed08a105/go.mod h1:Poczuq3dbt+CwyTKgOjGaEwJOMP7YxQobF7QhgNcguk=
-github.com/Overclock-Validator/solana-snapshot-finder-go v0.0.0-20251214224939-3d8fd6b99fd2 h1:BkT9e5FrDcPdJjESu79strDSqbMkYSULgwUeNp016jw=
-github.com/Overclock-Validator/solana-snapshot-finder-go v0.0.0-20251214224939-3d8fd6b99fd2/go.mod h1:eGid2BnlV//V7u9/SHtZGfBM7hY8insIBCR7oBwD2Gg=
+github.com/Overclock-Validator/solana-snapshot-finder-go v0.0.0-20251226044135-bdeaafa5ef54 h1:a5q75DvvOqcXauzdSWiCI3GCDE8q1Bl4PfVqAyVhwLk=
+github.com/Overclock-Validator/solana-snapshot-finder-go v0.0.0-20251226044135-bdeaafa5ef54/go.mod h1:XbqbvMA2NKeosY0w3WdBOpCg2eYJesBjfE4cNt9HSE8=
 github.com/Overclock-Validator/weightedrand v0.0.0-20251113203832-5ac028321d0a h1:tzw/MMcuueuiIXQP8eN7yDAMGuYoiebyqmw9En4CMC8=
 github.com/Overclock-Validator/weightedrand v0.0.0-20251113203832-5ac028321d0a/go.mod h1:6s4SdiWMKESRRXILwdc+t6aPtQXugAZfu14QecC2w20=
 github.com/Overclock-Validator/wide v0.0.0-20250221123529-f80959d02044 h1:ph9gnWIY116AWT/iCfXoPe9/cn2aWx2uJBuLdf/LyEE=

--- a/mithril.example.toml
+++ b/mithril.example.toml
@@ -23,7 +23,7 @@
     # path = "/tmp/blocks"
 
     # Output path for writing AccountsDB data to
-    # accounts_path = "/mnt/accountsdb"
+    # accounts_path = "/mnt/mithril-accounts"
 
     # Path of full snapshot or AccountsDB to load from (verifier mode)
     # snapshot_archive_path = "/path/to/snapshot-or-accountsdb"
@@ -168,10 +168,12 @@
     # stage2_top_k = 8
 
     # Warmup duration before measurement (seconds)
-    # stage2_warm_sec = 2
+    # Recommended: 3 seconds for home internet (more variable), 1-2 for datacenter
+    # stage2_warm_sec = 3
 
     # Measurement duration (seconds)
-    # stage2_measure_sec = 2
+    # Recommended: 3 seconds for home internet (more variable), 1-2 for datacenter
+    # stage2_measure_sec = 3
 
     # Minimum speed ratio (collapse if speed drops below this * peak)
     # stage2_min_ratio = 0.6

--- a/mithril.example.toml
+++ b/mithril.example.toml
@@ -128,5 +128,120 @@
 # ============================================================================
 
 [snapshot]
-    # Path to download snapshot to
+    # Path to download snapshot to (only used if save_to_disk = true)
     # download_path = ""
+
+    # Save snapshots to disk while streaming (requires download_path)
+    # When true: streams from network while saving to disk and processing (parallel)
+    # When false: streams from network and processes without saving (saves disk space)
+    # save_to_disk = false
+
+    # Enable verbose output showing detailed node discovery statistics
+    # verbose = false
+
+    # -------------------------------------------------------------------------
+    # Stage 1: Fast Parallel Triage
+    # Quickly tests many nodes in parallel to eliminate slow ones
+    # -------------------------------------------------------------------------
+
+    # Warmup data before timing (KiB)
+    # stage1_warm_kib = 512
+
+    # Size of each measurement window (KiB)
+    # stage1_window_kib = 512
+
+    # Number of measurement windows (total data = windows * window_kib)
+    # stage1_windows = 4
+
+    # Timeout for stage 1 testing per node (milliseconds)
+    # stage1_timeout_ms = 3000
+
+    # Number of concurrent downloads in stage 1 (0 = auto, uses CPU cores)
+    # stage1_concurrency = 0
+
+    # -------------------------------------------------------------------------
+    # Stage 2: Sustained Speed Test
+    # Tests top candidates from stage 1 with longer downloads
+    # -------------------------------------------------------------------------
+
+    # Number of top candidates from stage 1 to test in stage 2
+    # stage2_top_k = 8
+
+    # Warmup duration before measurement (seconds)
+    # stage2_warm_sec = 2
+
+    # Measurement duration (seconds)
+    # stage2_measure_sec = 2
+
+    # Minimum speed ratio (collapse if speed drops below this * peak)
+    # stage2_min_ratio = 0.6
+
+    # Minimum absolute speed (MB/s, 0 = disabled)
+    # stage2_min_abs_mbs = 0.0
+
+    # -------------------------------------------------------------------------
+    # Node Filtering
+    # -------------------------------------------------------------------------
+
+    # Maximum RTT to consider a node (milliseconds, 0 = disabled)
+    # max_rtt_ms = 200
+
+    # TCP connection timeout for pre-check (milliseconds)
+    # tcp_timeout_ms = 1000
+
+    # Minimum Solana version required (e.g., "2.2.0", empty = no filter)
+    # min_node_version = "2.2.0"
+
+    # Allowed Solana versions (empty = all versions allowed)
+    # Example: allowed_node_versions = ["2.2.0", "3.0.0"]
+    # allowed_node_versions = []
+
+    # -------------------------------------------------------------------------
+    # Snapshot Age Thresholds
+    # -------------------------------------------------------------------------
+
+    # Maximum age for full snapshots (slots)
+    # full_threshold = 100000
+
+    # Maximum age for incremental snapshots (slots)
+    # incremental_threshold = 200
+
+    # Safety margin - warn if snapshot is this close to expiration (slots)
+    # safety_margin_slots = 5000
+
+    # -------------------------------------------------------------------------
+    # Snapshot Retention
+    # -------------------------------------------------------------------------
+
+    # Maximum number of full snapshots to keep (0 = unlimited)
+    # max_full_snapshots = 2
+
+    # Automatically delete old snapshots based on age thresholds
+    # delete_old_snapshots = false
+
+    # -------------------------------------------------------------------------
+    # Performance
+    # -------------------------------------------------------------------------
+
+    # Number of concurrent workers for node evaluation
+    # worker_count = 100
+
+    # -------------------------------------------------------------------------
+    # Fallback Resilience
+    # -------------------------------------------------------------------------
+
+    # Maximum number of ranked snapshot sources to try before giving up
+    # This is a resilience mechanism - if the #1 fastest node's HTTP endpoint
+    # is down or snapshot was deleted, we try the next best ranked nodes.
+    # Set to 0 to try all available nodes.
+    # max_snapshot_url_attempts = 3
+
+    # -------------------------------------------------------------------------
+    # Incremental Snapshot Selection
+    # -------------------------------------------------------------------------
+
+    # Minimum download speed for incremental snapshot sources (MB/s)
+    # Incrementals are ~1GB, so this filters out nodes that would take too long.
+    # At 2 MB/s: ~8 minutes for 1GB (acceptable)
+    # Set to 0 to disable speed filtering.
+    # min_incremental_speed_mbs = 2.0

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -68,6 +68,48 @@ type BlockConfig struct {
 // SnapshotConfig holds snapshot download configuration
 type SnapshotConfig struct {
 	DownloadPath string `toml:"download_path" mapstructure:"download_path"` // Path to download snapshot to
+	SaveToDisk   bool   `toml:"save_to_disk" mapstructure:"save_to_disk"`   // Save snapshots while streaming (requires download_path)
+
+	// Output verbosity
+	Verbose bool `toml:"verbose" mapstructure:"verbose"` // Enable detailed statistics output
+
+	// Stage 1: Fast parallel triage
+	Stage1WarmKiB     int64 `toml:"stage1_warm_kib" mapstructure:"stage1_warm_kib"`
+	Stage1WindowKiB   int64 `toml:"stage1_window_kib" mapstructure:"stage1_window_kib"`
+	Stage1Windows     int   `toml:"stage1_windows" mapstructure:"stage1_windows"`
+	Stage1TimeoutMS   int64 `toml:"stage1_timeout_ms" mapstructure:"stage1_timeout_ms"`
+	Stage1Concurrency int   `toml:"stage1_concurrency" mapstructure:"stage1_concurrency"`
+
+	// Stage 2: Sustained speed test
+	Stage2TopK       int     `toml:"stage2_top_k" mapstructure:"stage2_top_k"`
+	Stage2WarmSec    int     `toml:"stage2_warm_sec" mapstructure:"stage2_warm_sec"`
+	Stage2MeasureSec int     `toml:"stage2_measure_sec" mapstructure:"stage2_measure_sec"`
+	Stage2MinRatio   float64 `toml:"stage2_min_ratio" mapstructure:"stage2_min_ratio"`
+	Stage2MinAbsMBs  float64 `toml:"stage2_min_abs_mbs" mapstructure:"stage2_min_abs_mbs"`
+
+	// Node filtering
+	MaxRTTMs            int      `toml:"max_rtt_ms" mapstructure:"max_rtt_ms"`
+	TCPTimeoutMs        int      `toml:"tcp_timeout_ms" mapstructure:"tcp_timeout_ms"`
+	MinNodeVersion      string   `toml:"min_node_version" mapstructure:"min_node_version"`
+	AllowedNodeVersions []string `toml:"allowed_node_versions" mapstructure:"allowed_node_versions"`
+
+	// Snapshot age thresholds
+	FullThreshold        int `toml:"full_threshold" mapstructure:"full_threshold"`
+	IncrementalThreshold int `toml:"incremental_threshold" mapstructure:"incremental_threshold"`
+	SafetyMarginSlots    int `toml:"safety_margin_slots" mapstructure:"safety_margin_slots"`
+
+	// Retention
+	MaxFullSnapshots   int  `toml:"max_full_snapshots" mapstructure:"max_full_snapshots"`
+	DeleteOldSnapshots bool `toml:"delete_old_snapshots" mapstructure:"delete_old_snapshots"`
+
+	// Performance
+	WorkerCount int `toml:"worker_count" mapstructure:"worker_count"`
+
+	// Fallback resilience
+	MaxSnapshotURLAttempts int `toml:"max_snapshot_url_attempts" mapstructure:"max_snapshot_url_attempts"`
+
+	// Incremental snapshot selection
+	MinIncrementalSpeedMBs float64 `toml:"min_incremental_speed_mbs" mapstructure:"min_incremental_speed_mbs"`
 }
 
 // Config holds all configuration options for Mithril (Firedancer-style hierarchy)
@@ -158,4 +200,9 @@ func GetStringSlice(key string) []string {
 // IsSet returns true if a key has been set (either via config file or flag)
 func IsSet(key string) bool {
 	return viper.IsSet(key)
+}
+
+// GetFloat64 returns a float64 value from viper (config file or flag)
+func GetFloat64(key string) float64 {
+	return viper.GetFloat64(key)
 }

--- a/pkg/snapshot/bufmonreader.go
+++ b/pkg/snapshot/bufmonreader.go
@@ -47,6 +47,13 @@ func NewBufMonReaderFromFile(file *os.File) (*bufmonreader, error) {
 }
 
 func NewBufMonReaderHTTP(url string) (*bufmonreader, error) {
+	return NewBufMonReaderHTTPWithSave(url, "")
+}
+
+// NewBufMonReaderHTTPWithSave streams from HTTP URL and optionally saves to disk.
+// If savePath is non-empty, the data will be written to disk while streaming.
+// Returns: (*bufmonreader, error)
+func NewBufMonReaderHTTPWithSave(url string, savePath string) (*bufmonreader, error) {
 	resp, err := http.Head(url)
 	if err != nil {
 		return nil, fmt.Errorf("HEAD %s: %v", url, err)
@@ -56,6 +63,7 @@ func NewBufMonReaderHTTP(url string) (*bufmonreader, error) {
 	}
 	totalSize := resp.ContentLength
 	resp.Body.Close()
+
 	resp, err = http.Get(url)
 	if err != nil {
 		return nil, fmt.Errorf("GET %s: %v", url, err)
@@ -64,13 +72,47 @@ func NewBufMonReaderHTTP(url string) (*bufmonreader, error) {
 		return nil, fmt.Errorf("GET %s: had not-ok status: %s", url, resp.Status)
 	}
 
+	var reader io.Reader = resp.Body
+	var closer io.Closer = resp.Body
+
+	// If savePath is provided, use TeeReader to write to disk while streaming
+	if savePath != "" {
+		mlog.Log.Infof("Saving snapshot to %s while streaming...", savePath)
+		outFile, err := os.Create(savePath)
+		if err != nil {
+			resp.Body.Close()
+			return nil, fmt.Errorf("creating save file %s: %v", savePath, err)
+		}
+
+		// TeeReader splits the stream: data goes to both the tar reader AND the file
+		reader = io.TeeReader(resp.Body, outFile)
+
+		// Create a multi-closer that closes both the HTTP body and the file
+		closer = &multiCloser{closers: []io.Closer{resp.Body, outFile}}
+	}
+
 	return &bufmonreader{
 		name:      url,
-		b:         resp.Body,
-		c:         resp.Body,
+		b:         reader,
+		c:         closer,
 		totalSize: totalSize,
 		startTime: time.Now(),
 	}, nil
+}
+
+// multiCloser closes multiple io.Closers
+type multiCloser struct {
+	closers []io.Closer
+}
+
+func (mc *multiCloser) Close() error {
+	var firstErr error
+	for _, c := range mc.closers {
+		if err := c.Close(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
 }
 
 func (x *bufmonreader) Read(p []byte) (int, error) {

--- a/pkg/snapshot/build_db.go
+++ b/pkg/snapshot/build_db.go
@@ -28,6 +28,24 @@ const (
 	maxAppendVecCopying    = 500
 )
 
+// cleanAccountsDbDir removes all artifacts from a previous incomplete snapshot run.
+// This prevents corruption from Ctrl+C or partial downloads.
+func cleanAccountsDbDir(accountsDbDir string) {
+	// List of all files/directories that may be left from a previous incomplete run
+	artifacts := []string{
+		"accounts",
+		"mithril_db",
+		"mithril_db_log_shards",
+		"bankhash_db",
+		"largest_file_id",
+		"bank_hash",
+		"manifest",
+	}
+	for _, artifact := range artifacts {
+		os.RemoveAll(filepath.Join(accountsDbDir, artifact))
+	}
+}
+
 var (
 	indexEntryCommitterInProgress = &atomic.Int64{}
 	indexEntryBuilderInProgress   = &atomic.Int64{}
@@ -40,6 +58,9 @@ func BuildAccountsDb(
 	incrementalSnapshotFile string,
 	accountsDbDir string,
 ) (*accountsdb.AccountsDb, *SnapshotManifest, error) {
+	// Clean any leftover artifacts from previous incomplete runs (e.g., Ctrl+C)
+	cleanAccountsDbDir(accountsDbDir)
+
 	manifest, err := UnmarshalManifestFromSnapshot(snapshotFile, accountsDbDir)
 	if err != nil {
 		return nil, nil, fmt.Errorf("reading snapshot manifest: %v", err)
@@ -69,6 +90,7 @@ func BuildAccountsDb(
 
 	numShards := 256
 	dbFn := filepath.Join(accountsDbDir, "mithril_db")
+
 	indexDb, err := fastcache.NewCache(fastcache.GB*256, &fastcache.Config{
 		Shards:     uint32(numShards),
 		MemoryType: fastcache.MMAP,

--- a/pkg/snapshot/build_db.go
+++ b/pkg/snapshot/build_db.go
@@ -278,15 +278,32 @@ func isAppendVec(filename string) bool {
 }
 
 func readTar(ctx context.Context, wg *sync.WaitGroup, filename string, appendVecCopyingPool *ants.PoolWithFunc) error {
-	tarReader, closer, err := newSnapshotReader(filename)
+	return readTarWithSave(ctx, wg, filename, "", appendVecCopyingPool)
+}
+
+func readTarWithSave(ctx context.Context, wg *sync.WaitGroup, filename string, savePath string, appendVecCopyingPool *ants.PoolWithFunc) error {
+	tarReader, closer, err := newSnapshotReaderWithSave(filename, savePath)
 	if err != nil {
 		return err
 	}
 	defer closer.Close()
 
+	// cleanupPartial deletes the partial download file if it exists
+	cleanupPartial := func(reason string) {
+		if savePath != "" {
+			if _, statErr := os.Stat(savePath); statErr == nil {
+				mlog.Log.Infof("Deleting partial download %s (%s)", savePath, reason)
+				if rmErr := os.Remove(savePath); rmErr != nil {
+					mlog.Log.Errorf("Failed to delete partial download %s: %v", savePath, rmErr)
+				}
+			}
+		}
+	}
+
 	for {
 		if ctx.Err() != nil {
 			mlog.Log.Infof("context cancelled, stopping snapshot unpack: %v", ctx.Err())
+			cleanupPartial("cancelled")
 			return ctx.Err()
 		}
 		header, err := tarReader.Next()
@@ -294,6 +311,7 @@ func readTar(ctx context.Context, wg *sync.WaitGroup, filename string, appendVec
 			break
 		} else if err != nil {
 			mlog.Log.Errorf("reading next tar: %s\n", err)
+			cleanupPartial("read error")
 			return err
 		}
 
@@ -305,6 +323,7 @@ func readTar(ctx context.Context, wg *sync.WaitGroup, filename string, appendVec
 		tarBytesRead, err := io.Copy(writer, tarReader)
 		if err != nil {
 			mlog.Log.Errorf("err copying data to reader: %s\n", err)
+			cleanupPartial("copy error")
 			return err
 		}
 		statsd.Count(statsd.SnapshotTarBytesRead, tarBytesRead, nil)
@@ -314,6 +333,7 @@ func readTar(ctx context.Context, wg *sync.WaitGroup, filename string, appendVec
 		err = appendVecCopyingPool.Invoke(task)
 		if err != nil {
 			mlog.Log.Errorf("error calling appendVecCopyingPool.Invoke: %v", err)
+			cleanupPartial("pool error")
 			return err
 		}
 	}

--- a/pkg/snapshot/build_db_with_incr.go
+++ b/pkg/snapshot/build_db_with_incr.go
@@ -36,6 +36,9 @@ func BuildAccountsDbWithIncr(
 	overcastEndpoint string,
 	snapCfg snapshotdl.SnapshotConfig,
 ) (*accountsdb.AccountsDb, *SnapshotManifest, error) {
+	// Clean any leftover artifacts from previous incomplete runs (e.g., Ctrl+C)
+	cleanAccountsDbDir(accountsDbDir)
+
 	manifest, err := UnmarshalManifestFromSnapshot(fullSnapshotFile, accountsDbDir)
 	if err != nil {
 		return nil, nil, fmt.Errorf("reading snapshot manifest: %v", err)
@@ -57,6 +60,7 @@ func BuildAccountsDbWithIncr(
 
 	numShards := 256
 	dbFn := filepath.Join(accountsDbDir, "mithril_db")
+
 	indexDb, err := fastcache.NewCache(fastcache.GB*256, &fastcache.Config{
 		Shards:     uint32(numShards),
 		MemoryType: fastcache.MMAP,

--- a/pkg/snapshot/build_db_with_incr.go
+++ b/pkg/snapshot/build_db_with_incr.go
@@ -34,6 +34,7 @@ func BuildAccountsDbWithIncr(
 	rpcEndpoints []string,
 	blockDir string,
 	overcastEndpoint string,
+	snapCfg snapshotdl.SnapshotConfig,
 ) (*accountsdb.AccountsDb, *SnapshotManifest, error) {
 	manifest, err := UnmarshalManifestFromSnapshot(fullSnapshotFile, accountsDbDir)
 	if err != nil {
@@ -190,10 +191,22 @@ func BuildAccountsDbWithIncr(
 		}
 	})
 
+	// Determine save path for full snapshot if streaming from HTTP
+	var fullSavePath string
+	if snapCfg.SaveToDisk && (strings.HasPrefix(fullSnapshotFile, "http://") || strings.HasPrefix(fullSnapshotFile, "https://")) {
+		if snapshotDownloadPath != "" {
+			// Extract filename from URL and create save path
+			urlParts := strings.Split(fullSnapshotFile, "/")
+			filename := urlParts[len(urlParts)-1]
+			fullSavePath = filepath.Join(snapshotDownloadPath, filename)
+			mlog.Log.Infof("Will save full snapshot to %s while streaming", fullSavePath)
+		}
+	}
+
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		err = readTar(ctx, wg, fullSnapshotFile, appendVecCopyingPool)
+		err = readTarWithSave(ctx, wg, fullSnapshotFile, fullSavePath, appendVecCopyingPool)
 	}()
 	wg.Wait()
 	mlog.Log.Infof("done processing full snapshot in %s.", time.Since(start))
@@ -205,18 +218,15 @@ func BuildAccountsDbWithIncr(
 	}
 
 	sl = NewShardLogger(numShards, logsDir, ss)
-	if err != nil {
-		mlog.Log.Errorf("processing snapshot: %v", err)
-	}
 
-	// download an incremental snapshot based on the full snapshot's slot number
-	mlog.Log.Infof("downloading incremental snapshot (%d)...", referenceSlot)
+	// Get incremental snapshot URL (tries same source first, then searches if needed)
+	mlog.Log.Infof("finding incremental snapshot matching full slot %d...", fullSnapshotSlot)
 	incrSnapshotDlStart := time.Now()
-	incrementalSnapshotPath, _, incrSlot, err := snapshotdl.DownloadIncrementalSnapshot(rpcEndpoints[0], snapshotDownloadPath, referenceSlot, fullSnapshotSlot)
+	incrementalSnapshotPath, _, incrSlot, err := snapshotdl.GetIncrementalSnapshotURL(rpcEndpoints[0], fullSnapshotFile, referenceSlot, fullSnapshotSlot, snapCfg)
 	if err != nil {
-		klog.Fatalf("error downloading snapshot: %s", err)
+		klog.Fatalf("error getting incremental snapshot URL: %s", err)
 	}
-	mlog.Log.Infof("finished downloading incremental snapshot in %s to %s", time.Since(incrSnapshotDlStart), incrementalSnapshotPath)
+	mlog.Log.Infof("found incremental snapshot URL in %s: %s", time.Since(incrSnapshotDlStart), incrementalSnapshotPath)
 
 	var downloaderOpts blockstream.BackgroundBlockDownloaderOpts
 	if overcastEndpoint != "" {
@@ -239,27 +249,70 @@ func BuildAccountsDbWithIncr(
 	catchupDownloader := blockstream.NewBlockDownloader(downloaderOpts)
 	go catchupDownloader.Start()
 
-	incrSnapshotStart := time.Now()
-	incrementalManifest, err = UnmarshalManifestFromSnapshot(incrementalSnapshotPath, accountsDbDir)
-	if err != nil {
-		return nil, nil, fmt.Errorf("reading incremental snapshot manifest: %v", err)
-	}
-	mlog.Log.Infof("parsed manifest from incrementalFile=%s", incrementalSnapshotPath)
-
+	// Retry loop for incremental snapshot download
+	// If download fails mid-way (not context cancellation), re-discover sources and retry
+	maxIncrRetries := 3
 	var incrementalErr error
+	for incrAttempt := 0; incrAttempt < maxIncrRetries; incrAttempt++ {
+		if incrAttempt > 0 {
+			// Re-discover incremental snapshot URL (sources may have changed)
+			mlog.Log.Infof("Incremental download failed, re-discovering sources (attempt %d/%d)...", incrAttempt+1, maxIncrRetries)
+			incrementalSnapshotPath, _, incrSlot, err = snapshotdl.GetIncrementalSnapshotURL(rpcEndpoints[0], fullSnapshotFile, referenceSlot, fullSnapshotSlot, snapCfg)
+			if err != nil {
+				mlog.Log.Errorf("Failed to re-discover incremental snapshot: %v", err)
+				continue
+			}
+			mlog.Log.Infof("Found new incremental snapshot URL: %s (slot %d)", incrementalSnapshotPath, incrSlot)
+		}
 
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		start := time.Now()
-		incrementalErr = readTarIncr(ctx, wg, incrementalSnapshotPath, appendVecCopyingPool)
-		mlog.Log.Infof("finished reading %s in %s", incrementalSnapshotPath, time.Since(start))
-	}()
-	wg.Wait()
-	mlog.Log.Infof("done processing incremental snapshot in %s.", time.Since(incrSnapshotStart))
+		incrSnapshotStart := time.Now()
+		incrementalManifest, err = UnmarshalManifestFromSnapshot(incrementalSnapshotPath, accountsDbDir)
+		if err != nil {
+			mlog.Log.Errorf("reading incremental snapshot manifest: %v", err)
+			incrementalErr = fmt.Errorf("reading incremental snapshot manifest: %v", err)
+			continue
+		}
+		mlog.Log.Infof("parsed manifest from incrementalFile=%s", incrementalSnapshotPath)
 
-	if err != nil || incrementalErr != nil {
+		// Determine save path for incremental snapshot if streaming from HTTP
+		var incrSavePath string
+		if snapCfg.SaveToDisk && (strings.HasPrefix(incrementalSnapshotPath, "http://") || strings.HasPrefix(incrementalSnapshotPath, "https://")) {
+			if snapshotDownloadPath != "" {
+				// Extract filename from URL and create save path
+				urlParts := strings.Split(incrementalSnapshotPath, "/")
+				filename := urlParts[len(urlParts)-1]
+				incrSavePath = filepath.Join(snapshotDownloadPath, filename)
+				mlog.Log.Infof("Will save incremental snapshot to %s while streaming", incrSavePath)
+			}
+		}
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			start := time.Now()
+			incrementalErr = readTarIncrWithSave(ctx, wg, incrementalSnapshotPath, incrSavePath, appendVecCopyingPool)
+			mlog.Log.Infof("finished reading %s in %s", incrementalSnapshotPath, time.Since(start))
+		}()
+		wg.Wait()
+		mlog.Log.Infof("done processing incremental snapshot in %s.", time.Since(incrSnapshotStart))
+
+		// Check if we should retry
+		if incrementalErr == nil {
+			break // Success
+		}
+		if ctx.Err() != nil {
+			// Context cancelled - don't retry, just exit
+			return nil, nil, ctx.Err()
+		}
+		// Download failed mid-way, will retry with re-discovery
+		mlog.Log.Errorf("Incremental download failed: %v", incrementalErr)
+	}
+
+	if err != nil {
 		return nil, nil, err
+	}
+	if incrementalErr != nil {
+		return nil, nil, fmt.Errorf("incremental snapshot download failed after %d attempts: %w", maxIncrRetries, incrementalErr)
 	}
 
 	mlog.Log.Infof("Closing shard logger for incremental snapshot.")
@@ -313,15 +366,32 @@ func BuildAccountsDbWithIncr(
 }
 
 func readTarIncr(ctx context.Context, wg *sync.WaitGroup, filename string, appendVecCopyingPool *ants.PoolWithFunc) error {
-	tarReader, closer, err := newSnapshotReader(filename)
+	return readTarIncrWithSave(ctx, wg, filename, "", appendVecCopyingPool)
+}
+
+func readTarIncrWithSave(ctx context.Context, wg *sync.WaitGroup, filename string, savePath string, appendVecCopyingPool *ants.PoolWithFunc) error {
+	tarReader, closer, err := newSnapshotReaderWithSave(filename, savePath)
 	if err != nil {
 		return err
 	}
 	defer closer.Close()
 
+	// cleanupPartial deletes the partial download file if it exists
+	cleanupPartial := func(reason string) {
+		if savePath != "" {
+			if _, statErr := os.Stat(savePath); statErr == nil {
+				mlog.Log.Infof("Deleting partial incremental download %s (%s)", savePath, reason)
+				if rmErr := os.Remove(savePath); rmErr != nil {
+					mlog.Log.Errorf("Failed to delete partial incremental download %s: %v", savePath, rmErr)
+				}
+			}
+		}
+	}
+
 	for {
 		if ctx.Err() != nil {
 			mlog.Log.Infof("context cancelled, stopping snapshot unpack: %v", ctx.Err())
+			cleanupPartial("cancelled")
 			return ctx.Err()
 		}
 		header, err := tarReader.Next()
@@ -329,6 +399,7 @@ func readTarIncr(ctx context.Context, wg *sync.WaitGroup, filename string, appen
 			break
 		} else if err != nil {
 			mlog.Log.Errorf("reading next tar: %s\n", err)
+			cleanupPartial("read error")
 			return err
 		}
 
@@ -340,6 +411,7 @@ func readTarIncr(ctx context.Context, wg *sync.WaitGroup, filename string, appen
 		tarBytesRead, err := io.Copy(writer, tarReader)
 		if err != nil {
 			mlog.Log.Errorf("err copying data to reader: %s\n", err)
+			cleanupPartial("copy error")
 			return err
 		}
 		statsd.Count(statsd.SnapshotTarBytesRead, tarBytesRead, nil)
@@ -349,6 +421,7 @@ func readTarIncr(ctx context.Context, wg *sync.WaitGroup, filename string, appen
 		err = appendVecCopyingPool.Invoke(task)
 		if err != nil {
 			mlog.Log.Errorf("error calling appendVecCopyingPool.Invoke: %v", err)
+			cleanupPartial("pool error")
 			return err
 		}
 	}

--- a/pkg/snapshot/snapshot.go
+++ b/pkg/snapshot/snapshot.go
@@ -122,11 +122,18 @@ func parseSnapshotType(snapshotFileName string) int {
 }
 
 func newSnapshotReader(filename string) (*tar.Reader, io.Closer, error) {
+	return newSnapshotReaderWithSave(filename, "")
+}
+
+// newSnapshotReaderWithSave creates a tar reader for a snapshot file or HTTP URL.
+// If filename is an HTTP URL and savePath is non-empty, the data will be saved
+// to disk while streaming (using io.TeeReader for parallel download+processing+saving).
+func newSnapshotReaderWithSave(filename string, savePath string) (*tar.Reader, io.Closer, error) {
 	snapshotType := parseSnapshotType(filename)
 	var bmr *bufmonreader
 	var err error
 	if strings.HasPrefix(filename, "https://") || strings.HasPrefix(filename, "http://") {
-		bmr, err = NewBufMonReaderHTTP(filename)
+		bmr, err = NewBufMonReaderHTTPWithSave(filename, savePath)
 	} else {
 		snapshotFile, err := os.Open(filename)
 		if err != nil {

--- a/pkg/snapshotdl/snapshotdl.go
+++ b/pkg/snapshotdl/snapshotdl.go
@@ -1,9 +1,11 @@
 package snapshotdl
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/Overclock-Validator/mithril/pkg/mlog"
 	"github.com/Overclock-Validator/solana-snapshot-finder-go/pkg/config"
@@ -11,96 +13,472 @@ import (
 	"github.com/Overclock-Validator/solana-snapshot-finder-go/pkg/snapshot"
 )
 
+// SnapshotConfig holds configuration for snapshot downloading.
+// This can be populated from CLI flags or TOML config.
+type SnapshotConfig struct {
+	// Stage 1: Fast parallel triage
+	Stage1WarmKiB     int64
+	Stage1WindowKiB   int64
+	Stage1Windows     int
+	Stage1TimeoutMS   int64
+	Stage1Concurrency int
+
+	// Stage 2: Sustained speed test for top candidates
+	Stage2TopK       int
+	Stage2WarmSec    int
+	Stage2MeasureSec int
+	Stage2MinRatio   float64
+	Stage2MinAbsMBs  float64
+
+	// Node filtering
+	MaxRTTMs            int
+	TCPTimeoutMs        int
+	MinNodeVersion      string
+	AllowedNodeVersions []string
+
+	// Snapshot age thresholds (slots)
+	FullThreshold        int
+	IncrementalThreshold int
+
+	// Retention
+	MaxFullSnapshots   int
+	DeleteOldSnapshots bool
+
+	// Safety
+	SafetyMarginSlots int
+
+	// Worker settings
+	WorkerCount int
+
+	// Output verbosity
+	Verbose bool
+
+	// Disk saving
+	SaveToDisk   bool   // Save snapshots to disk while streaming
+	DownloadPath string // Path to save snapshots to (only used if SaveToDisk=true)
+
+	// Fallback resilience
+	MaxSnapshotURLAttempts int // Number of ranked nodes to try when getting snapshot URLs (0 = try all)
+
+	// Incremental snapshot selection
+	MinIncrementalSpeedMBs float64 // Minimum speed for incremental sources (MB/s, 0 = no minimum)
+}
+
+// DefaultSnapshotConfig returns production-ready defaults matching solana-snapshot-finder-go
+func DefaultSnapshotConfig() SnapshotConfig {
+	return SnapshotConfig{
+		// Stage 1: Fast parallel downloads for quick triage
+		Stage1WarmKiB:     512,  // 512 KiB warmup
+		Stage1WindowKiB:   512,  // 512 KiB measurement windows
+		Stage1Windows:     4,    // 4 windows = 2 MiB total per node
+		Stage1TimeoutMS:   3000, // 3 second timeout per node
+		Stage1Concurrency: 0,    // Auto (number of CPU cores)
+
+		// Stage 2: Sustained speed test for top candidates
+		Stage2TopK:       8,   // Test top 8 from stage 1
+		Stage2WarmSec:    2,   // 2 second warmup
+		Stage2MeasureSec: 2,   // 2 second measurement
+		Stage2MinRatio:   0.6, // Collapse if speed drops below 60%
+		Stage2MinAbsMBs:  0.0, // Disabled (0 = no minimum)
+
+		// Node filtering
+		MaxRTTMs:            200,     // 200ms max RTT
+		TCPTimeoutMs:        1000,    // 1 second TCP precheck
+		MinNodeVersion:      "2.2.0", // Minimum Agave 2.2.0
+		AllowedNodeVersions: nil,     // Accept all versions >= minimum
+
+		// Snapshot age thresholds
+		FullThreshold:        100000, // Full snapshots up to 100k slots old (Agave 3.0+)
+		IncrementalThreshold: 200,    // Allow slightly ahead incrementals
+
+		// Retention
+		MaxFullSnapshots:   2,     // Keep last 2 full snapshots
+		DeleteOldSnapshots: false, // Let mithril manage deletion
+
+		// Safety
+		SafetyMarginSlots: 5000, // Warn if <5000 slots until expiration
+
+		// Workers
+		WorkerCount: 100, // Concurrent node evaluation workers
+
+		// Output
+		Verbose: false, // Quiet by default
+
+		// Disk saving
+		SaveToDisk:   false, // Stream only by default (save disk space)
+		DownloadPath: "",    // No download path by default
+
+		// Fallback resilience
+		MaxSnapshotURLAttempts: 3, // Try top 3 ranked nodes before giving up
+
+		// Incremental selection
+		MinIncrementalSpeedMBs: 2.0, // Minimum 2 MB/s for incrementals (~8min for 1GB)
+	}
+}
+
+// toInternalConfig converts SnapshotConfig to snapshot-finder's config.Config
+func (sc SnapshotConfig) toInternalConfig(endpoint string, path string) config.Config {
+	return config.Config{
+		RPCAddresses:         []string{endpoint},
+		SnapshotPath:         path,
+		NumOfRetries:         5,
+		SleepBeforeRetry:     2,
+		EnableBlacklist:      false,
+		WhitelistMode:        "disabled",
+		WorkerCount:          sc.WorkerCount,
+		FullThreshold:        sc.FullThreshold,
+		IncrementalThreshold: sc.IncrementalThreshold,
+		Stage1WarmKiB:        sc.Stage1WarmKiB,
+		Stage1WindowKiB:      sc.Stage1WindowKiB,
+		Stage1Windows:        sc.Stage1Windows,
+		Stage1TimeoutMS:      sc.Stage1TimeoutMS,
+		Stage1Concurrency:    sc.Stage1Concurrency,
+		Stage2TopK:           sc.Stage2TopK,
+		Stage2WarmSec:        sc.Stage2WarmSec,
+		Stage2MeasureSec:     sc.Stage2MeasureSec,
+		Stage2MinRatio:       sc.Stage2MinRatio,
+		Stage2MinAbsMBs:      sc.Stage2MinAbsMBs,
+		MaxRTTMs:             sc.MaxRTTMs,
+		TCPTimeoutMs:         sc.TCPTimeoutMs,
+		MinNodeVersion:       sc.MinNodeVersion,
+		AllowedNodeVersions:  sc.AllowedNodeVersions,
+		MaxFullSnapshots:     sc.MaxFullSnapshots,
+		DeleteOldSnapshots:   sc.DeleteOldSnapshots,
+		SafetyMarginSlots:    sc.SafetyMarginSlots,
+	}
+}
+
+// formatProbeStats formats ProbeStats for mithril's logging style
+func formatProbeStats(stats *rpc.ProbeStats, cfg config.Config) {
+	if stats == nil {
+		return
+	}
+
+	mlog.Log.Infof("=== Snapshot Node Discovery Statistics ===")
+	mlog.Log.Infof("Total nodes discovered: %d", stats.TotalNodes)
+	mlog.Log.Infof("TCP connectivity passed: %d", stats.TotalNodes-stats.TCPFailed)
+	mlog.Log.Infof("Nodes with any snapshot: %d", stats.HasAnySnapshot)
+	mlog.Log.Infof("Nodes with incremental: %d (usable: %d)", stats.WithIncremental, stats.WithUsableInc)
+
+	if cfg.MinNodeVersion != "" || len(cfg.AllowedNodeVersions) > 0 {
+		mlog.Log.Infof("After version filter: %d", stats.AfterVersionFilter)
+	}
+	if cfg.MaxRTTMs > 0 {
+		mlog.Log.Infof("After RTT filter (<%dms): %d", cfg.MaxRTTMs, stats.AfterRTTFilter)
+	}
+	mlog.Log.Infof("After age filters (full<%d, incr<%d slots): full=%d, incr=%d",
+		cfg.FullThreshold, cfg.IncrementalThreshold,
+		stats.AfterFullAgeFilter, stats.AfterIncAgeFilter)
+	mlog.Log.Infof("Final eligible nodes: %d", stats.Eligible)
+	mlog.Log.Infof("==========================================")
+}
+
+// DownloadSnapshot downloads a full snapshot from the best available RPC node.
+// It returns: (downloadPath, referenceSlot, snapshotSlot, error)
+//
+// This function:
+// 1. Gets the reference slot from the network
+// 2. Discovers available RPC nodes from the cluster
+// 3. Evaluates nodes for snapshot availability and download speed
+// 4. Downloads from the fastest node with a recent snapshot
 func DownloadSnapshot(endpoint string, path string) (string, int, int, error) {
-	cfg := config.Config{RPCAddress: endpoint, SnapshotPath: path, NumOfRetries: 5,
-		MinDownloadSpeed: 100, MaxLatency: 10, WorkerCount: 100, FullThreshold: 100000}
+	return DownloadSnapshotWithConfig(endpoint, path, DefaultSnapshotConfig())
+}
 
-	referenceSlot, err := rpc.GetReferenceSlot(cfg.RPCAddress)
+// GetSnapshotURL discovers the best RPC node and returns the HTTP URL for streaming.
+// Returns: (httpURL, referenceSlot, snapshotSlot, error)
+//
+// This function:
+// 1. Gets the reference slot from the network
+// 2. Discovers available RPC nodes from the cluster
+// 3. Evaluates nodes for snapshot availability and download speed
+// 4. Returns HTTP URL from the fastest node (for streaming)
+//
+// The returned URL can be passed directly to snapshot processing functions
+// which will stream the data from HTTP (no disk download required).
+func GetSnapshotURL(endpoint string, snapCfg SnapshotConfig) (string, int, int, error) {
+	cfg := snapCfg.toInternalConfig(endpoint, "")
+	ctx := context.Background()
+
+	// Step 1: Get reference slot from multiple RPCs for reliability
+	mlog.Log.Infof("Getting reference slot from RPC(s)...")
+	referenceSlot, preferredRPC, err := rpc.GetReferenceSlotFromMultiple(cfg.RPCAddresses)
 	if err != nil {
-		return "", 0, 0, fmt.Errorf("error getting reference slot: %s", err)
+		return "", 0, 0, fmt.Errorf("error getting reference slot: %w", err)
 	}
+	mlog.Log.Infof("Reference slot: %d (from %s)", referenceSlot, preferredRPC)
 
-	nodes := rpc.FetchRPCNodes(cfg)
+	// Step 2: Fetch cluster nodes
+	mlog.Log.Infof("Discovering RPC nodes from cluster...")
+	nodes := rpc.FetchClusterNodes(cfg, preferredRPC)
 	if len(nodes) == 0 {
-		return "", 0, 0, fmt.Errorf("no rpc nodes available")
+		return "", 0, 0, fmt.Errorf("no rpc nodes available from cluster")
+	}
+	mlog.Log.Infof("Found %d potential snapshot sources", len(nodes))
+
+	// Step 3: Evaluate nodes with version tracking and statistics
+	mlog.Log.Infof("Evaluating nodes for snapshot availability and speed...")
+	evaluateStart := time.Now()
+	results, stats := rpc.EvaluateNodesWithVersionsAndStats(nodes, cfg, referenceSlot)
+	mlog.Log.Infof("Node evaluation completed in %s", time.Since(evaluateStart))
+
+	// Print statistics if verbose mode
+	if snapCfg.Verbose && stats != nil {
+		formatProbeStats(stats, cfg)
 	}
 
-	results := rpc.EvaluateNodesWithVersions(nodes, cfg, referenceSlot)
-	bestRPCs := rpc.SortBestRPCs(results)
+	// Step 4: Sort and select best nodes by download speed
+	bestNodes, rankedNodes := rpc.SortBestNodesWithStats(results, cfg, stats, referenceSlot)
+	if len(bestNodes) == 0 {
+		return "", 0, 0, fmt.Errorf("no suitable nodes found with snapshots")
+	}
 
-	var finalPath string
-	for _, rpc := range bestRPCs {
-		finalPath, err = snapshot.DownloadSnapshot(rpc, cfg, "snapshot-", referenceSlot)
-		if err == nil && finalPath != "" {
+	// Step 5: Get snapshot URL from best nodes (with configurable fallback)
+	// NOTE: This fallback pattern is useful for resilience - if the #1 ranked node's
+	// HTTP endpoint is down or snapshot was deleted, we try the next best nodes.
+	// This pattern could be extracted to snapshot-finder library for reuse.
+	var snapshotURL string
+	var snapshotSlot int
+	var selectedNodeRPC string
+	var selectedRank int
+	var selectedSpeed float64
+	var urlErr error
+
+	maxAttempts := snapCfg.MaxSnapshotURLAttempts
+	if maxAttempts <= 0 {
+		maxAttempts = len(bestNodes) // 0 means try all available nodes
+	}
+
+	for i, nodeRPC := range bestNodes {
+		if i >= maxAttempts {
 			break
-		} else if err != nil {
-			fmt.Printf("failed to download snapshot from %s: %v. trying next.\n", rpc, err)
+		}
+
+		if i > 0 {
+			// We're on a fallback attempt
+			mlog.Log.Infof("Trying fallback source #%d: %s", i+1, nodeRPC)
+		}
+
+		if snapCfg.Verbose {
+			mlog.Log.Infof("Getting snapshot URL from: %s (rank #%d)", nodeRPC, i+1)
+		}
+		urlInfo, err := snapshot.GetSnapshotURL(ctx, nodeRPC, "full")
+
+		if err == nil && urlInfo != nil {
+			// Find the speed for this node from rankedNodes
+			for _, rn := range rankedNodes {
+				if rn.Result.RPC == nodeRPC {
+					selectedSpeed = rn.S1.MedianMBs
+					break
+				}
+			}
+			selectedNodeRPC = nodeRPC
+			selectedRank = i + 1
+			snapshotURL = urlInfo.URL
+			snapshotSlot = urlInfo.Slot
+			break
+		}
+
+		if err != nil {
+			if snapCfg.Verbose {
+				mlog.Log.Infof("Failed to get snapshot URL from %s: %v. Trying next...", nodeRPC, err)
+			}
+			urlErr = err
 		} else {
-			fmt.Printf("snapshot download from %s returned empty path. trying next.\n", rpc)
+			if snapCfg.Verbose {
+				mlog.Log.Infof("GetSnapshotURL from %s returned nil. Trying next...", nodeRPC)
+			}
+		}
+	}
+
+	if snapshotURL == "" {
+		return "", 0, 0, fmt.Errorf("failed to get snapshot URL from any RPC node (tried %d nodes, last error: %v)", maxAttempts, urlErr)
+	}
+
+	// Always log the selected source (even in non-verbose mode)
+	mlog.Log.Infof("📸 Full snapshot source: %s (rank #%d, %.1f MB/s, slot %d)",
+		selectedNodeRPC, selectedRank, selectedSpeed, snapshotSlot)
+	return snapshotURL, referenceSlot, snapshotSlot, nil
+}
+
+// DownloadSnapshotWithConfig is like DownloadSnapshot but accepts custom config
+func DownloadSnapshotWithConfig(endpoint string, path string, snapCfg SnapshotConfig) (string, int, int, error) {
+	cfg := snapCfg.toInternalConfig(endpoint, path)
+	ctx := context.Background()
+
+	// Step 1: Get reference slot from multiple RPCs for reliability
+	mlog.Log.Infof("Getting reference slot from RPC(s)...")
+	referenceSlot, preferredRPC, err := rpc.GetReferenceSlotFromMultiple(cfg.RPCAddresses)
+	if err != nil {
+		return "", 0, 0, fmt.Errorf("error getting reference slot: %w", err)
+	}
+	mlog.Log.Infof("Reference slot: %d (from %s)", referenceSlot, preferredRPC)
+
+	// Step 2: Fetch cluster nodes
+	mlog.Log.Infof("Discovering RPC nodes from cluster...")
+	nodes := rpc.FetchClusterNodes(cfg, preferredRPC)
+	if len(nodes) == 0 {
+		return "", 0, 0, fmt.Errorf("no rpc nodes available from cluster")
+	}
+	mlog.Log.Infof("Found %d potential snapshot sources", len(nodes))
+
+	// Step 3: Evaluate nodes with version tracking and statistics
+	mlog.Log.Infof("Evaluating nodes for snapshot availability and speed...")
+	evaluateStart := time.Now()
+	results, stats := rpc.EvaluateNodesWithVersionsAndStats(nodes, cfg, referenceSlot)
+	mlog.Log.Infof("Node evaluation completed in %s", time.Since(evaluateStart))
+
+	// Print statistics if verbose mode
+	if snapCfg.Verbose && stats != nil {
+		formatProbeStats(stats, cfg)
+	}
+
+	// Step 4: Sort and select best nodes by download speed
+	bestNodes, _ := rpc.SortBestNodesWithStats(results, cfg, stats, referenceSlot)
+	if len(bestNodes) == 0 {
+		return "", 0, 0, fmt.Errorf("no suitable nodes found with snapshots")
+	}
+
+	// Step 5: Download snapshot from best nodes (with configurable fallback)
+	var finalPath string
+	var downloadErr error
+
+	maxAttempts := snapCfg.MaxSnapshotURLAttempts
+	if maxAttempts <= 0 {
+		maxAttempts = len(bestNodes) // 0 means try all available nodes
+	}
+
+	for i, nodeRPC := range bestNodes {
+		if i >= maxAttempts {
+			break
+		}
+
+		if i > 0 {
+			mlog.Log.Infof("Trying fallback source #%d: %s", i+1, nodeRPC)
+		}
+
+		mlog.Log.Infof("Downloading from: %s (rank #%d)", nodeRPC, i+1)
+		downloadStart := time.Now()
+		finalPath, downloadErr = snapshot.DownloadSnapshotWithContext(
+			ctx, nodeRPC, cfg, "snapshot-", referenceSlot, nil)
+
+		if downloadErr == nil && finalPath != "" {
+			mlog.Log.Infof("Successfully downloaded snapshot from %s in %s", nodeRPC, time.Since(downloadStart))
+			break
+		}
+
+		if downloadErr != nil {
+			mlog.Log.Infof("Failed to download from %s: %v. Trying next...", nodeRPC, downloadErr)
+		} else {
+			mlog.Log.Infof("Download from %s returned empty path. Trying next...", nodeRPC)
 		}
 	}
 
 	if finalPath == "" {
-		return "", 0, 0, fmt.Errorf("failed to download snapshot from any RPC node")
+		return "", 0, 0, fmt.Errorf("failed to download snapshot from any RPC node (tried %d nodes, last error: %v)", maxAttempts, downloadErr)
 	}
 
-	snapshotSlot := extractFullSnapshotSlot(finalPath)
+	// Step 6: Extract slot from downloaded snapshot
+	snapshotSlot, err := snapshot.ExtractFullSnapshotSlot(finalPath)
+	if err != nil {
+		// Fallback to old parsing method for backward compatibility
+		snapshotSlot = extractFullSnapshotSlot(finalPath)
+	}
 
+	mlog.Log.Infof("Downloaded full snapshot: slot=%d, path=%s", snapshotSlot, finalPath)
 	return finalPath, referenceSlot, snapshotSlot, nil
 }
 
+// DownloadIncrementalSnapshot downloads an incremental snapshot that matches
+// the given fullSnapshotSlot.
+//
+// It returns: (downloadPath, baseSlot, endSlot, error)
+//
+// This function uses the new FindMatchingIncremental API to search across
+// ranked nodes for an incremental snapshot that matches the full snapshot.
 func DownloadIncrementalSnapshot(endpoint string, path string, referenceSlot int, fullSnapshotSlot int) (string, int, int, error) {
-	cfg := config.Config{RPCAddress: endpoint, SnapshotPath: path, NumOfRetries: 5,
-		MinDownloadSpeed: 100, MaxLatency: 10, WorkerCount: 100, FullThreshold: 100000}
+	return DownloadIncrementalSnapshotWithConfig(endpoint, path, referenceSlot, fullSnapshotSlot, DefaultSnapshotConfig())
+}
 
-	var err error
-	nodes := rpc.FetchRPCNodes(cfg)
+// DownloadIncrementalSnapshotWithConfig is like DownloadIncrementalSnapshot but accepts custom config
+func DownloadIncrementalSnapshotWithConfig(endpoint string, path string, referenceSlot int, fullSnapshotSlot int, snapCfg SnapshotConfig) (string, int, int, error) {
+	cfg := snapCfg.toInternalConfig(endpoint, path)
+	ctx := context.Background()
+
+	mlog.Log.Infof("Searching for incremental snapshot matching full slot %d...", fullSnapshotSlot)
+
+	// Step 1: Get cluster nodes
+	nodes := rpc.FetchClusterNodes(cfg, endpoint)
 	if len(nodes) == 0 {
-		return "", 0, 0, fmt.Errorf("no rpc nodes available")
+		return "", 0, 0, fmt.Errorf("no rpc nodes available from cluster")
 	}
 
-	results := rpc.EvaluateNodesWithVersions(nodes, cfg, referenceSlot)
-	bestRPCs := rpc.SortBestRPCs(results)
+	// Step 2: Evaluate nodes
+	evaluateStart := time.Now()
+	results, stats := rpc.EvaluateNodesWithVersionsAndStats(nodes, cfg, referenceSlot)
+	mlog.Log.Infof("Node evaluation completed in %s", time.Since(evaluateStart))
 
-	var finalPath string
-	var incrSlotNum, slotNum int
-	for _, rpc := range bestRPCs {
-		finalPath, err = snapshot.DownloadSnapshot(rpc, cfg, "incremental", referenceSlot)
-		if err == nil {
-			slotNum, incrSlotNum = ExtractIncrementalSnapshotSlots(finalPath)
-			if slotNum == fullSnapshotSlot {
-				break
-			} else {
-				mlog.Log.Infof("downloaded incremental snapshot for slot %d, need %d. trying another download source.", slotNum, fullSnapshotSlot)
-			}
-		} else {
-			fmt.Printf("failed to download snapshot from %s. trying next.\n", rpc)
-		}
+	if snapCfg.Verbose && stats != nil {
+		formatProbeStats(stats, cfg)
 	}
 
-	return finalPath, slotNum, incrSlotNum, nil
-}
+	// Step 3: Filter nodes by minimum slot (must have snapshot >= fullSnapshotSlot)
+	// This ensures we don't get nodes that haven't seen our full snapshot yet
+	bestNodes, rankedNodes := rpc.SortBestRPCsFilteredBySlot(
+		results, cfg, stats, int64(fullSnapshotSlot), referenceSlot)
 
-// expected format of incr snapshot fn: snapshot-362871357-2m6Qctcrk54WooSWdHdu8Wjz49vzp6hpT5gXTJJUgT2C.tar.zst
-func extractFullSnapshotSlot(path string) int {
-	parts := strings.Split(path, "/")
-	filename := parts[len(parts)-1]
-
-	parts = strings.Split(filename, "-")
-	if len(parts) < 3 {
-		panic(fmt.Sprintf("invalid full snapshot filename format: %s", path))
+	if len(bestNodes) == 0 {
+		return "", 0, 0, fmt.Errorf("no nodes found with snapshots >= slot %d", fullSnapshotSlot)
 	}
 
-	slotStr := parts[1]
-	slot, err := strconv.Atoi(slotStr)
+	mlog.Log.Infof("Found %d nodes with matching full snapshot", len(bestNodes))
+
+	// Step 4: Use the new FindMatchingIncremental API
+	// This searches ranked nodes for an incremental that matches fullSnapshotSlot
+	mlog.Log.Infof("Searching for matching incremental snapshot...")
+	incrInfo, err := rpc.FindMatchingIncremental(rankedNodes, int64(fullSnapshotSlot), 5000)
 	if err != nil {
-		panic(err)
+		return "", 0, 0, fmt.Errorf("failed to find matching incremental: %w", err)
 	}
 
-	return slot
+	if incrInfo == nil {
+		return "", 0, 0, fmt.Errorf("no matching incremental snapshot found for base slot %d", fullSnapshotSlot)
+	}
+
+	mlog.Log.Infof("Found matching incremental on %s: base=%d, end=%d",
+		incrInfo.NodeRPC, incrInfo.BaseSlot, incrInfo.EndSlot)
+
+	// Step 5: Download the incremental snapshot
+	downloadStart := time.Now()
+	finalPath, err := snapshot.DownloadSnapshotWithContext(
+		ctx, incrInfo.NodeRPC, cfg, "incremental", referenceSlot, nil)
+
+	if err != nil {
+		return "", 0, 0, fmt.Errorf("failed to download incremental from %s: %w", incrInfo.NodeRPC, err)
+	}
+
+	mlog.Log.Infof("Downloaded incremental snapshot from %s in %s", incrInfo.NodeRPC, time.Since(downloadStart))
+
+	// Step 6: Verify the downloaded snapshot matches expected slots
+	baseSlot, endSlot, err := snapshot.ExtractIncrementalSnapshotSlots(finalPath)
+	if err != nil {
+		// Fallback to old parsing
+		baseSlot, endSlot = ExtractIncrementalSnapshotSlots(finalPath)
+	}
+
+	if baseSlot != int(incrInfo.BaseSlot) {
+		mlog.Log.Infof("WARNING: Downloaded incremental has base slot %d, expected %d", baseSlot, incrInfo.BaseSlot)
+	}
+
+	mlog.Log.Infof("Downloaded incremental snapshot: base=%d, end=%d, path=%s", baseSlot, endSlot, finalPath)
+	return finalPath, baseSlot, endSlot, nil
 }
 
-// expected format of incr snapshot fn: incremental-snapshot-361569776-XXXX-....
+// ExtractIncrementalSnapshotSlots extracts the base and end slots from an
+// incremental snapshot filename.
+//
+// Expected format: incremental-snapshot-{baseSlot}-{endSlot}-{hash}.tar.zst
+// Returns: (baseSlot, endSlot)
 func ExtractIncrementalSnapshotSlots(path string) (int, int) {
 	parts := strings.Split(path, "/")
 	filename := parts[len(parts)-1]
@@ -113,13 +491,230 @@ func ExtractIncrementalSnapshotSlots(path string) (int, int) {
 	slotStr := parts[2]
 	slot, err := strconv.Atoi(slotStr)
 	if err != nil {
-		panic(err)
+		panic(fmt.Sprintf("failed to parse base slot from %s: %v", path, err))
 	}
 
 	incrSlotStr := parts[3]
 	incrSlot, err := strconv.Atoi(incrSlotStr)
 	if err != nil {
-		panic(err)
+		panic(fmt.Sprintf("failed to parse end slot from %s: %v", path, err))
 	}
+
 	return slot, incrSlot
+}
+
+// extractFullSnapshotSlot extracts the slot from a full snapshot filename.
+//
+// Expected format: snapshot-{slot}-{hash}.tar.zst
+// Returns: slot number
+//
+// This is kept for backward compatibility but now also uses the new API
+func extractFullSnapshotSlot(path string) int {
+	parts := strings.Split(path, "/")
+	filename := parts[len(parts)-1]
+
+	parts = strings.Split(filename, "-")
+	if len(parts) < 3 {
+		panic(fmt.Sprintf("invalid full snapshot filename format: %s", path))
+	}
+
+	slotStr := parts[1]
+	slot, err := strconv.Atoi(slotStr)
+	if err != nil {
+		panic(fmt.Sprintf("failed to parse slot from %s: %v", path, err))
+	}
+
+	return slot
+}
+
+// GetIncrementalSnapshotURL finds an incremental snapshot URL that matches the full snapshot.
+// It first tries the same source as the full snapshot, then searches other nodes if needed.
+// Returns: (httpURL, baseSlot, endSlot, error)
+//
+// Fallback strategy (different from full snapshot):
+// 1. Try the same node that provided the full snapshot (fastest, most likely match)
+// 2. If that fails, find ALL nodes with matching base slot (more flexible than full snapshot)
+// 3. Among matching nodes, prioritize by:
+//    a. Freshness (highest end slot = most recent incremental)
+//    b. Speed (faster downloads preferred when end slots are equal)
+// 4. Try multiple candidates for resilience (uses MaxSnapshotURLAttempts)
+func GetIncrementalSnapshotURL(endpoint string, fullSnapshotURL string, referenceSlot int, fullSnapshotSlot int, snapCfg SnapshotConfig) (string, int, int, error) {
+	cfg := snapCfg.toInternalConfig(endpoint, "")
+	ctx := context.Background()
+
+	// Extract the source node RPC from the full snapshot URL
+	// Example: "http://node.example.com:8899/snapshot-123-abc.tar.zst" -> "http://node.example.com:8899"
+	var sourceNodeRPC string
+	if strings.HasPrefix(fullSnapshotURL, "http://") || strings.HasPrefix(fullSnapshotURL, "https://") {
+		parts := strings.Split(fullSnapshotURL, "/")
+		if len(parts) >= 3 {
+			sourceNodeRPC = strings.Join(parts[:3], "/") // protocol + // + host:port
+		}
+	}
+
+	// Step 1: Try to get incremental from the same source as the full snapshot
+	if sourceNodeRPC != "" {
+		mlog.Log.Infof("Checking same source for incremental (base slot %d): %s", fullSnapshotSlot, sourceNodeRPC)
+		urlInfo, err := snapshot.GetSnapshotURL(ctx, sourceNodeRPC, "incremental")
+
+		if err == nil && urlInfo != nil && urlInfo.BaseSlot == fullSnapshotSlot {
+			mlog.Log.Infof("📸 Incremental snapshot source: %s (same as full, base=%d, end=%d)",
+				sourceNodeRPC, urlInfo.BaseSlot, urlInfo.Slot)
+			return urlInfo.URL, urlInfo.BaseSlot, urlInfo.Slot, nil
+		}
+		mlog.Log.Infof("Same source unavailable for incremental. Searching cluster...")
+	}
+
+	// Step 2: Fallback - search all nodes for matching incremental
+	// For incrementals, we need to be more flexible: find ANY node with matching base slot,
+	// then prefer fresher incrementals (higher end slot) with reasonable speed
+	mlog.Log.Infof("Searching cluster for incremental snapshot matching full slot %d...", fullSnapshotSlot)
+
+	// Get cluster nodes
+	nodes := rpc.FetchClusterNodes(cfg, endpoint)
+	if len(nodes) == 0 {
+		return "", 0, 0, fmt.Errorf("no rpc nodes available from cluster")
+	}
+
+	// Evaluate nodes
+	evaluateStart := time.Now()
+	results, stats := rpc.EvaluateNodesWithVersionsAndStats(nodes, cfg, referenceSlot)
+	mlog.Log.Infof("Node evaluation completed in %s", time.Since(evaluateStart))
+
+	if snapCfg.Verbose && stats != nil {
+		formatProbeStats(stats, cfg)
+	}
+
+	// Filter nodes by minimum slot (must have snapshot >= fullSnapshotSlot)
+	_, rankedNodes := rpc.SortBestRPCsFilteredBySlot(
+		results, cfg, stats, int64(fullSnapshotSlot), referenceSlot)
+
+	if len(rankedNodes) == 0 {
+		return "", 0, 0, fmt.Errorf("no nodes found with snapshots >= slot %d", fullSnapshotSlot)
+	}
+
+	// Filter to only nodes with matching base slot
+	var matchingNodes []rpc.RankedNode
+	for _, node := range rankedNodes {
+		if node.Result.HasInc && node.Result.IncBase == int64(fullSnapshotSlot) {
+			matchingNodes = append(matchingNodes, node)
+		}
+	}
+
+	if len(matchingNodes) == 0 {
+		return "", 0, 0, fmt.Errorf("no nodes found with incremental base slot %d", fullSnapshotSlot)
+	}
+
+	// Filter out nodes that are too slow (incrementals are ~1GB, don't want 15min downloads)
+	if snapCfg.MinIncrementalSpeedMBs > 0 {
+		var fastEnoughNodes []rpc.RankedNode
+		for _, node := range matchingNodes {
+			if node.S1.MedianMBs >= snapCfg.MinIncrementalSpeedMBs {
+				fastEnoughNodes = append(fastEnoughNodes, node)
+			}
+		}
+		if len(fastEnoughNodes) > 0 {
+			matchingNodes = fastEnoughNodes
+			if snapCfg.Verbose {
+				mlog.Log.Infof("Filtered to %d nodes with speed >= %.1f MB/s",
+					len(matchingNodes), snapCfg.MinIncrementalSpeedMBs)
+			}
+		} else {
+			// No nodes meet speed requirement, continue with all matching nodes
+			if snapCfg.Verbose {
+				mlog.Log.Infof("No nodes meet minimum speed %.1f MB/s, using all %d matching nodes",
+					snapCfg.MinIncrementalSpeedMBs, len(matchingNodes))
+			}
+		}
+	}
+
+	// Sort by end slot descending (freshest first), then by speed
+	// Note: This sorts in-place
+	for i := 0; i < len(matchingNodes)-1; i++ {
+		for j := i + 1; j < len(matchingNodes); j++ {
+			// Sort by end slot descending
+			if matchingNodes[j].Result.IncSlot > matchingNodes[i].Result.IncSlot {
+				matchingNodes[i], matchingNodes[j] = matchingNodes[j], matchingNodes[i]
+			} else if matchingNodes[j].Result.IncSlot == matchingNodes[i].Result.IncSlot {
+				// If same end slot, prefer faster node
+				if matchingNodes[j].S1.MedianMBs > matchingNodes[i].S1.MedianMBs {
+					matchingNodes[i], matchingNodes[j] = matchingNodes[j], matchingNodes[i]
+				}
+			}
+		}
+	}
+
+	mlog.Log.Infof("Found %d nodes with matching base slot %d", len(matchingNodes), fullSnapshotSlot)
+	if snapCfg.Verbose && len(matchingNodes) > 0 {
+		mlog.Log.Infof("Top candidates with matching base:")
+		for i := 0; i < min(3, len(matchingNodes)); i++ {
+			node := matchingNodes[i]
+			mlog.Log.Infof("  #%d: %s (end slot: %d, %.1f MB/s)",
+				i+1, node.Result.RPC, node.Result.IncSlot, node.S1.MedianMBs)
+		}
+	}
+
+	// Try multiple candidates with matching base slot for resilience
+	maxAttempts := snapCfg.MaxSnapshotURLAttempts
+	if maxAttempts <= 0 {
+		maxAttempts = len(matchingNodes) // Try all if configured
+	}
+
+	var incrURL string
+	var incrBaseSlot, incrEndSlot int
+	var selectedNode string
+	var urlErr error
+
+	for i := 0; i < min(maxAttempts, len(matchingNodes)); i++ {
+		node := matchingNodes[i]
+
+		if i > 0 {
+			mlog.Log.Infof("Trying fallback incremental source #%d: %s (end slot: %d)",
+				i+1, node.Result.RPC, node.Result.IncSlot)
+		}
+
+		if snapCfg.Verbose {
+			mlog.Log.Infof("Getting incremental URL from %s (base=%d, end=%d)",
+				node.Result.RPC, node.Result.IncBase, node.Result.IncSlot)
+		}
+
+		urlInfo, err := snapshot.GetSnapshotURL(ctx, node.Result.RPC, "incremental")
+		if err == nil && urlInfo != nil {
+			// Verify base slot still matches (could have changed since evaluation)
+			if urlInfo.BaseSlot == fullSnapshotSlot {
+				incrURL = urlInfo.URL
+				incrBaseSlot = urlInfo.BaseSlot
+				incrEndSlot = urlInfo.Slot
+				selectedNode = node.Result.RPC
+				break
+			}
+			if snapCfg.Verbose {
+				mlog.Log.Infof("Base slot mismatch: got %d, need %d. Trying next...",
+					urlInfo.BaseSlot, fullSnapshotSlot)
+			}
+		} else {
+			if snapCfg.Verbose {
+				mlog.Log.Infof("Failed to get URL from %s: %v. Trying next...", node.Result.RPC, err)
+			}
+			urlErr = err
+		}
+	}
+
+	if incrURL == "" {
+		return "", 0, 0, fmt.Errorf("failed to get incremental URL from any matching node (tried %d nodes, last error: %v)",
+			min(maxAttempts, len(matchingNodes)), urlErr)
+	}
+
+	// Always log the selected source
+	mlog.Log.Infof("📸 Incremental snapshot source: %s (base=%d, end=%d)",
+		selectedNode, incrBaseSlot, incrEndSlot)
+	return incrURL, incrBaseSlot, incrEndSlot, nil
+}
+
+// min returns the minimum of two integers
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
 }

--- a/pkg/snapshotdl/snapshotdl.go
+++ b/pkg/snapshotdl/snapshotdl.go
@@ -76,8 +76,8 @@ func DefaultSnapshotConfig() SnapshotConfig {
 
 		// Stage 2: Sustained speed test for top candidates
 		Stage2TopK:       8,   // Test top 8 from stage 1
-		Stage2WarmSec:    2,   // 2 second warmup
-		Stage2MeasureSec: 2,   // 2 second measurement
+		Stage2WarmSec:    3,   // 3 second warmup (recommended for home internet, 1-2 for datacenter)
+		Stage2MeasureSec: 3,   // 3 second measurement (recommended for home internet, 1-2 for datacenter)
 		Stage2MinRatio:   0.6, // Collapse if speed drops below 60%
 		Stage2MinAbsMBs:  0.0, // Disabled (0 = no minimum)
 


### PR DESCRIPTION
## Summary

Integrates the `solana-snapshot-finder-go` library to provide intelligent snapshot source discovery and selection. This replaces the previous snapshot download logic with a two-stage speed testing algorithm that finds the fastest available snapshot sources.

### Key Features

**Intelligent Node Discovery**
- Two-stage algorithm: fast parallel triage followed by sustained speed testing
- Filters nodes by Solana version, RTT, TCP connectivity, and snapshot age
- Ranks nodes by actual download speed, not just network latency
- Configurable fallback to try multiple ranked nodes if the best one fails

**HTTP Streaming Mode**
- Stream snapshots directly from HTTP to the processing pipeline
- Optional disk saving while streaming using `io.TeeReader` (parallel processing + save)
- When `save_to_disk=false` (default): no disk space required for snapshot files
- When `save_to_disk=true`: saves snapshots to `download_path` while streaming

**Smart Incremental Snapshot Selection**
- Prioritizes freshness (end slot) over pure speed for incrementals
- Tries the same source as the full snapshot first (fastest path)
- Falls back to cluster-wide search if the primary source doesn't have a matching incremental
- Minimum speed threshold (`min_incremental_speed_mbs`) to filter out slow nodes

**Retry and Cleanup Logic**
- Automatic retry with re-discovery when incremental download fails mid-way
- Partial download cleanup on Ctrl+C or errors (no orphaned files)
- Up to 3 retry attempts with fresh source discovery between attempts

### Configuration

New `[snapshot]` section in `mithril.toml` with comprehensive options:

```toml
[snapshot]
    # Save snapshots to disk while streaming
    save_to_disk = false
    download_path = "/data/snapshots"
    
    # Stage 1: Fast parallel triage
    stage1_warm_kib = 512
    stage1_window_kib = 512
    stage1_windows = 4
    stage1_timeout_ms = 3000
    
    # Stage 2: Sustained speed test
    stage2_top_k = 8
    stage2_warm_sec = 2
    stage2_measure_sec = 2
    stage2_min_ratio = 0.6
    
    # Node filtering
    max_rtt_ms = 200
    min_node_version = "2.2.0"
    
    # Fallback resilience
    max_snapshot_url_attempts = 3
```

See `docs/snapshot.md` for complete documentation.

### Dependencies

Requires the updated `solana-snapshot-finder-go` library with library mode support (PR #6).

## Test plan

- [ ] Run `verify-live` with default config (HTTP streaming, no disk save)
- [ ] Run with `save_to_disk = true` to verify parallel save works
- [ ] Test Ctrl+C during download to verify cleanup
- [ ] Verify Stage 1 and Stage 2 logging output
- [ ] Test incremental retry by simulating a mid-download failure