### PR TITLE
fix: graceful Ctrl+C handling and consolidate snapshot config

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,8 +132,8 @@ name = "mithril"
     txpar = 24
 
 [snapshot]
-    # Save snapshots to disk while streaming (optional)
-    # save_to_disk = true
+    # Keep snapshots on disk (0 = stream-only, 1+ = save and retain N)
+    # max_full_snapshots = 2
     download_path = "/mnt/mithril-ledger/snapshots"
 
     # Verbose output shows detailed node discovery statistics

--- a/cmd/mithril/node/node.go
+++ b/cmd/mithril/node/node.go
@@ -351,9 +351,6 @@ func buildSnapshotConfig() snapshotdl.SnapshotConfig {
 	if config.IsSet("snapshot.verbose") {
 		cfg.Verbose = config.GetBool("snapshot.verbose")
 	}
-	if config.IsSet("snapshot.save_to_disk") {
-		cfg.SaveToDisk = config.GetBool("snapshot.save_to_disk")
-	}
 	if config.IsSet("snapshot.download_path") {
 		cfg.DownloadPath = config.GetString("snapshot.download_path")
 	}
@@ -410,9 +407,6 @@ func buildSnapshotConfig() snapshotdl.SnapshotConfig {
 	}
 	if config.IsSet("snapshot.max_full_snapshots") {
 		cfg.MaxFullSnapshots = config.GetInt("snapshot.max_full_snapshots")
-	}
-	if config.IsSet("snapshot.delete_old_snapshots") {
-		cfg.DeleteOldSnapshots = config.GetBool("snapshot.delete_old_snapshots")
 	}
 	if config.IsSet("snapshot.worker_count") {
 		cfg.WorkerCount = config.GetInt("snapshot.worker_count")

--- a/config.example.toml
+++ b/config.example.toml
@@ -129,13 +129,23 @@ scratch_directory = "/mnt/mithril-ledger"
 # ============================================================================
 
 [snapshot]
-    # Path to download snapshot to (only used if save_to_disk = true)
-    download_path = "/mnt/mithril-ledger/snapshots"
+    # -------------------------------------------------------------------------
+    # Snapshot Storage
+    # -------------------------------------------------------------------------
 
-    # Save snapshots to disk while streaming (requires download_path)
-    # When true: streams from network while saving to disk and processing (parallel)
-    # When false: streams from network and processes without saving (saves disk space)
-    save_to_disk = false
+    # Maximum snapshots to keep on disk (controls both saving and retention)
+    #   0 = Stream-only mode (don't save snapshots, saves disk space)
+    #   1 = Save one snapshot, delete previous before downloading new
+    #   2+ = Keep N snapshots, delete oldest when limit exceeded
+    #
+    # Saved snapshots are valuable for debugging and reproducing issues -
+    # the dev team can start from a snapshot to investigate problems.
+    # Set to 0 for stream-only mode (saves disk space but requires re-download
+    # if interrupted).
+    max_full_snapshots = 1
+
+    # Path to save snapshots (only used when max_full_snapshots > 0)
+    download_path = "/mnt/mithril-ledger/snapshots"
 
     # Enable verbose output showing detailed node discovery statistics
     verbose = false
@@ -211,16 +221,6 @@ scratch_directory = "/mnt/mithril-ledger"
 
     # Safety margin - warn if snapshot is this close to expiration (slots)
     safety_margin_slots = 5000
-
-    # -------------------------------------------------------------------------
-    # Snapshot Retention
-    # -------------------------------------------------------------------------
-
-    # Maximum number of full snapshots to keep (0 = unlimited)
-    max_full_snapshots = 2
-
-    # Automatically delete old snapshots based on age thresholds
-    delete_old_snapshots = false
 
     # -------------------------------------------------------------------------
     # Performance

--- a/docs/snapshot.md
+++ b/docs/snapshot.md
@@ -118,7 +118,7 @@ Incremental snapshots must match the base slot of the full snapshot. The selecti
 
 ### Streaming Mode (Default)
 
-When `save_to_disk = false` (default):
+When `max_full_snapshots = 0` (default):
 - Snapshot data streams directly from HTTP to processing pipeline
 - No disk space required for snapshot files
 - Cannot resume if interrupted
@@ -126,10 +126,11 @@ When `save_to_disk = false` (default):
 
 ### Streaming + Save Mode
 
-When `save_to_disk = true` and `download_path` is set:
+When `max_full_snapshots > 0` and `download_path` is set:
 - Uses `io.TeeReader` to write to disk while streaming
 - Processing happens in parallel with disk write
 - Snapshot files are saved for potential reuse
+- Old snapshots automatically deleted when limit exceeded
 - Slightly higher memory usage
 
 ### Disk Download Mode
@@ -164,13 +165,18 @@ All configuration options can be set in `config.toml` under the `[snapshot]` sec
 
 ```toml
 [snapshot]
-    # Path to download snapshot to (only used if save_to_disk = true)
-    # download_path = ""
+    # Maximum snapshots to keep on disk (controls both saving and retention)
+    #   0 = Stream-only mode (don't save snapshots, saves disk space)
+    #   1 = Save one snapshot, delete previous before downloading new
+    #   2+ = Keep N snapshots, delete oldest when limit exceeded
+    #
+    # When set to 0, snapshots are streamed directly from the network and
+    # processed without saving to disk. This saves significant disk space
+    # but means you'll need to re-download if the process is interrupted.
+    # max_full_snapshots = 1
 
-    # Save snapshots to disk while streaming (requires download_path)
-    # When true: streams from network while saving to disk and processing (parallel)
-    # When false: streams from network and processes without saving (saves disk space)
-    # save_to_disk = false
+    # Path to save snapshots (only used when max_full_snapshots > 0)
+    # download_path = ""
 
     # Enable verbose output showing detailed node discovery statistics
     # verbose = false
@@ -243,16 +249,6 @@ All configuration options can be set in `config.toml` under the `[snapshot]` sec
     # safety_margin_slots = 5000
 
     # -------------------------------------------------------------------------
-    # Snapshot Retention
-    # -------------------------------------------------------------------------
-
-    # Maximum number of full snapshots to keep (0 = unlimited)
-    # max_full_snapshots = 2
-
-    # Automatically delete old snapshots based on age thresholds
-    # delete_old_snapshots = false
-
-    # -------------------------------------------------------------------------
     # Performance
     # -------------------------------------------------------------------------
 
@@ -284,7 +280,7 @@ All configuration options can be set in `config.toml` under the `[snapshot]` sec
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
-| `save_to_disk` | `false` | Stream-only by default |
+| `max_full_snapshots` | `1` | Save one snapshot (0=stream, 1+=save and retain N) |
 | `verbose` | `false` | Quiet logging |
 | `stage1_warm_kib` | `512` | 512 KiB warmup |
 | `stage1_window_kib` | `512` | 512 KiB windows |
@@ -302,7 +298,6 @@ All configuration options can be set in `config.toml` under the `[snapshot]` sec
 | `full_threshold` | `100000` | ~11 hours old |
 | `incremental_threshold` | `200` | ~80 seconds old |
 | `safety_margin_slots` | `5000` | Warn if close to expiration |
-| `max_full_snapshots` | `2` | Keep last 2 |
 | `worker_count` | `100` | 100 concurrent workers |
 | `max_snapshot_url_attempts` | `3` | Try top 3 nodes |
 | `min_incremental_speed_mbs` | `2.0` | Minimum 2 MB/s |
@@ -356,7 +351,8 @@ mithril verify-live --config my-config.toml
 
 ```toml
 [snapshot]
-    save_to_disk = true
+    # Keep 2 snapshots on disk
+    max_full_snapshots = 2
     download_path = "/data/snapshots"
 ```
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -67,8 +67,11 @@ type BlockConfig struct {
 
 // SnapshotConfig holds snapshot download configuration
 type SnapshotConfig struct {
-	DownloadPath string `toml:"download_path" mapstructure:"download_path"` // Path to download snapshot to
-	SaveToDisk   bool   `toml:"save_to_disk" mapstructure:"save_to_disk"`   // Save snapshots while streaming (requires download_path)
+	// MaxFullSnapshots controls both saving and retention:
+	//   0 = Stream-only mode (don't save snapshots to disk)
+	//   1+ = Save snapshots and keep up to N on disk
+	MaxFullSnapshots int    `toml:"max_full_snapshots" mapstructure:"max_full_snapshots"`
+	DownloadPath     string `toml:"download_path" mapstructure:"download_path"` // Path to download snapshot to
 
 	// Output verbosity
 	Verbose bool `toml:"verbose" mapstructure:"verbose"` // Enable detailed statistics output
@@ -97,10 +100,6 @@ type SnapshotConfig struct {
 	FullThreshold        int `toml:"full_threshold" mapstructure:"full_threshold"`
 	IncrementalThreshold int `toml:"incremental_threshold" mapstructure:"incremental_threshold"`
 	SafetyMarginSlots    int `toml:"safety_margin_slots" mapstructure:"safety_margin_slots"`
-
-	// Retention
-	MaxFullSnapshots   int  `toml:"max_full_snapshots" mapstructure:"max_full_snapshots"`
-	DeleteOldSnapshots bool `toml:"delete_old_snapshots" mapstructure:"delete_old_snapshots"`
 
 	// Performance
 	WorkerCount int `toml:"worker_count" mapstructure:"worker_count"`

--- a/pkg/progress/progress.go
+++ b/pkg/progress/progress.go
@@ -20,9 +20,10 @@ const (
 
 	// Teal/cyan color (using 256-color mode for wider terminal compatibility)
 	// Index 85 is a teal/cyan in the 256-color palette
-	colorTeal  = "\x1b[38;5;85m"
-	colorReset = "\x1b[0m"
-	colorDim   = "\x1b[2m"
+	colorTeal   = "\x1b[38;5;85m"
+	colorYellow = "\x1b[38;5;220m"
+	colorReset  = "\x1b[0m"
+	colorDim    = "\x1b[2m"
 
 	// Cursor control
 	clearLine = "\x1b[2K"
@@ -210,6 +211,7 @@ type DualProgress struct {
 	mu            sync.Mutex
 	started       bool
 	done          bool
+	interrupted   bool
 	stopCh        chan struct{}
 	doneCh        chan struct{}
 	output        io.Writer
@@ -346,6 +348,30 @@ func (d *DualProgress) Stop() {
 	<-d.doneCh
 }
 
+// Interrupt stops the progress display and shows interrupted status
+func (d *DualProgress) Interrupt() {
+	d.mu.Lock()
+	d.interrupted = true
+	d.mu.Unlock()
+
+	d.Stop()
+
+	// Print final interrupted status
+	fmt.Fprintf(d.output, "\033[2K") // Clear line
+	if d.useColor {
+		fmt.Fprintf(d.output, "%s⚠ Interrupted by user%s\n", colorYellow, colorReset)
+	} else {
+		fmt.Fprintln(d.output, "⚠ Interrupted by user")
+	}
+}
+
+// IsInterrupted returns true if the progress was interrupted
+func (d *DualProgress) IsInterrupted() bool {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.interrupted
+}
+
 // IndexingProgress tracks shard flush progress
 type IndexingProgress struct {
 	label     string
@@ -427,6 +453,26 @@ func (p *IndexingProgress) Update(completed, total int) {
 // Finish marks completion
 func (p *IndexingProgress) Finish() {
 	p.Update(p.total, p.total)
+}
+
+// Interrupt shows interrupted status
+func (p *IndexingProgress) Interrupt() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if !p.started {
+		return
+	}
+
+	// Move up and clear line
+	if p.useColor {
+		fmt.Fprint(p.output, moveUp+clearLine)
+		fmt.Fprintf(p.output, "%s%-24s%s %s⚠ Interrupted%s\n",
+			colorTeal, p.label, colorReset,
+			colorYellow, colorReset)
+	} else {
+		fmt.Fprintf(p.output, "%-24s ⚠ Interrupted\n", p.label)
+	}
 }
 
 // PrintBanner prints the Mithril ASCII art banner centered in the terminal

--- a/pkg/snapshot/build_db_with_incr.go
+++ b/pkg/snapshot/build_db_with_incr.go
@@ -199,7 +199,7 @@ func BuildAccountsDbWithIncr(
 
 	// Determine save path for full snapshot if streaming from HTTP
 	var fullSavePath string
-	if snapCfg.SaveToDisk && (strings.HasPrefix(fullSnapshotFile, "http://") || strings.HasPrefix(fullSnapshotFile, "https://")) {
+	if snapCfg.MaxFullSnapshots > 0 && (strings.HasPrefix(fullSnapshotFile, "http://") || strings.HasPrefix(fullSnapshotFile, "https://")) {
 		if snapshotDownloadPath != "" {
 			// Extract filename from URL and create save path
 			urlParts := strings.Split(fullSnapshotFile, "/")
@@ -306,7 +306,7 @@ func BuildAccountsDbWithIncr(
 
 		// Determine save path for incremental snapshot if streaming from HTTP
 		var incrSavePath string
-		if snapCfg.SaveToDisk && (strings.HasPrefix(incrementalSnapshotPath, "http://") || strings.HasPrefix(incrementalSnapshotPath, "https://")) {
+		if snapCfg.MaxFullSnapshots > 0 && (strings.HasPrefix(incrementalSnapshotPath, "http://") || strings.HasPrefix(incrementalSnapshotPath, "https://")) {
 			if snapshotDownloadPath != "" {
 				// Extract filename from URL and create save path
 				urlParts := strings.Split(incrementalSnapshotPath, "/")

--- a/pkg/snapshot/build_db_with_incr.go
+++ b/pkg/snapshot/build_db_with_incr.go
@@ -221,6 +221,14 @@ func BuildAccountsDbWithIncr(
 	}()
 	wg.Wait()
 
+	// Check if processing was interrupted (context cancelled or error)
+	if err != nil {
+		if dp != nil {
+			dp.Interrupt()
+		}
+		return nil, nil, fmt.Errorf("processing full snapshot: %w", err)
+	}
+
 	// Stop progress display after full snapshot is processed
 	if dp != nil {
 		dp.Stop()
@@ -235,6 +243,7 @@ func BuildAccountsDbWithIncr(
 		indexProgress.Update(completed, total)
 	})
 	if err != nil {
+		indexProgress.Interrupt()
 		return nil, nil, fmt.Errorf("closing shard logger: %w", err)
 	}
 

--- a/pkg/snapshotdl/snapshotdl.go
+++ b/pkg/snapshotdl/snapshotdl.go
@@ -57,9 +57,10 @@ type SnapshotConfig struct {
 	FullThreshold        int
 	IncrementalThreshold int
 
-	// Retention
-	MaxFullSnapshots   int
-	DeleteOldSnapshots bool
+	// Snapshot storage (controls both saving and retention)
+	// 0 = Stream-only mode (don't save snapshots to disk)
+	// 1+ = Save snapshots and keep up to N on disk
+	MaxFullSnapshots int
 
 	// Safety
 	SafetyMarginSlots int
@@ -70,9 +71,8 @@ type SnapshotConfig struct {
 	// Output verbosity
 	Verbose bool
 
-	// Disk saving
-	SaveToDisk   bool   // Save snapshots to disk while streaming
-	DownloadPath string // Path to save snapshots to (only used if SaveToDisk=true)
+	// Download path (only used when MaxFullSnapshots > 0)
+	DownloadPath string
 
 	// Fallback resilience
 	MaxSnapshotURLAttempts int // Number of ranked nodes to try when getting snapshot URLs (0 = try all)
@@ -108,9 +108,9 @@ func DefaultSnapshotConfig() SnapshotConfig {
 		FullThreshold:        100000, // Full snapshots up to 100k slots old (Agave 3.0+)
 		IncrementalThreshold: 200,    // Allow slightly ahead incrementals
 
-		// Retention
-		MaxFullSnapshots:   2,     // Keep last 2 full snapshots
-		DeleteOldSnapshots: false, // Let mithril manage deletion
+		// Snapshot storage (0 = stream-only, 1+ = save and retain N)
+		// Saved snapshots are valuable for debugging and reproducing issues
+		MaxFullSnapshots: 1, // Save one snapshot by default
 
 		// Safety
 		SafetyMarginSlots: 5000, // Warn if <5000 slots until expiration
@@ -121,9 +121,8 @@ func DefaultSnapshotConfig() SnapshotConfig {
 		// Output
 		Verbose: false, // Quiet by default
 
-		// Disk saving
-		SaveToDisk:   false, // Stream only by default (save disk space)
-		DownloadPath: "",    // No download path by default
+		// Download path (set via config when MaxFullSnapshots > 0)
+		DownloadPath: "",
 
 		// Fallback resilience
 		MaxSnapshotURLAttempts: 3, // Try top 3 ranked nodes before giving up
@@ -159,9 +158,8 @@ func (sc SnapshotConfig) toInternalConfig(endpoint string, path string) config.C
 		TCPTimeoutMs:         sc.TCPTimeoutMs,
 		MinNodeVersion:       sc.MinNodeVersion,
 		AllowedNodeVersions:  sc.AllowedNodeVersions,
-		MaxFullSnapshots:     sc.MaxFullSnapshots,
-		DeleteOldSnapshots:   sc.DeleteOldSnapshots,
-		SafetyMarginSlots:    sc.SafetyMarginSlots,
+		MaxFullSnapshots:  sc.MaxFullSnapshots,
+		SafetyMarginSlots: sc.SafetyMarginSlots,
 		Quiet:                true, // Mithril prints its own summary
 	}
 }


### PR DESCRIPTION
## Summary
- Shows "Interrupted by user" instead of misleading "done" messages when Ctrl+C is pressed during snapshot download and AccountsDB build
- Consolidates snapshot config: merges `save_to_disk` and `delete_old_snapshots` into single `max_full_snapshots` setting
  - `max_full_snapshots = 0`: Stream-only mode (don't save snapshots to disk)
  - `max_full_snapshots = 1+`: Save snapshots and keep up to N on disk
  - Default is 1 (save one snapshot) because saved snapshots are valuable for debugging and reproducing issues

## Test plan
- [x] Run verify-live and press Ctrl+C during snapshot download - should show "Interrupted" status
- [x] Run verify-live and press Ctrl+C during AccountsDB build - should show "Interrupted" status
- [x] Verify max_full_snapshots=0 streams without saving
- [x] Verify max_full_snapshots=1 saves and replaces previous snapshot

🤖 Generated with [Claude Code](https://claude.com/claude-code)