### PR TITLE
fix(F-D10): ELF-loader get_string_in_section method

### DIFF
--- a/pkg/sbpf/asm.go
+++ b/pkg/sbpf/asm.go
@@ -148,15 +148,15 @@ func (ip *Interpreter) disassemble(slot Slot, slot2 Slot) string {
 	case OpLe, OpBe:
 		return fmt.Sprintf("%s%d r%d", mnemonic, slot.Uimm(), slot.Dst())
 	case OpJa:
-		return fmt.Sprintf("ja")
+		return "ja"
 	case OpJeqImm, OpJgtImm, OpJgeImm, OpJltImm, OpJleImm, OpJsetImm, OpJneImm, OpJsgtImm, OpJsgeImm, OpJsltImm, OpJsleImm:
 		return fmt.Sprintf("%s r%d, %d", mnemonic, slot.Dst(), int64(slot.Imm()))
 	case OpJeqReg, OpJgtReg, OpJgeReg, OpJltReg, OpJleReg, OpJsetReg, OpJneReg, OpJsgtReg, OpJsgeReg, OpJsltReg, OpJsleReg:
 		return fmt.Sprintf("%s r%d, r%d", mnemonic, slot.Dst(), slot.Src())
 	case OpCall:
-		return fmt.Sprintf("call")
+		return "call"
 	case OpCallx:
-		return fmt.Sprintf("callx")
+		return "callx"
 	case OpExit:
 		return "exit"
 	default:

--- a/pkg/sbpf/errors.go
+++ b/pkg/sbpf/errors.go
@@ -1,0 +1,27 @@
+package sbpf
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Exception codes.
+var (
+	ExcDivideByZero           = errors.New("divide by zero at BPF instruction")
+	ExcDivideOverflow         = errors.New("divide overflow")
+	ExcOutOfCU                = errors.New("compute unit overrun")
+	ExcCallDepth              = errors.New("call depth exceeded")
+	ExcInvalidInstr           = errors.New("invalid instruction - feature not enabled")
+	ErrOutOfBounds            = errors.New("value out of bounds")
+	ErrInvalidSectionHeader   = errors.New("invalid section header")
+	ExcUnsupportedInstruction = errors.New("unsupported BPF instruction")
+)
+
+type ErrStringTooLong struct {
+	Name string
+	Len  uint64
+}
+
+func (e *ErrStringTooLong) Error() string {
+	return fmt.Sprintf("Section or symbol name `%s` is longer than `%d` bytes", e.Name, e.Len)
+}

--- a/pkg/sbpf/loader/loader.go
+++ b/pkg/sbpf/loader/loader.go
@@ -17,6 +17,16 @@ import (
 )
 
 var ErrOutOfBounds = errors.New("value out of bounds")
+var ErrInvalidSectionHeader = errors.New("invalid section header")
+
+type ErrStringTooLong struct {
+	Name string
+	Len  uint64
+}
+
+func (e *ErrStringTooLong) Error() string {
+	return fmt.Sprintf("Section or symbol name `%s` is longer than `%d` bytes", e.Name, e.Len)
+}
 
 // TODO Fuzz
 // TODO Differential fuzz against rbpf

--- a/pkg/sbpf/loader/loader.go
+++ b/pkg/sbpf/loader/loader.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"debug/elf"
 	"encoding/binary"
-	"errors"
 	"fmt"
 	"io"
 
@@ -15,18 +14,6 @@ import (
 	"github.com/Overclock-Validator/mithril/pkg/sbpf"
 	"github.com/Overclock-Validator/mithril/pkg/sbpf/sbpfver"
 )
-
-var ErrOutOfBounds = errors.New("value out of bounds")
-var ErrInvalidSectionHeader = errors.New("invalid section header")
-
-type ErrStringTooLong struct {
-	Name string
-	Len  uint64
-}
-
-func (e *ErrStringTooLong) Error() string {
-	return fmt.Sprintf("Section or symbol name `%s` is longer than `%d` bytes", e.Name, e.Len)
-}
 
 // TODO Fuzz
 // TODO Differential fuzz against rbpf

--- a/pkg/sbpf/loader/parse.go
+++ b/pkg/sbpf/loader/parse.go
@@ -11,6 +11,7 @@ import (
 	"math/bits"
 	"strings"
 
+	"github.com/Overclock-Validator/mithril/pkg/sbpf"
 	"github.com/Overclock-Validator/mithril/pkg/sbpf/sbpfver"
 )
 
@@ -91,7 +92,7 @@ func (l *Loader) newSymTableIter(sh *elf.Section64) (*symTableIter, error) {
 
 func (l *Loader) readHeader() error {
 	if l.fileSize < ehLen {
-		return ErrOutOfBounds
+		return sbpf.ErrOutOfBounds
 	}
 
 	var hdrBuf [ehLen]byte
@@ -297,22 +298,22 @@ func (l *Loader) readSectionHeaderTable() error {
 // See https://github.com/anza-xyz/sbpf/blob/main/src/elf_parser/mod.rs#L468
 func (l *Loader) getString(strtab *elf.Section64, stroff uint32, maxLen uint16) (string, error) {
 	if elf.SectionType(strtab.Type) != elf.SHT_STRTAB {
-		return "", ErrInvalidSectionHeader
+		return "", sbpf.ErrInvalidSectionHeader
 	}
 
 	offset, carry := bits.Add64(strtab.Off, uint64(stroff), 0)
 	if carry != 0 {
-		return "", ErrOutOfBounds
+		return "", sbpf.ErrOutOfBounds
 	}
 
 	sectionEnd, carry := bits.Add64(strtab.Off, strtab.Size, 0)
 	if carry != 0 {
-		return "", ErrOutOfBounds
+		return "", sbpf.ErrOutOfBounds
 	}
 
 	maxEnd, carry := bits.Add64(offset, uint64(maxLen), 0)
 	if carry != 0 {
-		return "", ErrOutOfBounds
+		return "", sbpf.ErrOutOfBounds
 	}
 
 	if sectionEnd < maxEnd {
@@ -320,7 +321,7 @@ func (l *Loader) getString(strtab *elf.Section64, stroff uint32, maxLen uint16) 
 	}
 
 	if offset > l.fileSize {
-		return "", ErrOutOfBounds
+		return "", sbpf.ErrOutOfBounds
 	}
 
 	readLen := maxEnd - offset
@@ -328,7 +329,7 @@ func (l *Loader) getString(strtab *elf.Section64, stroff uint32, maxLen uint16) 
 		readLen = l.fileSize - offset
 	}
 	if readLen == 0 {
-		return "", ErrOutOfBounds
+		return "", sbpf.ErrOutOfBounds
 	}
 
 	rd := bufio.NewReader(io.NewSectionReader(l.rd, int64(offset), int64(readLen)))
@@ -338,7 +339,7 @@ func (l *Loader) getString(strtab *elf.Section64, stroff uint32, maxLen uint16) 
 		if err != nil {
 			switch {
 			case errors.Is(err, io.EOF):
-				return "", &ErrStringTooLong{Name: builder.String(), Len: readLen}
+				return "", &sbpf.ErrStringTooLong{Name: builder.String(), Len: readLen}
 			default:
 				return "", err
 			}

--- a/pkg/sbpf/loader/parse.go
+++ b/pkg/sbpf/loader/parse.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"debug/elf"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -291,26 +292,63 @@ func (l *Loader) readSectionHeaderTable() error {
 	return iter.Err()
 }
 
+// Query a single string from a section which is marked as SHT_STRTAB
+//
+// See https://github.com/anza-xyz/sbpf/blob/main/src/elf_parser/mod.rs#L468
 func (l *Loader) getString(strtab *elf.Section64, stroff uint32, maxLen uint16) (string, error) {
 	if elf.SectionType(strtab.Type) != elf.SHT_STRTAB {
-		return "", fmt.Errorf("invalid strtab")
+		return "", ErrInvalidSectionHeader
 	}
-	offset := strtab.Off + uint64(stroff)
-	if offset > l.fileSize || offset+uint64(maxLen) > l.fileSize {
-		return "", io.ErrUnexpectedEOF
+
+	offset, carry := bits.Add64(strtab.Off, uint64(stroff), 0)
+	if carry != 0 {
+		return "", ErrOutOfBounds
 	}
-	rd := bufio.NewReader(io.NewSectionReader(l.rd, int64(offset), int64(maxLen)))
+
+	sectionEnd, carry := bits.Add64(strtab.Off, strtab.Size, 0)
+	if carry != 0 {
+		return "", ErrOutOfBounds
+	}
+
+	maxEnd, carry := bits.Add64(offset, uint64(maxLen), 0)
+	if carry != 0 {
+		return "", ErrOutOfBounds
+	}
+
+	if sectionEnd < maxEnd {
+		maxEnd = sectionEnd
+	}
+
+	if offset > l.fileSize {
+		return "", ErrOutOfBounds
+	}
+
+	readLen := maxEnd - offset
+	if maxEnd > l.fileSize {
+		readLen = l.fileSize - offset
+	}
+	if readLen == 0 {
+		return "", ErrOutOfBounds
+	}
+
+	rd := bufio.NewReader(io.NewSectionReader(l.rd, int64(offset), int64(readLen)))
 	var builder strings.Builder
 	for {
 		b, err := rd.ReadByte()
 		if err != nil {
-			return "", err
+			switch {
+			case errors.Is(err, io.EOF):
+				return "", &ErrStringTooLong{Name: builder.String(), Len: readLen}
+			default:
+				return "", err
+			}
 		}
-		if b == 0 {
+		if b == 0x00 {
 			break
 		}
 		builder.WriteByte(b)
 	}
+
 	return builder.String(), nil
 }
 

--- a/pkg/sbpf/loader/parse_test.go
+++ b/pkg/sbpf/loader/parse_test.go
@@ -3,6 +3,8 @@ package loader
 import (
 	"debug/elf"
 	"testing"
+
+	"github.com/Overclock-Validator/mithril/pkg/sbpf"
 )
 
 func TestLoader_getString(t *testing.T) {
@@ -28,7 +30,7 @@ func TestLoader_getString(t *testing.T) {
 			stroff:  0,
 			maxLen:  16,
 			want:    "",
-			wantErr: ErrInvalidSectionHeader,
+			wantErr: sbpf.ErrInvalidSectionHeader,
 		},
 		"out of bounds": {
 			buf:     []byte(".text\x00"),
@@ -36,7 +38,7 @@ func TestLoader_getString(t *testing.T) {
 			stroff:  0,
 			maxLen:  16,
 			want:    "",
-			wantErr: ErrOutOfBounds,
+			wantErr: sbpf.ErrOutOfBounds,
 		},
 		"section header too long": {
 			buf:     []byte(".data.rel.ro\x00"),
@@ -44,7 +46,7 @@ func TestLoader_getString(t *testing.T) {
 			stroff:  0,
 			maxLen:  16,
 			want:    "",
-			wantErr: &ErrStringTooLong{Name: ".data.", Len: 6},
+			wantErr: &sbpf.ErrStringTooLong{Name: ".data.", Len: 6},
 		},
 	}
 	for name, tt := range tests {

--- a/pkg/sbpf/loader/parse_test.go
+++ b/pkg/sbpf/loader/parse_test.go
@@ -1,0 +1,68 @@
+package loader
+
+import (
+	"debug/elf"
+	"testing"
+)
+
+func TestLoader_getString(t *testing.T) {
+	tests := map[string]struct {
+		buf     []byte
+		strtab  *elf.Section64
+		stroff  uint32
+		maxLen  uint16
+		want    string
+		wantErr error
+	}{
+		"valid string in section": {
+			buf:     []byte(".text\x00"),
+			strtab:  &elf.Section64{Off: 0, Size: 6, Type: uint32(elf.SHT_STRTAB)},
+			stroff:  0,
+			maxLen:  16,
+			want:    ".text",
+			wantErr: nil,
+		},
+		"invalid section header": {
+			buf:     []byte(".text\x00"),
+			strtab:  &elf.Section64{Off: 0, Size: 6},
+			stroff:  0,
+			maxLen:  16,
+			want:    "",
+			wantErr: ErrInvalidSectionHeader,
+		},
+		"out of bounds": {
+			buf:     []byte(".text\x00"),
+			strtab:  &elf.Section64{Off: 6, Size: 6, Type: uint32(elf.SHT_STRTAB)},
+			stroff:  0,
+			maxLen:  16,
+			want:    "",
+			wantErr: ErrOutOfBounds,
+		},
+		"section header too long": {
+			buf:     []byte(".data.rel.ro\x00"),
+			strtab:  &elf.Section64{Off: 0, Size: 6, Type: uint32(elf.SHT_STRTAB)},
+			stroff:  0,
+			maxLen:  16,
+			want:    "",
+			wantErr: &ErrStringTooLong{Name: ".data.", Len: 6},
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			l, err := NewLoaderFromBytes(tt.buf)
+			if err != nil {
+				t.Fatalf("could not construct receiver type: %v", err)
+			}
+			got, gotErr := l.getString(tt.strtab, tt.stroff, tt.maxLen)
+
+			if gotErr != nil && gotErr.Error() != tt.wantErr.Error() {
+				t.Errorf("getString() failed: %+v", gotErr)
+				return
+			}
+
+			if got != tt.want {
+				t.Errorf("getString() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/sbpf/vm.go
+++ b/pkg/sbpf/vm.go
@@ -1,7 +1,6 @@
 package sbpf
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/Overclock-Validator/mithril/pkg/cu"
@@ -67,17 +66,6 @@ func (e *Exception) Error() string {
 func (e *Exception) Unwrap() error {
 	return e.Detail
 }
-
-// Exception codes.
-var (
-	ExcDivideByZero   = errors.New("divide by zero at BPF instruction")
-	ExcDivideOverflow = errors.New("divide overflow")
-	ExcOutOfCU        = errors.New("compute unit overrun")
-	ExcCallDepth      = errors.New("call depth exceeded")
-	ExcInvalidInstr   = errors.New("invalid instruction - feature not enabled")
-
-	ExcUnsupportedInstruction = errors.New("unsupported BPF instruction")
-)
 
 type ExcBadAccess struct {
 	Addr   uint64


### PR DESCRIPTION
### Problem

Mithril's ELF loader `getString()` function doesn't properly handle string parsing from ELF string tables when the requested maximum length would exceed section bounds.

### Summary of Changes

- migrate [fn get_string_in_section](https://github.com/anza-xyz/sbpf/blob/main/src/elf_parser/mod.rs#L468) logic
- move sbpf-related errors into sbpf package
- replace some unneeded formatings like` fmt.Sprintf("ja")` with strings directly, like `"ja"`

closes #118 

cc @smcio 