### PR TITLE
fix(F-D01): inconsistent error code for empty ELF file

### DIFF
--- a/pkg/sbpf/loader/loader.go
+++ b/pkg/sbpf/loader/loader.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"debug/elf"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 
@@ -14,6 +15,8 @@ import (
 	"github.com/Overclock-Validator/mithril/pkg/sbpf"
 	"github.com/Overclock-Validator/mithril/pkg/sbpf/sbpfver"
 )
+
+var ErrOutOfBounds = errors.New("value out of bounds")
 
 // TODO Fuzz
 // TODO Differential fuzz against rbpf

--- a/pkg/sbpf/loader/parse.go
+++ b/pkg/sbpf/loader/parse.go
@@ -89,9 +89,6 @@ func (l *Loader) newSymTableIter(sh *elf.Section64) (*symTableIter, error) {
 }
 
 func (l *Loader) readHeader() error {
-	if l.fileSize == 0 {
-		return ErrOutOfBounds
-	}
 	if l.fileSize < ehLen {
 		return ErrOutOfBounds
 	}

--- a/pkg/sbpf/loader/parse.go
+++ b/pkg/sbpf/loader/parse.go
@@ -89,6 +89,13 @@ func (l *Loader) newSymTableIter(sh *elf.Section64) (*symTableIter, error) {
 }
 
 func (l *Loader) readHeader() error {
+	if l.fileSize == 0 {
+		return ErrOutOfBounds
+	}
+	if l.fileSize < ehLen {
+		return ErrOutOfBounds
+	}
+
 	var hdrBuf [ehLen]byte
 	if _, err := io.ReadFull(io.NewSectionReader(l.rd, 0, ehLen), hdrBuf[:]); err != nil {
 		return err


### PR DESCRIPTION
### Problem

Mithril's ELF loader returns a different error code than Agave when encountering an empty ELF file

### Summary of Changes

- return error out of bounds when file length is less than size of elf.Header64

closes #130 