### PR TITLE
fix: gopls S1004 - use bytes.Equal instead of bytes.Compare

### DIFF
--- a/pkg/sealevel/el_gamal_proof_program.go
+++ b/pkg/sealevel/el_gamal_proof_program.go
@@ -1411,11 +1411,11 @@ func verifyGroupedCiphertext2HandlesValidity(context, proof []byte) error {
 	var points [16]*ristretto255.Element
 	pubkey2NotZero := true
 	var ristrettoCompressedZero [32]byte
-	if bytes.Compare(pubkey2, ristrettoCompressedZero[:]) == 0 {
+	if bytes.Equal(pubkey2, ristrettoCompressedZero[:]) {
 		pubkey2NotZero = false
 
-		if bytes.Compare(handle2, ristrettoCompressedZero[:]) != 0 ||
-			bytes.Compare(proofY2, ristrettoCompressedZero[:]) != 0 {
+		if !bytes.Equal(handle2, ristrettoCompressedZero[:]) ||
+			!bytes.Equal(proofY2, ristrettoCompressedZero[:]) {
 			return ErrInvalidProof
 		}
 	}
@@ -1754,12 +1754,12 @@ func verifyBatchedGroupedCiphertext2HandlesValidity(context, proof []byte) error
 	var points [16]*ristretto255.Element
 	pubkey2NotZero := true
 	var ristrettoCompressedZero [32]byte
-	if bytes.Compare(pubkey2, ristrettoCompressedZero[:]) == 0 {
+	if bytes.Equal(pubkey2, ristrettoCompressedZero[:]) {
 		pubkey2NotZero = false
 
-		if bytes.Compare(handle2, ristrettoCompressedZero[:]) != 0 ||
-			bytes.Compare(proofY2, ristrettoCompressedZero[:]) != 0 ||
-			bytes.Compare(handle2Hi, ristrettoCompressedZero[:]) != 0 {
+		if !bytes.Equal(handle2, ristrettoCompressedZero[:]) ||
+			!bytes.Equal(proofY2, ristrettoCompressedZero[:]) ||
+			!bytes.Equal(handle2Hi, ristrettoCompressedZero[:]) {
 			return ErrInvalidProof
 		}
 	}

--- a/pkg/sealevel/syscalls_curve.go
+++ b/pkg/sealevel/syscalls_curve.go
@@ -645,7 +645,7 @@ func g1Decompress(input []byte) ([]byte, error) {
 		return nil, fmt.Errorf("wrong input length")
 	}
 
-	if bytes.Compare(input, empty32Bytes[:]) == 0 {
+	if bytes.Equal(input, empty32Bytes[:]) {
 		return empty64Bytes[:], nil
 	}
 
@@ -679,7 +679,7 @@ func g2Decompress(input []byte) ([]byte, error) {
 		return nil, fmt.Errorf("wrong input length")
 	}
 
-	if bytes.Compare(input, empty64Bytes[:]) == 0 {
+	if bytes.Equal(input, empty64Bytes[:]) {
 		return empty128Bytes[:], nil
 	}
 


### PR DESCRIPTION
### Problem

In Go, when comparing two byte slices for equality, it is recommended to use `bytes.Equal(x, y)` instead of `bytes.Compare(x, y) == 0`.

- [gopls S1004](https://go.dev/gopls/analyzers#s1004-replace-call-to-bytescompare-with-bytesequal)
- [datadoghq description](https://docs.datadoghq.com/security/code_security/static_analysis/static_analysis_rules/go-best-practices/bytes-compare-equal/)

### Solution

use `bytes.Equal(x, y)` instead of `bytes.Compare(x, y) == 0`.

cc @7layermagik