### PR TITLE
fix(F-D19): missing UnsupportedInstruction for invalid opcode

### DIFF
--- a/pkg/sbpf/interpreter.go
+++ b/pkg/sbpf/interpreter.go
@@ -1,6 +1,7 @@
 package sbpf
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"math/bits"
@@ -18,6 +19,8 @@ import (
 	"github.com/gagliardetto/solana-go"
 	//"github.com/Overclock-Validator/mithril/pkg/mlog"
 )
+
+var ExcUnsupportedInstruction = errors.New("unsupported BPF instruction")
 
 // Interpreter implements the SBF core in pure Go.
 type Interpreter struct {
@@ -946,7 +949,8 @@ mainLoop:
 				break mainLoop
 			}
 		default:
-			panic(fmt.Sprintf("unimplemented opcode %#02x", ins.Op()))
+			err = ExcUnsupportedInstruction
+			return
 		}
 
 		// Post execute

--- a/pkg/sbpf/interpreter.go
+++ b/pkg/sbpf/interpreter.go
@@ -1,7 +1,6 @@
 package sbpf
 
 import (
-	"errors"
 	"fmt"
 	"math"
 	"math/bits"
@@ -19,8 +18,6 @@ import (
 	"github.com/gagliardetto/solana-go"
 	//"github.com/Overclock-Validator/mithril/pkg/mlog"
 )
-
-var ExcUnsupportedInstruction = errors.New("unsupported BPF instruction")
 
 // Interpreter implements the SBF core in pure Go.
 type Interpreter struct {

--- a/pkg/sbpf/vm.go
+++ b/pkg/sbpf/vm.go
@@ -75,6 +75,8 @@ var (
 	ExcOutOfCU        = errors.New("compute unit overrun")
 	ExcCallDepth      = errors.New("call depth exceeded")
 	ExcInvalidInstr   = errors.New("invalid instruction - feature not enabled")
+
+	ExcUnsupportedInstruction = errors.New("unsupported BPF instruction")
 )
 
 type ExcBadAccess struct {


### PR DESCRIPTION
### Problem

Mithril's sBPF VM interpreter panics when encountering an unimplemented/invalid opcode instead of returning the `UnsupportedInstruction` error that Agave returns.

### Summary of Changes

- added `UnsupportedInstruction` error the same as `agave` has
- return this error instead of panic for invalid opcodes

closes #129

cc @smcio 