### PR TITLE
fix: clean up AccountsDB and snapshot artifacts early on startup

### DIFF
--- a/cmd/mithril/node/node.go
+++ b/cmd/mithril/node/node.go
@@ -584,7 +584,25 @@ func runVerifyLive(c *cobra.Command, args []string) {
 	// Now start the metrics server (after banner so errors don't appear first)
 	statsd.StartMetricsServer()
 
+	// Clean up any leftover artifacts from previous runs early,
+	// before any operations that could fail (snapshot finding, downloading, etc.)
+	// This ensures disk space is reclaimed even if the program exits early.
+	if accountsPath != "" {
+		mlog.Log.Infof("cleaning up previous AccountsDB artifacts in %s", accountsPath)
+		snapshot.CleanAccountsDbDir(accountsPath)
+	}
+
 	snapshotDownloadPath := scratchDirectory
+
+	// Clean up old snapshot files based on retention settings
+	if snapshotDownloadPath != "" {
+		maxSnapshots := config.GetInt("snapshot.max_full_snapshots")
+		if maxSnapshots == 0 {
+			maxSnapshots = 2 // default
+		}
+		deleteOld := config.GetBool("snapshot.delete_old_snapshots")
+		snapshot.CleanSnapshotDownloadDir(snapshotDownloadPath, maxSnapshots, deleteOld)
+	}
 
 	// Determine if using Overcast based on block source
 	useOvercast := blockSource == "overcast"

--- a/pkg/snapshot/build_db.go
+++ b/pkg/snapshot/build_db.go
@@ -29,9 +29,10 @@ const (
 	maxAppendVecCopying    = 500
 )
 
-// cleanAccountsDbDir removes all artifacts from a previous incomplete snapshot run.
+// CleanAccountsDbDir removes all artifacts from a previous incomplete snapshot run.
 // This prevents corruption from Ctrl+C or partial downloads.
-func cleanAccountsDbDir(accountsDbDir string) {
+// Exported so it can be called early in startup before any failures.
+func CleanAccountsDbDir(accountsDbDir string) {
 	// List of all files/directories that may be left from a previous incomplete run
 	artifacts := []string{
 		"accounts",
@@ -43,7 +44,92 @@ func cleanAccountsDbDir(accountsDbDir string) {
 		"manifest",
 	}
 	for _, artifact := range artifacts {
-		os.RemoveAll(filepath.Join(accountsDbDir, artifact))
+		path := filepath.Join(accountsDbDir, artifact)
+		if err := os.RemoveAll(path); err != nil {
+			mlog.Log.Errorf("failed to remove %s: %v", path, err)
+		}
+	}
+}
+
+// CleanSnapshotDownloadDir removes old snapshot files based on retention settings.
+// maxSnapshots: maximum full snapshots to keep (0 = unlimited)
+// deleteOldSnapshots: if true, always clean excess; if false, only clean when over limit
+func CleanSnapshotDownloadDir(downloadPath string, maxSnapshots int, deleteOldSnapshots bool) {
+	if downloadPath == "" || maxSnapshots < 0 {
+		return
+	}
+	entries, err := os.ReadDir(downloadPath)
+	if err != nil {
+		return // Directory may not exist yet
+	}
+
+	// Collect snapshot files with their info
+	type snapshotFile struct {
+		name    string
+		path    string
+		modTime time.Time
+	}
+	var fullSnapshots []snapshotFile
+	var incrSnapshots []snapshotFile
+
+	for _, entry := range entries {
+		name := entry.Name()
+		if strings.HasPrefix(name, "snapshot-") && strings.HasSuffix(name, ".tar.zst") {
+			path := filepath.Join(downloadPath, name)
+			info, err := entry.Info()
+			if err != nil {
+				continue
+			}
+			fullSnapshots = append(fullSnapshots, snapshotFile{name, path, info.ModTime()})
+		}
+		if strings.HasPrefix(name, "incremental-snapshot-") && strings.HasSuffix(name, ".tar.zst") {
+			path := filepath.Join(downloadPath, name)
+			info, err := entry.Info()
+			if err != nil {
+				continue
+			}
+			incrSnapshots = append(incrSnapshots, snapshotFile{name, path, info.ModTime()})
+		}
+	}
+
+	// If maxSnapshots is 0 (unlimited) and deleteOldSnapshots is false, don't clean anything
+	if maxSnapshots == 0 && !deleteOldSnapshots {
+		return
+	}
+
+	// Sort by modification time (newest first)
+	sortByTime := func(files []snapshotFile) {
+		for i := 0; i < len(files)-1; i++ {
+			for j := i + 1; j < len(files); j++ {
+				if files[j].modTime.After(files[i].modTime) {
+					files[i], files[j] = files[j], files[i]
+				}
+			}
+		}
+	}
+
+	// Clean full snapshots beyond the retention limit
+	if maxSnapshots > 0 && len(fullSnapshots) > maxSnapshots {
+		sortByTime(fullSnapshots)
+		for i := maxSnapshots; i < len(fullSnapshots); i++ {
+			if err := os.Remove(fullSnapshots[i].path); err != nil {
+				mlog.Log.Errorf("failed to remove old snapshot %s: %v", fullSnapshots[i].name, err)
+			} else {
+				mlog.Log.Infof("cleaned up old snapshot file (retention limit %d): %s", maxSnapshots, fullSnapshots[i].name)
+			}
+		}
+	}
+
+	// Clean incremental snapshots beyond the retention limit (same limit as full)
+	if maxSnapshots > 0 && len(incrSnapshots) > maxSnapshots {
+		sortByTime(incrSnapshots)
+		for i := maxSnapshots; i < len(incrSnapshots); i++ {
+			if err := os.Remove(incrSnapshots[i].path); err != nil {
+				mlog.Log.Errorf("failed to remove old incremental snapshot %s: %v", incrSnapshots[i].name, err)
+			} else {
+				mlog.Log.Infof("cleaned up old incremental snapshot file (retention limit %d): %s", maxSnapshots, incrSnapshots[i].name)
+			}
+		}
 	}
 }
 
@@ -60,7 +146,7 @@ func BuildAccountsDb(
 	accountsDbDir string,
 ) (*accountsdb.AccountsDb, *SnapshotManifest, error) {
 	// Clean any leftover artifacts from previous incomplete runs (e.g., Ctrl+C)
-	cleanAccountsDbDir(accountsDbDir)
+	CleanAccountsDbDir(accountsDbDir)
 
 	manifest, err := UnmarshalManifestFromSnapshot(snapshotFile, accountsDbDir)
 	if err != nil {

--- a/pkg/snapshot/build_db_with_incr.go
+++ b/pkg/snapshot/build_db_with_incr.go
@@ -39,7 +39,7 @@ func BuildAccountsDbWithIncr(
 	dp *progress.DualProgress,
 ) (*accountsdb.AccountsDb, *SnapshotManifest, error) {
 	// Clean any leftover artifacts from previous incomplete runs (e.g., Ctrl+C)
-	cleanAccountsDbDir(accountsDbDir)
+	CleanAccountsDbDir(accountsDbDir)
 
 	manifest, err := UnmarshalManifestFromSnapshot(fullSnapshotFile, accountsDbDir)
 	if err != nil {


### PR DESCRIPTION
## Summary
- Clean up stale AccountsDB artifacts (accounts/, mithril_db, etc.) immediately on startup, before any network operations that could fail
- Add snapshot file retention cleanup based on `max_full_snapshots` config setting
- Prevents disk from filling up after interrupted verify-live runs

## Problem
When verify-live is interrupted (Ctrl+C) or fails early (e.g., snapshot URL fetch fails), AccountsDB artifacts from partial runs would accumulate and fill up the disk. The cleanup was only happening inside `BuildAccountsDbWithIncr`, which is called after several operations that could fail.

## Solution
- Export `CleanAccountsDbDir` and call it early in verify-live startup (right after banner)
- Add `CleanSnapshotDownloadDir` to clean old snapshot files based on retention settings
- Both cleanups run before any network operations, so disk space is reclaimed even if subsequent operations fail

## Files Changed
- `cmd/mithril/node/node.go` - Add early cleanup calls after banner
- `pkg/snapshot/build_db.go` - Export `CleanAccountsDbDir`, add `CleanSnapshotDownloadDir`
- `pkg/snapshot/build_db_with_incr.go` - Use exported `CleanAccountsDbDir`

## Test plan
- [x] Run verify-live, Ctrl+C during download phase
- [x] Check disk usage shows ~60GB of partial artifacts
- [x] Run verify-live again, verify cleanup log appears
- [x] Ctrl+C during node probing (before download)
- [x] Verify disk is empty (cleanup worked)
- [x] Verify verify-live still completes successfully with cleanup enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)