### PR TITLE
fix(F-D17): missing Divide-by-Zero Check in OpUrem32Reg

### DIFF
--- a/pkg/sbpf/interpreter.go
+++ b/pkg/sbpf/interpreter.go
@@ -488,7 +488,11 @@ mainLoop:
 				err = ExcInvalidInstr
 				break
 			}
-			r[ins.Dst()] = uint64(uint32(r[ins.Dst()]) % uint32(r[ins.Src()]))
+			if src := r[ins.Src()]; src != 0 {
+				r[ins.Dst()] = uint64(r[ins.Dst()] % src)
+			} else {
+				err = ExcDivideByZero
+			}
 			pc++
 		case OpUrem64Imm:
 			if !ip.sbpfVersion.EnablePqr() {

--- a/pkg/sbpf/vm.go
+++ b/pkg/sbpf/vm.go
@@ -70,7 +70,7 @@ func (e *Exception) Unwrap() error {
 
 // Exception codes.
 var (
-	ExcDivideByZero   = errors.New("division by zero")
+	ExcDivideByZero   = errors.New("divide by zero at BPF instruction")
 	ExcDivideOverflow = errors.New("divide overflow")
 	ExcOutOfCU        = errors.New("compute unit overrun")
 	ExcCallDepth      = errors.New("call depth exceeded")


### PR DESCRIPTION
### Problem

The SBPF interpreter's `OpUrem32Reg` instruction handler is missing a divide-by-zero check, causing a Go runtime panic instead of returning the proper` ExcDivideByZero` error when the source register contains zero.

### Summary of Changes

- changed error text to be the same as `DivideByZero` error of original `sbpf` returns
- added check with returning `DivideByZero` error

closes #127 

cc @smcio 