### PR TITLE
Operational improvements: versioning, state management, graceful shutdown

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -1,0 +1,29 @@
+# Mithril Compatibility
+
+## Policy
+
+- Mithril uses independent semver, not tied to Agave patch versions.
+- A release is compatible with a network only if the expected feature gates match.
+- Testnet and mainnet support are tracked separately.
+
+## Release Matrix
+
+| Mithril | Date | Agave baseline | Gate set | Mainnet | Testnet | Notes |
+|---------|------|----------------|----------|---------|---------|-------|
+| v0.1.0-alpha.1 | TBD | 3.0.x | mainnet-alpha-TBD | supported | not supported | first public alpha |
+
+## Gate Set: mainnet-alpha-TBD
+
+Expected to match Solana mainnet feature gate state at release time.
+
+| Gate name | Feature pubkey | Expected state | Required | Notes |
+|-----------|----------------|----------------|----------|-------|
+| TBD | TBD | TBD | TBD | Fill in before release |
+
+## Network State Snapshot
+
+- mainnet: slot TBD, rpc TBD
+
+## Divergences
+
+- Testnet is not supported for this release.

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ LDFLAGS := -X github.com/Overclock-Validator/mithril/pkg/version.Version=$(VERSI
            -X github.com/Overclock-Validator/mithril/pkg/version.GitCommit=$(GIT_COMMIT) \
            -X github.com/Overclock-Validator/mithril/pkg/version.BuildDate=$(BUILD_DATE)
 
-.PHONY: build release clean
+.PHONY: build release clean server-setup disk-setup tune
 
 build:
 	go build -ldflags "$(LDFLAGS)" -o mithril ./cmd/mithril
@@ -16,3 +16,13 @@ release:
 
 clean:
 	rm -f mithril
+
+# Server setup scripts (require sudo)
+server-setup:
+	sudo ./scripts/server-setup.sh $(ARGS)
+
+disk-setup:
+	sudo ./scripts/disk-setup.sh $(ARGS)
+
+tune:
+	sudo ./scripts/performance-tune.sh $(ARGS)

--- a/Makefile
+++ b/Makefile
@@ -17,12 +17,12 @@ release:
 clean:
 	rm -f mithril
 
-# Server setup scripts (require sudo)
+# Server setup scripts (require sudo - run as: sudo make server-setup ...)
 server-setup:
-	sudo ./scripts/server-setup.sh $(ARGS)
+	./scripts/server-setup.sh $(ARGS)
 
 disk-setup:
-	sudo ./scripts/disk-setup.sh $(ARGS)
+	./scripts/disk-setup.sh $(ARGS)
 
 tune:
-	sudo ./scripts/performance-tune.sh $(ARGS)
+	./scripts/performance-tune.sh $(ARGS)

--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,9 @@ VERSION ?= dev
 GIT_COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 BUILD_DATE := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 
-LDFLAGS := -X main.Version=$(VERSION) \
-           -X main.GitCommit=$(GIT_COMMIT) \
-           -X main.BuildDate=$(BUILD_DATE)
+LDFLAGS := -X github.com/Overclock-Validator/mithril/pkg/version.Version=$(VERSION) \
+           -X github.com/Overclock-Validator/mithril/pkg/version.GitCommit=$(GIT_COMMIT) \
+           -X github.com/Overclock-Validator/mithril/pkg/version.BuildDate=$(BUILD_DATE)
 
 .PHONY: build release clean
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+VERSION ?= dev
+GIT_COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+BUILD_DATE := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+LDFLAGS := -X main.Version=$(VERSION) \
+           -X main.GitCommit=$(GIT_COMMIT) \
+           -X main.BuildDate=$(BUILD_DATE)
+
+.PHONY: build release clean
+
+build:
+	go build -ldflags "$(LDFLAGS)" -o mithril ./cmd/mithril
+
+release:
+	go build -ldflags "$(LDFLAGS) -s -w" -o mithril ./cmd/mithril
+
+clean:
+	rm -f mithril

--- a/README.md
+++ b/README.md
@@ -51,19 +51,19 @@ We provide helper scripts for setting up your system. See the [scripts documenta
 - **Disk Setup** - Benchmark NVMe drives, format with optimal settings, reset Mithril data
 - **Performance Tuning** - Kernel settings, CPU optimization, etc.
 
-The scripts create the following directory structure (following Agave conventions):
+```bash
+# These scripts require root privileges
+sudo ./scripts/disk-setup.sh --setup
+sudo ./scripts/performance-tune.sh
+```
+
+The scripts create the following directory structure and automatically set ownership to your user:
 
 ```
 /mnt/mithril-accounts/   # AccountsDB (needs higher random IOPS - use fastest drive)
 /mnt/mithril-ledger/     # Blockstore and snapshots (can use slower drive)
     ├── blockstore/
     └── snapshots/
-```
-
-After running the disk setup script, set ownership so Mithril can write to these directories:
-
-```bash
-sudo chown -R $USER:$USER /mnt/mithril-accounts /mnt/mithril-ledger
 ```
 
 **Step 3: Install build dependencies**
@@ -151,6 +151,8 @@ See `config.example.toml` for all available configuration options including snap
 ```bash
 ./mithril run --config config.toml
 ```
+
+**Note:** Do not run Mithril with `sudo`. The setup scripts automatically configure directory permissions for your user.
 
 **What happens:**
 1. Mithril queries the Solana cluster to find reliable snapshot sources

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ The `run` command starts Mithril as a live full node - it bootstraps from a Sola
 
 ### Hardware Requirements
 
+> **Tip for new users:** The easiest way to run Mithril is on a dedicated small server or mini PC. This avoids disk management headaches from sharing storage with other applications and simplifies the setup process significantly.
+
 **Operating System**
 - Ubuntu 24.04 LTS (recommended)
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ The scripts create the following directory structure and automatically set owner
 /mnt/mithril-ledger/     # Blockstore and snapshots (can use slower drive)
     ├── blockstore/
     └── snapshots/
+/mnt/mithril-logs/       # Log files (auto-rotated)
 ```
 
 **Step 3: Install build dependencies**

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ While Mithril is already functional and runs reliably for many use cases, it is 
 
 ## Running Mithril
 
-The `run` command starts Mithril as a live verifier - it bootstraps from a Solana snapshot and continuously verifies new blocks as they are produced on mainnet-beta.
+The `run` command starts Mithril as a live full node - it bootstraps from a Solana snapshot and continuously verifies new blocks as they are produced on mainnet-beta.
 
 ### Hardware Requirements
 

--- a/README.md
+++ b/README.md
@@ -197,7 +197,15 @@ We're actively expanding RPC method coverage. Upcoming methods include transacti
 
 ### Current Limitations
 
-- **Block Catchup**: Mithril currently relies on `getBlock` RPC calls to catch up to the tip of mainnet-beta. We are actively working on adding support for direct shred replay, which will be more decentralized and performant.
+- **Block Catchup**: Mithril currently relies on `getBlock` RPC calls to catch up to the tip of mainnet-beta. This dependency is temporary — we are actively working on direct shred replay, which will eliminate the need for external RPC sources entirely.
+
+### RPC Sources
+
+Mithril fetches blocks via `getBlock` RPC calls during catchup. For **short-term testing**, most free RPC plans (Helius, QuickNode, Triton, etc.) are sufficient to try out Mithril.
+
+For **extended testing** or if you'd like to help with longer-running nodes, reach out to us on the [Overclock Validator Discord](https://discord.gg/overclock) — we can provide access to our RPC endpoints.
+
+Once direct shred replay is implemented, external RPC sources will no longer be required for block fetching.
 
 ### Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -148,8 +148,21 @@ See `config.example.toml` for all available configuration options including snap
 
 ### Running Mithril
 
+From inside the `mithril` directory (where you built the binary):
+
 ```bash
-./mithril run --config config.toml
+# If you're not already there:
+cd ~/mithril
+
+# Start Mithril (uses config.toml in current directory by default)
+./mithril run
+```
+
+The `./` prefix tells your shell to run the `mithril` binary in the current directory. Without it, your shell will look for `mithril` in your system PATH.
+
+You can also specify a config file explicitly:
+```bash
+./mithril run --config /path/to/custom-config.toml
 ```
 
 **Note:** Do not run Mithril with `sudo`. The setup scripts automatically configure directory permissions for your user.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,14 @@ Mithril is a Solana full node client written in Golang with the goal of serving 
 
 This project is under active development. We are completing an audit with [Runtime Verification](https://runtimeverification.com/) and expect a more polished, feature-rich release in early Q1 2026.
 
-While Mithril is already functional and runs reliably for many use cases, it is not yet considered production-ready. Users should expect occasional bugs, incomplete features, and ongoing changes as development progresses. Please use with appropriate caution and follow the dev branch for the latest updates.
+While Mithril is already functional and runs reliably for many use cases, it is not yet considered production-ready. Users should expect occasional bugs, incomplete features, and ongoing changes as development progresses. Please use with appropriate caution and follow the **alpha** branch for the latest stable updates.
+
+### Release Channels
+
+- **alpha** (recommended): Latest tagged alpha release. Tested for mainnet and suitable for public use.
+- **dev** (cutting-edge): New features land here first and may be less stable.
+
+Use **alpha** for reliability; use **dev** if you want the newest changes and can tolerate breakage.
 
 ---
 
@@ -44,6 +51,9 @@ The `run` command starts Mithril as a live full node - it bootstraps from a Sola
 ```bash
 git clone https://github.com/Overclock-Validator/mithril.git
 cd mithril
+git checkout alpha  # More stable alpha branch
+# OR
+git checkout dev    # Cutting-edge, may be less stable
 ```
 
 **Step 2 (Optional): Run setup scripts**
@@ -112,42 +122,19 @@ Generate a starter config with sensible defaults:
 ./mithril config init
 ```
 
-This creates `config.toml` with all essential settings. Key options to review:
+This creates `config.toml`. **We strongly recommend reviewing [`config.example.toml`](config.example.toml)** for all available options and detailed documentation.
+
+**Important: RPC Configuration**
+
+The default config uses `api.mainnet-beta.solana.com` as the RPC endpoint, but this public endpoint has rate limits. For reliable operation, add a dedicated RPC provider (Helius, Triton, etc.) as the primary endpoint:
 
 ```toml
-name = "mithril"
-
-[bootstrap]
-    # How Mithril initializes state:
-    #   "auto"         - Use existing AccountsDB if valid, else download snapshot (default)
-    #   "snapshot"     - Use existing snapshot if valid, else download new
-    #   "new-snapshot" - Always download a fresh snapshot
-    #   "accountsdb"   - Require existing AccountsDB, fail if missing
-    mode = "auto"
-
-[storage]
-    # AccountsDB path - use your fastest NVMe
-    accounts = "/mnt/mithril-accounts"
-    # Blockstore (reserved for future block persistence)
-    blockstore = "/mnt/mithril-ledger/blockstore"
-    # Snapshot download location
-    snapshots = "/mnt/mithril-ledger/snapshots"
-
 [network]
-    # Solana RPC endpoint(s) for discovering snapshots and fetching blocks
-    rpc = ["https://api.mainnet-beta.solana.com"]
-
-[replay]
-    # Transaction parallelism - recommended: 2x your CPU core count
-    # e.g., 192 for a 96-core machine, 24 for a 12-core machine
-    txpar = 24
-
-[rpc]
-    # Mithril's RPC server (binds to all interfaces, enabled by default)
-    port = 8899
+    # Primary RPC first, public endpoint as fallback
+    rpc = ["https://your-rpc-provider.com", "https://api.mainnet-beta.solana.com"]
 ```
 
-See `config.example.toml` for all available configuration options including snapshot finder tuning and performance settings.
+Mithril will use the first endpoint for block fetching and fall back to others if needed.
 
 ### Running Mithril
 

--- a/README.md
+++ b/README.md
@@ -232,6 +232,12 @@ For detailed troubleshooting tips, see [docs/TROUBLESHOOTING.md](docs/TROUBLESHO
 
 ---
 
+## Compatibility
+
+See [COMPATIBILITY.md](COMPATIBILITY.md) for supported networks and feature gate requirements per release.
+
+---
+
 ## Development Milestones
 
 ### Milestone 1 (Completed): Reimplementation of the Solana Virtual Machine in Golang

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ We're actively expanding RPC method coverage. Upcoming methods include transacti
 
 ### RPC Sources
 
-Mithril fetches blocks via `getBlock` RPC calls during catchup. For **short-term testing**, most free RPC plans (Helius, QuickNode, Triton, etc.) are sufficient to try out Mithril.
+Mithril fetches blocks via `getBlock` RPC calls during catchup. For **short-term testing**, most free Solana RPC plans are sufficient to try out Mithril.
 
 For **extended testing** or if you'd like to help with longer-running nodes, reach out to us on the [Overclock Validator Discord](https://discord.gg/overclock) — we can provide access to our RPC endpoints.
 

--- a/README.md
+++ b/README.md
@@ -116,15 +116,19 @@ name = "mithril"
 
 [bootstrap]
     # How Mithril initializes state:
-    #   "auto"       - Use existing AccountsDB if valid, else download snapshot (default)
-    #   "snapshot"   - Always download fresh snapshot
-    #   "accountsdb" - Require existing AccountsDB, fail if missing
+    #   "auto"         - Use existing AccountsDB if valid, else download snapshot (default)
+    #   "snapshot"     - Use existing snapshot if valid, else download new
+    #   "new-snapshot" - Always download a fresh snapshot
+    #   "accountsdb"   - Require existing AccountsDB, fail if missing
     mode = "auto"
 
 [storage]
     # AccountsDB path - use your fastest NVMe
     accounts = "/mnt/mithril-accounts"
+    # Blockstore (reserved for future block persistence)
     blockstore = "/mnt/mithril-ledger/blockstore"
+    # Snapshot download location
+    snapshots = "/mnt/mithril-ledger/snapshots"
 
 [network]
     # Solana RPC endpoint(s) for discovering snapshots and fetching blocks
@@ -136,7 +140,7 @@ name = "mithril"
     txpar = 24
 
 [rpc]
-    # Mithril's RPC server (localhost only, enabled by default)
+    # Mithril's RPC server (binds to all interfaces, enabled by default)
     port = 8899
 ```
 
@@ -150,7 +154,7 @@ See `config.example.toml` for all available configuration options including snap
 
 **What happens:**
 1. Mithril queries the Solana cluster to find reliable snapshot sources
-2. The full snapshot is streamed directly into memory and processed
+2. The full snapshot is streamed and processed (optionally saved to disk for faster restarts)
 3. An incremental snapshot is fetched to bring the state closer to the tip
 4. Mithril block execution (aka replay) is initiated and blocks are retrieved with RPC `getBlock` calls and verified
 5. Mithril keeps up very close to the tip of the chain with recommended hardware specs
@@ -182,6 +186,7 @@ curl http://YOUR_MITHRIL_IP:8899 -X POST -H "Content-Type: application/json" -d 
 
 **Currently supported RPC methods:**
 - `getAccountInfo` - Get account data and lamports
+- `getBankHash` - Get bankhash for a slot (Mithril extension, not standard Solana RPC)
 - `getBlockHeight` - Get current block height
 - `getEpochInfo` - Get current epoch info
 - `getLatestBlockhash` - Get recent blockhash
@@ -222,7 +227,7 @@ go build -o mithril ./cmd/mithril
 ./mithril run --config config.toml
 ```
 
-**Note:** The default `bootstrap.mode = "auto"` will reuse an existing valid AccountsDB when available, otherwise it downloads a snapshot. Set `bootstrap.mode = "snapshot"` to always start fresh from a snapshot, or `bootstrap.mode = "new-snapshot"` to always download a new one.
+**Note:** The default `bootstrap.mode = "auto"` will reuse an existing valid AccountsDB when available, otherwise it downloads a snapshot. Set `bootstrap.mode = "snapshot"` to use an existing snapshot if available, or `bootstrap.mode = "new-snapshot"` to always download a fresh one.
 
 ### Operational Best Practices
 

--- a/cmd/mithril/configcmd/configcmd.go
+++ b/cmd/mithril/configcmd/configcmd.go
@@ -129,6 +129,7 @@ blockstore = "/mnt/mithril-ledger/blockstore" # NOTE: block persistence temporar
 snapshots = "/mnt/mithril-ledger/snapshots"  # ~100GB for full + incremental
 
 [network]
+cluster = "mainnet-beta"  # Required: "mainnet-beta" | "testnet" | "devnet"
 rpc = ["https://api.mainnet-beta.solana.com"]
 
 [block]

--- a/cmd/mithril/configcmd/configcmd.go
+++ b/cmd/mithril/configcmd/configcmd.go
@@ -133,8 +133,8 @@ cluster = "mainnet-beta"  # Required: "mainnet-beta" | "testnet" | "devnet"
 rpc = ["https://api.mainnet-beta.solana.com"]
 
 [block]
-source = "rpc"   # "rpc" | "overcast" (overcast temporarily disabled, falls back to rpc)
-# overcast_endpoint = "localhost:9000"
+source = "rpc"   # "rpc" | "lightbringer" (lightbringer temporarily disabled, falls back to rpc)
+# lightbringer_endpoint = "localhost:9000"
 
 [replay]
 txpar = 24   # Recommended: 2x your CPU core count

--- a/cmd/mithril/configcmd/configcmd.go
+++ b/cmd/mithril/configcmd/configcmd.go
@@ -142,6 +142,13 @@ txpar = 24   # Recommended: 2x your CPU core count
 [rpc]
 port = 8899  # Mithril's RPC server (binds to all interfaces)
 
+[log]
+dir = "/mnt/mithril-logs"  # Log files (created if missing)
+level = "info"             # "debug" | "info" | "warn" | "error"
+to_stdout = true           # Also write to stdout
+max_size_mb = 100          # Max log file size before rotation
+max_age_days = 7           # Delete logs older than this
+
 # Advanced options (defaults work well for most setups)
 # See config.example.toml for: [tuning], [debug], [snapshot], [reporting]
 `

--- a/cmd/mithril/configcmd/configcmd.go
+++ b/cmd/mithril/configcmd/configcmd.go
@@ -121,7 +121,7 @@ func generateStarterConfig() string {
 name = "mithril"
 
 [bootstrap]
-mode = "snapshot"   # "auto" | "snapshot" | "accountsdb"
+mode = "auto"   # "auto" | "snapshot" | "new-snapshot" | "accountsdb"
 
 [storage]
 accounts = "/mnt/mithril-accounts"           # AccountsDB (~500GB, use fastest NVMe)
@@ -140,7 +140,7 @@ source = "rpc"   # "rpc" | "overcast" (overcast temporarily disabled, falls back
 txpar = 24   # Recommended: 2x your CPU core count
 
 [rpc]
-port = 8899  # Mithril's RPC server (localhost only)
+port = 8899  # Mithril's RPC server (binds to all interfaces)
 
 # Advanced options (defaults work well for most setups)
 # See config.example.toml for: [tuning], [debug], [snapshot], [reporting]

--- a/cmd/mithril/main.go
+++ b/cmd/mithril/main.go
@@ -20,9 +20,12 @@ import (
 
 var cmd = cobra.Command{
 	Use:     "mithril",
-	Short:   "mithril Solana verifier node",
+	Short:   "Mithril - Solana full node client",
 	Version: Version,
-	Long: `Mithril is a lightweight Solana verifier node that replays and validates transactions.
+	Long: `Mithril - Solana Full Node Client
+
+A lightweight full node client for Solana written in Go. Mithril replays and
+validates transactions, enabling independent verification of the Solana blockchain.
 
 Quick start:
   1. mithril config init              # Generate config.toml
@@ -31,8 +34,7 @@ Quick start:
 
 Disk setup (recommended before first run):
   sudo ./scripts/disk-setup.sh --setup    # Format and mount NVMe drives
-  ./scripts/disk-setup.sh --status        # Show current storage status
-  ./scripts/disk-setup.sh                 # Show all disk commands`,
+  ./scripts/disk-setup.sh --status        # Show current storage status`,
 }
 
 func init() {

--- a/cmd/mithril/main.go
+++ b/cmd/mithril/main.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/Overclock-Validator/mithril/cmd/mithril/configcmd"
 	"github.com/Overclock-Validator/mithril/cmd/mithril/node"
+	"github.com/Overclock-Validator/mithril/cmd/mithril/statecmd"
 	"github.com/Overclock-Validator/mithril/pkg/config"
 	"github.com/spf13/cobra"
 	"k8s.io/klog/v2"
@@ -45,6 +46,7 @@ func init() {
 	cmd.AddCommand(
 		&node.Run,              // Primary command for running Mithril
 		&configcmd.ConfigCmd,   // Config management (init, etc.)
+		&statecmd.StateCmd,     // State file inspection and management
 		&node.VerifyRange,      // Developer/advanced command
 		&node.VerifyLive,       // Backwards compatibility alias for Run
 	)

--- a/cmd/mithril/main.go
+++ b/cmd/mithril/main.go
@@ -18,8 +18,9 @@ import (
 )
 
 var cmd = cobra.Command{
-	Use:   "mithril",
-	Short: "mithril Solana verifier node",
+	Use:     "mithril",
+	Short:   "mithril Solana verifier node",
+	Version: Version,
 	Long: `Mithril is a lightweight Solana verifier node that replays and validates transactions.
 
 Quick start:

--- a/cmd/mithril/node/node.go
+++ b/cmd/mithril/node/node.go
@@ -107,6 +107,7 @@ var (
 	blockNearTipLookahead int // Slots ahead to schedule in near-tip
 
 	snapshotDlPath string
+	logDir         string
 	numReplaySlots              int64
 	endSlot                     int64
 	pprofPort                   int64
@@ -1019,6 +1020,9 @@ func runLive(c *cobra.Command, args []string) {
 		logCfg.MaxBackups = 10
 	}
 
+	// Store log dir for startup info display
+	logDir = logCfg.Dir
+
 	if err := mlog.Initialize(logCfg, replay.CurrentRunID); err != nil {
 		// Non-fatal, continue with stdout-only logging
 		fmt.Fprintf(os.Stderr, "warning: failed to initialize file logging: %v\n", err)
@@ -1888,6 +1892,11 @@ func printStartupInfo(commandName string) {
 		}
 	}
 
+	// Log directory
+	if logDir != "" {
+		fmt.Printf("  Logs:         %s%s%s\n", gold, logDir, reset)
+	}
+
 	// Block source
 	fmt.Printf("  Block source: %s%s%s", gold, blockSource, reset)
 	if blockSource == "lightbringer" {
@@ -1904,43 +1913,6 @@ func printStartupInfo(commandName string) {
 			fmt.Printf("                %s%s%s (fallback)\n", gold, ep, reset)
 		}
 	}
-
-	// Block mode config (resolve defaults for display)
-	fmt.Println()
-	fmt.Printf("%s━━━ Block Mode Config ━━━%s\n", gold, reset)
-
-	// Resolve actual values that will be used (0 means default will be applied in BlockSource)
-	displayNearTip := blockNearTipThreshold
-	if displayNearTip == 0 {
-		displayNearTip = 32
-	}
-	displayCatchup := blockCatchupThreshold
-	if displayCatchup == 0 {
-		displayCatchup = 64
-	}
-	displayTipGate := blockCatchupTipGateThreshold
-	if displayTipGate == 0 {
-		displayTipGate = 128
-	}
-	displaySafetyMargin := blockTipSafetyMargin
-	if displaySafetyMargin == 0 {
-		displaySafetyMargin = 64
-	}
-	displayNearTipPoll := blockNearTipPollMs
-	if displayNearTipPoll == 0 {
-		displayNearTipPoll = 500
-	}
-	displayNearTipLookahead := blockNearTipLookahead
-	if displayNearTipLookahead == 0 {
-		displayNearTipLookahead = 2
-	}
-
-	fmt.Printf("  %snear_tip_threshold=%d, catchup_threshold=%d%s\n",
-		dim, displayNearTip, displayCatchup, reset)
-	fmt.Printf("  %stip_safety_margin=%d (applies only when gap > %d)%s\n",
-		dim, displaySafetyMargin, displayTipGate, reset)
-	fmt.Printf("  %snear_tip_poll_interval_ms=%d, near_tip_lookahead=%d%s\n",
-		dim, displayNearTipPoll, displayNearTipLookahead, reset)
 
 	fmt.Println()
 }

--- a/cmd/mithril/node/node.go
+++ b/cmd/mithril/node/node.go
@@ -1188,12 +1188,13 @@ func runLive(c *cobra.Command, args []string) {
 		}
 
 		if hasValidState {
-			// Check if AccountsDB is stale (significantly behind chain tip)
+			// Check if AccountsDB is behind chain tip (more than 2000 slots triggers prompt)
 			// Use queryCurrentSlot instead of queryLatestSnapshotSlot to avoid expensive node discovery
+			const stalePromptThreshold = 2000
 			currentSlot, err := queryCurrentSlot(ctx, rpcEndpoints)
 			if err != nil {
 				mlog.Log.Infof("could not query current slot: %v (continuing with existing AccountsDB)", err)
-			} else if mithrilState.IsStale(currentSlot, uint64(fullThreshold)) {
+			} else if mithrilState.IsStale(currentSlot, stalePromptThreshold) {
 				slotsBehind := currentSlot - mithrilState.GetCurrentSlot()
 				mlog.Log.Infof("AccountsDB is %d slots behind chain tip", slotsBehind)
 

--- a/cmd/mithril/node/node.go
+++ b/cmd/mithril/node/node.go
@@ -35,6 +35,7 @@ import (
 	"github.com/Overclock-Validator/mithril/pkg/snapshotdl"
 	"github.com/Overclock-Validator/mithril/pkg/state"
 	"github.com/Overclock-Validator/mithril/pkg/statsd"
+	"github.com/Overclock-Validator/mithril/pkg/version"
 	solrpc "github.com/gagliardetto/solana-go/rpc"
 	"github.com/mr-tron/base58"
 	"github.com/spf13/cobra"
@@ -982,6 +983,13 @@ func runLive(c *cobra.Command, args []string) {
 	// Use configured snapshot directory (storage.snapshots / snapshot.download_path), not scratch
 	snapshotDownloadPath := snapshotDlPath
 
+	// Prune old history entries if needed (keeps last 100)
+	if accountsPath != "" {
+		if err := state.PruneHistory(accountsPath); err != nil {
+			mlog.Log.Errorf("failed to prune state history: %v", err)
+		}
+	}
+
 	// Check for valid state file first (this is the authoritative source of truth)
 	mithrilState, _ = state.CheckAndLoadValidState(accountsPath)
 	hasValidState := mithrilState != nil
@@ -1071,6 +1079,8 @@ func runLive(c *cobra.Command, args []string) {
 		if err := mithrilState.Save(accountsPath); err != nil {
 			mlog.Log.Errorf("failed to save state file: %v", err)
 		}
+		// Record bootstrap in history
+		state.RecordBootstrap(accountsPath, manifest.Bank.Slot, "", replay.CurrentRunID, getVersion(), getCommit())
 
 	case "snapshot":
 		// Mode: Rebuild AccountsDB from snapshot, reuse existing snapshot file if fresh enough
@@ -1125,6 +1135,8 @@ func runLive(c *cobra.Command, args []string) {
 		if err := mithrilState.Save(accountsPath); err != nil {
 			mlog.Log.Errorf("failed to save state file: %v", err)
 		}
+		// Record bootstrap in history
+		state.RecordBootstrap(accountsPath, manifest.Bank.Slot, "", replay.CurrentRunID, getVersion(), getCommit())
 
 	case "auto":
 		fallthrough
@@ -1191,12 +1203,16 @@ func runLive(c *cobra.Command, args []string) {
 					if err := mithrilState.Save(accountsPath); err != nil {
 						mlog.Log.Errorf("failed to save state file: %v", err)
 					}
+					// Record bootstrap in history
+					state.RecordBootstrap(accountsPath, manifest.Bank.Slot, "", replay.CurrentRunID, getVersion(), getCommit())
 					break // Exit the switch, continue with fresh AccountsDB
 				}
 				// choice == 1: continue with existing AccountsDB
 			}
 
 			mlog.Log.Infof("mode=auto: resuming from existing AccountsDB at slot %d", accountsDBSlot)
+			// Record resume in history
+			state.RecordResume(accountsPath, mithrilState.LastSlot, mithrilState.LastBankhash, replay.CurrentRunID, getVersion(), getCommit())
 			accountsDb, err = accountsdb.OpenDb(accountsPath)
 			if err != nil {
 				klog.Fatalf("failed to open AccountsDB at %s: %v", accountsPath, err)
@@ -1217,6 +1233,8 @@ func runLive(c *cobra.Command, args []string) {
 					mlog.Log.Errorf("failed to mark state as corrupted: %v", markErr)
 				} else {
 					mlog.Log.Infof("state file updated to indicate corruption")
+					// Record corruption in history
+					state.RecordCorrupted(accountsPath, mithrilState.LastSlot, mithrilState.LastBankhash, replay.CurrentRunID, getVersion(), getCommit(), err.Error())
 				}
 
 				// Close AccountsDB before exiting
@@ -1287,6 +1305,8 @@ func runLive(c *cobra.Command, args []string) {
 			if err := mithrilState.Save(accountsPath); err != nil {
 				mlog.Log.Errorf("failed to save state file: %v", err)
 			}
+			// Record bootstrap in history
+			state.RecordBootstrap(accountsPath, manifest.Bank.Slot, "", replay.CurrentRunID, getVersion(), getCommit())
 		}
 	}
 
@@ -1381,6 +1401,8 @@ func runLive(c *cobra.Command, args []string) {
 		if err := mithrilState.Save(accountsPath); err != nil {
 			mlog.Log.Errorf("failed to save state file: %v", err)
 		}
+		// Record bootstrap in history
+		state.RecordBootstrap(accountsPath, manifest.Bank.Slot, "", replay.CurrentRunID, getVersion(), getCommit())
 	}
 
 	liveEndSlot := uint64(math.MaxUint64)
@@ -1481,9 +1503,16 @@ func runLive(c *cobra.Command, args []string) {
 				// Shutdown tracking
 				ShutdownReason: shutdownReason,
 			}
-		}
-		if err := mithrilState.UpdateLastSlotWithContext(accountsPath, result.LastPersistedSlot, result.LastPersistedBankhash, resumeCtx); err != nil {
-			mlog.Log.Errorf("failed to update state file: %v", err)
+			// Record shutdown in history (must be inside this block where shutdownReason is defined)
+			if err := mithrilState.UpdateLastSlotWithContext(accountsPath, result.LastPersistedSlot, result.LastPersistedBankhash, resumeCtx); err != nil {
+				mlog.Log.Errorf("failed to update state file: %v", err)
+			}
+			state.RecordShutdown(accountsPath, result.LastPersistedSlot, base58.Encode(result.LastPersistedBankhash), replay.CurrentRunID, getVersion(), getCommit(), shutdownReason)
+		} else {
+			// No resume context - just update slot
+			if err := mithrilState.UpdateLastSlotWithContext(accountsPath, result.LastPersistedSlot, result.LastPersistedBankhash, resumeCtx); err != nil {
+				mlog.Log.Errorf("failed to update state file: %v", err)
+			}
 		}
 	}
 
@@ -1527,16 +1556,14 @@ func getCommitHash() string {
 	return ""
 }
 
-// getVersion returns the build version (set via ldflags or defaults to "dev")
-// TODO: Wire this up to the Version variable in cmd/mithril/version.go via a shared package
+// getVersion returns the build version from the shared version package.
 func getVersion() string {
-	return "dev" // Placeholder - will be set by ldflags at build time
+	return version.Version
 }
 
-// getCommit returns the git commit hash (set via ldflags or defaults to "unknown")
-// TODO: Wire this up to the GitCommit variable in cmd/mithril/version.go via a shared package
+// getCommit returns the git commit hash from the shared version package.
 func getCommit() string {
-	return "unknown" // Placeholder - will be set by ldflags at build time
+	return version.GitCommit
 }
 
 // fetchGenesisHash fetches the genesis hash from the first RPC endpoint.
@@ -2264,6 +2291,9 @@ func runReplayWithRecovery(
 					reason := fmt.Sprintf("panic during commit at slot %d: %v", commitSlot, r)
 					if err := mithrilState.MarkCorrupted(accountsDbPath, reason); err != nil {
 						mlog.Log.Errorf("[run:%s] Failed to mark state as corrupted: %v", runID, err)
+					} else {
+						// Record corruption in history
+						state.RecordCorrupted(accountsDbPath, mithrilState.LastSlot, mithrilState.LastBankhash, runID, getVersion(), getCommit(), reason)
 					}
 				}
 			} else {

--- a/cmd/mithril/node/node.go
+++ b/cmd/mithril/node/node.go
@@ -88,6 +88,7 @@ var (
 	accountsPath                string
 	scratchDirectory            string
 	rpcEndpoints                []string
+	cluster                     string   // "mainnet-beta", "testnet", "devnet"
 	blockSource                 string   // "rpc" or "overcast"
 	overcastEndpoint            string
 	blockMaxRPS                 int      // Rate limit for block fetching
@@ -170,8 +171,11 @@ func init() {
 	Run.Flags().StringVarP(&accountsPath, "accounts-path", "o", "", "Output path for writing AccountsDB data to")
 	Run.Flags().StringVar(&blockstorePath, "ledger-path", "/tmp/blocks", "Path containing slot.json files")
 
-	// [rpc] section flags
+	// [network] section flags
 	Run.Flags().StringSliceVarP(&rpcEndpoints, "rpc", "r", []string{}, "URL(s) for RPC endpoint(s) - can specify multiple")
+	Run.Flags().StringVar(&cluster, "cluster", "", "Solana cluster: 'mainnet-beta', 'testnet', or 'devnet'")
+
+	// [rpc] section flags (Mithril's RPC server)
 	Run.Flags().IntVar(&rpcPort, "rpc-port", 0, "RPC server port. Default off.")
 
 	// [replay] section flags
@@ -360,6 +364,19 @@ func initConfigAndBindFlags(cmd *cobra.Command) error {
 	rpcEndpoints = getStringSlice("rpc", "network.rpc")
 	if len(rpcEndpoints) == 0 {
 		rpcEndpoints = getStringSlice("rpc", "rpc.rpc")
+	}
+
+	// Cluster is required for safety (prevents mainnet/testnet mixups)
+	cluster = getString("cluster", "network.cluster")
+	if cluster == "" {
+		return fmt.Errorf("network.cluster is required - set to 'mainnet-beta', 'testnet', or 'devnet'")
+	}
+	// Validate cluster value
+	switch cluster {
+	case "mainnet-beta", "testnet", "devnet":
+		// Valid
+	default:
+		return fmt.Errorf("invalid network.cluster %q - must be 'mainnet-beta', 'testnet', or 'devnet'", cluster)
 	}
 
 	// [rpc] section - Mithril's RPC server
@@ -862,7 +879,10 @@ func runVerifyRange(c *cobra.Command, args []string) {
 				// Run tracking - for log correlation
 				RunID:        replay.CurrentRunID,
 				RunStartedAt: replayStartTime,
-				Commit:       getCommitHash(),
+
+				// Writer info
+				WriterVersion: getVersion(),
+				WriterCommit:  getCommitHash(),
 
 				// Shutdown tracking
 				ShutdownReason: shutdownReason,
@@ -966,6 +986,24 @@ func runLive(c *cobra.Command, args []string) {
 	mithrilState, _ = state.CheckAndLoadValidState(accountsPath)
 	hasValidState := mithrilState != nil
 
+	// Validate genesis hash if we have a valid state (prevents mainnet/testnet mixups)
+	if hasValidState {
+		genesisHash := fetchGenesisHash(ctx)
+		if genesisHash != "" {
+			if err := mithrilState.ValidateGenesisHash(genesisHash); err != nil {
+				klog.Fatalf("FATAL: %v\nThis AccountsDB was built for a different cluster. Use --bootstrap-mode=snapshot to rebuild.", err)
+			}
+			// If state has no genesis hash (older version), set it now
+			if mithrilState.GenesisHash == "" {
+				mlog.Log.Infof("updating state file with cluster=%s genesis=%s", cluster, genesisHash[:12]+"...")
+				mithrilState.SetClusterInfo(cluster, genesisHash)
+				if err := mithrilState.Save(accountsPath); err != nil {
+					mlog.Log.Infof("WARNING: failed to update state file with cluster info: %v", err)
+				}
+			}
+		}
+	}
+
 	// Fall back to legacy detection if no state file
 	hasAccountsDB, accountsDBSlot := detectExistingAccountsDB(accountsPath)
 	if hasValidState {
@@ -1006,6 +1044,12 @@ func runLive(c *cobra.Command, args []string) {
 		}
 		mlog.Log.Infof("mode=new-snapshot: downloading fresh snapshot")
 		if accountsPath != "" {
+			// Record rebuild in history before cleanup (history file is preserved)
+			if mithrilState != nil {
+				state.RecordRebuild(accountsPath, mithrilState.LastSlot, mithrilState.LastBankhash, getVersion(), getCommit(), "new-snapshot mode")
+			} else {
+				state.RecordRebuild(accountsPath, 0, "", getVersion(), getCommit(), "new-snapshot mode (no prior state)")
+			}
 			mlog.Log.Infof("cleaning up previous AccountsDB artifacts in %s", accountsPath)
 			snapshot.CleanAccountsDbDir(accountsPath)
 		}
@@ -1035,6 +1079,12 @@ func runLive(c *cobra.Command, args []string) {
 		}
 		mlog.Log.Infof("mode=snapshot: will rebuild AccountsDB from snapshot")
 		if accountsPath != "" {
+			// Record rebuild in history before cleanup (history file is preserved)
+			if mithrilState != nil {
+				state.RecordRebuild(accountsPath, mithrilState.LastSlot, mithrilState.LastBankhash, getVersion(), getCommit(), "snapshot mode")
+			} else {
+				state.RecordRebuild(accountsPath, 0, "", getVersion(), getCommit(), "snapshot mode (no prior state)")
+			}
 			mlog.Log.Infof("cleaning up previous AccountsDB artifacts in %s", accountsPath)
 			snapshot.CleanAccountsDbDir(accountsPath)
 		}
@@ -1109,6 +1159,9 @@ func runLive(c *cobra.Command, args []string) {
 					}
 					mlog.Log.Infof("user chose to rebuild from latest snapshot")
 					if accountsPath != "" {
+						// Record rebuild in history before cleanup (history file is preserved)
+						// mithrilState is guaranteed non-nil here (we prompted because it was stale)
+						state.RecordRebuild(accountsPath, mithrilState.LastSlot, mithrilState.LastBankhash, getVersion(), getCommit(), "user chose rebuild (stale AccountsDB)")
 						snapshot.CleanAccountsDbDir(accountsPath)
 					}
 					// Check for existing fresh snapshot
@@ -1183,6 +1236,19 @@ func runLive(c *cobra.Command, args []string) {
 				mlog.Log.Infof("mode=auto: no existing AccountsDB, will download snapshot")
 			}
 			if accountsPath != "" {
+				// Record rebuild in history before cleanup (history file is preserved)
+				// Try to load any existing state (even invalid) to capture slot info
+				var reason string
+				if hasAccountsDB {
+					reason = "auto mode (AccountsDB exists but state invalid)"
+				} else {
+					reason = "auto mode (no existing AccountsDB)"
+				}
+				if existingState, _ := state.LoadState(accountsPath); existingState != nil {
+					state.RecordRebuild(accountsPath, existingState.LastSlot, existingState.LastBankhash, getVersion(), getCommit(), reason)
+				} else {
+					state.RecordRebuild(accountsPath, 0, "", getVersion(), getCommit(), reason)
+				}
 				mlog.Log.Infof("cleaning up previous AccountsDB artifacts in %s", accountsPath)
 				snapshot.CleanAccountsDbDir(accountsPath)
 			}
@@ -1209,7 +1275,15 @@ func runLive(c *cobra.Command, args []string) {
 			if sealevel.SysvarCache.EpochSchedule.Sysvar != nil {
 				snapshotEpoch = sealevel.SysvarCache.EpochSchedule.Sysvar.GetEpoch(manifest.Bank.Slot)
 			}
-			mithrilState = state.NewReadyState(manifest.Bank.Slot, snapshotEpoch, "", "", 0, 0)
+			mithrilState = state.NewReadyStateWithOpts(state.NewReadyStateOpts{
+				SnapshotSlot:  manifest.Bank.Slot,
+				SnapshotEpoch: snapshotEpoch,
+				BuildMode:     bootstrapMode,
+				Cluster:       cluster,
+				GenesisHash:   fetchGenesisHash(ctx),
+				WriterVersion: getVersion(),
+				WriterCommit:  getCommitHash(),
+			})
 			if err := mithrilState.Save(accountsPath); err != nil {
 				mlog.Log.Errorf("failed to save state file: %v", err)
 			}
@@ -1399,7 +1473,10 @@ func runLive(c *cobra.Command, args []string) {
 				// Run tracking - for log correlation
 				RunID:        replay.CurrentRunID,
 				RunStartedAt: replayStartTime,
-				Commit:       getCommitHash(),
+
+				// Writer info
+				WriterVersion: getVersion(),
+				WriterCommit:  getCommitHash(),
 
 				// Shutdown tracking
 				ShutdownReason: shutdownReason,
@@ -1448,6 +1525,33 @@ func getCommitHash() string {
 		}
 	}
 	return ""
+}
+
+// getVersion returns the build version (set via ldflags or defaults to "dev")
+// TODO: Wire this up to the Version variable in cmd/mithril/version.go via a shared package
+func getVersion() string {
+	return "dev" // Placeholder - will be set by ldflags at build time
+}
+
+// getCommit returns the git commit hash (set via ldflags or defaults to "unknown")
+// TODO: Wire this up to the GitCommit variable in cmd/mithril/version.go via a shared package
+func getCommit() string {
+	return "unknown" // Placeholder - will be set by ldflags at build time
+}
+
+// fetchGenesisHash fetches the genesis hash from the first RPC endpoint.
+// Returns empty string on error (caller should log and continue).
+func fetchGenesisHash(ctx context.Context) string {
+	if len(rpcEndpoints) == 0 {
+		return ""
+	}
+	client := solrpc.New(rpcEndpoints[0])
+	hash, err := client.GetGenesisHash(ctx)
+	if err != nil {
+		mlog.Log.Infof("WARNING: failed to fetch genesis hash from RPC: %v", err)
+		return ""
+	}
+	return hash.String()
 }
 
 // formatDurationShort formats a duration in a compact human-readable format (e.g., "2h 30m", "45m", "3d 2h")

--- a/cmd/mithril/node/node.go
+++ b/cmd/mithril/node/node.go
@@ -924,7 +924,7 @@ func runVerifyRange(c *cobra.Command, args []string) {
 
 				// Writer info
 				WriterVersion: getVersion(),
-				WriterCommit:  getCommitHash(),
+				WriterCommit:  getCommit(),
 
 				// Shutdown tracking
 				ShutdownReason: shutdownReason,
@@ -949,7 +949,7 @@ func runVerifyRange(c *cobra.Command, args []string) {
 			SnapshotBaseSlot: snapshotBaseSlot,
 			AccountsDBPath:   accountsDbDir,
 			ReplayDuration:   time.Since(replayStartTime),
-			WasCancelled:     true,
+			WasCancelled:     result.WasCancelled,
 			RunID:            replay.CurrentRunID,
 			Epoch:            epoch,
 			SnapshotEpoch:    snapshotEpoch,
@@ -965,6 +965,47 @@ func runLive(c *cobra.Command, args []string) {
 
 	// Print the Mithril banner first, before any other output
 	progress.PrintBanner()
+
+	// Generate run ID early so it's available for logging and state tracking
+	replay.CurrentRunID = replay.GenerateRunID()
+
+	// Initialize file logging
+	logCfg := mlog.LogConfig{
+		Dir:        config.GetString("log.dir"),
+		Level:      config.GetString("log.level"),
+		ToStdout:   true, // Default true, override if explicitly set false
+		MaxSizeMB:  config.GetInt("log.max_size_mb"),
+		MaxAgeDays: config.GetInt("log.max_age_days"),
+		MaxBackups: config.GetInt("log.max_backups"),
+	}
+	// Handle to_stdout explicitly (viper returns false for missing bool)
+	if config.IsSet("log.to_stdout") {
+		logCfg.ToStdout = config.GetBool("log.to_stdout")
+	}
+	// Apply defaults if not set
+	if logCfg.Dir == "" {
+		logCfg.Dir = "/mnt/mithril-logs"
+	}
+	if logCfg.Level == "" {
+		logCfg.Level = "info"
+	}
+	if logCfg.MaxSizeMB == 0 {
+		logCfg.MaxSizeMB = 100
+	}
+	if logCfg.MaxAgeDays == 0 {
+		logCfg.MaxAgeDays = 7
+	}
+	if logCfg.MaxBackups == 0 {
+		logCfg.MaxBackups = 10
+	}
+
+	if err := mlog.Initialize(logCfg, replay.CurrentRunID); err != nil {
+		// Non-fatal, continue with stdout-only logging
+		fmt.Fprintf(os.Stderr, "warning: failed to initialize file logging: %v\n", err)
+	} else if logPath := mlog.GetLogPath(); logPath != "" {
+		fmt.Printf("  Log file: %s\n", logPath)
+	}
+	defer mlog.Shutdown()
 
 	// Kill any existing mithril processes to prevent zombie accumulation
 	if killed := killExistingMithrilProcesses(); killed > 0 {
@@ -1342,7 +1383,7 @@ func runLive(c *cobra.Command, args []string) {
 				Cluster:       cluster,
 				GenesisHash:   fetchGenesisHash(ctx),
 				WriterVersion: getVersion(),
-				WriterCommit:  getCommitHash(),
+				WriterCommit:  getCommit(),
 			})
 			if err := mithrilState.Save(accountsPath); err != nil {
 				mlog.Log.Errorf("failed to save state file: %v", err)
@@ -1541,7 +1582,7 @@ func runLive(c *cobra.Command, args []string) {
 
 				// Writer info
 				WriterVersion: getVersion(),
-				WriterCommit:  getCommitHash(),
+				WriterCommit:  getCommit(),
 
 				// Shutdown tracking
 				ShutdownReason: shutdownReason,
@@ -1582,21 +1623,6 @@ func runLive(c *cobra.Command, args []string) {
 
 	mlog.Log.Infof("done replaying, closing DB")
 	accountsDb.CloseDb()
-}
-
-// getCommitHash returns the short git commit hash from build info
-func getCommitHash() string {
-	if info, ok := debug.ReadBuildInfo(); ok {
-		for _, setting := range info.Settings {
-			if setting.Key == "vcs.revision" {
-				if len(setting.Value) > 8 {
-					return setting.Value[:8]
-				}
-				return setting.Value
-			}
-		}
-	}
-	return ""
 }
 
 // getVersion returns the build version from the shared version package.
@@ -2360,7 +2386,7 @@ func runReplayWithRecovery(
 
 				// Writer info
 				WriterVersion: getVersion(),
-				WriterCommit:  getCommitHash(),
+				WriterCommit:  getCommit(),
 
 				// Shutdown tracking - this is always a cancel (Ctrl+C)
 				ShutdownReason: state.ShutdownReasonNormal,

--- a/cmd/mithril/node/node.go
+++ b/cmd/mithril/node/node.go
@@ -214,6 +214,42 @@ func init() {
 	VerifyLive.Flags().AddFlagSet(Run.Flags())
 }
 
+// checkDirWritable verifies the current user can write to a directory.
+// Returns an error with a helpful fix message if the directory exists but is not writable.
+func checkDirWritable(path, description string) error {
+	if path == "" {
+		return nil
+	}
+
+	info, err := os.Stat(path)
+	if os.IsNotExist(err) {
+		// Directory doesn't exist yet - will be created later
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("cannot access %s at %s: %v", description, path, err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("%s path is not a directory: %s", description, path)
+	}
+
+	// Try to create a temp file to verify write permission
+	testFile := filepath.Join(path, ".mithril_write_test")
+	f, err := os.Create(testFile)
+	if err != nil {
+		// Get owner info for helpful error message
+		if stat, ok := info.Sys().(*syscall.Stat_t); ok {
+			return fmt.Errorf("%s directory not writable: %s (owned by uid %d, running as uid %d)\n\nFix: sudo chown -R $USER:$USER %s",
+				description, path, stat.Uid, os.Getuid(), path)
+		}
+		return fmt.Errorf("%s directory not writable: %s\n\nFix: sudo chown -R $USER:$USER %s",
+			description, path, path)
+	}
+	f.Close()
+	os.Remove(testFile)
+	return nil
+}
+
 // initConfigAndBindFlags loads TOML config file (if specified) and binds flags to viper.
 // After this runs, config values can be read from either CLI flags or config file,
 // with CLI flags taking precedence.
@@ -355,6 +391,10 @@ func initConfigAndBindFlags(cmd *cobra.Command) error {
 	accountsPath = getString("accounts-path", "storage.accounts")
 	if accountsPath == "" {
 		accountsPath = getString("accounts-path", "ledger.accounts_path")
+	}
+	// Check write permission early to fail fast with helpful error
+	if err := checkDirWritable(accountsPath, "AccountsDB"); err != nil {
+		return err
 	}
 	blockstorePath = getString("ledger-path", "storage.blockstore")
 	if blockstorePath == "" {

--- a/cmd/mithril/node/node.go
+++ b/cmd/mithril/node/node.go
@@ -1652,9 +1652,26 @@ func getVersion() string {
 	return version.Version
 }
 
-// getCommit returns the git commit hash from the shared version package.
+// getCommit returns the git commit hash, preferring ldflags but falling back to
+// runtime/debug.BuildInfo for dev builds.
 func getCommit() string {
-	return version.GitCommit
+	// If set via ldflags (release builds), use that
+	if version.GitCommit != "" && version.GitCommit != "unknown" {
+		return version.GitCommit
+	}
+	// Fallback to runtime/debug for dev builds (go build without ldflags)
+	if info, ok := debug.ReadBuildInfo(); ok {
+		for _, setting := range info.Settings {
+			if setting.Key == "vcs.revision" {
+				// Return short hash (8 chars) for consistency
+				if len(setting.Value) > 8 {
+					return setting.Value[:8]
+				}
+				return setting.Value
+			}
+		}
+	}
+	return "unknown"
 }
 
 // fetchGenesisHash fetches the genesis hash from the first RPC endpoint.

--- a/cmd/mithril/node/node.go
+++ b/cmd/mithril/node/node.go
@@ -1026,8 +1026,6 @@ func runLive(c *cobra.Command, args []string) {
 	if err := mlog.Initialize(logCfg, replay.CurrentRunID); err != nil {
 		// Non-fatal, continue with stdout-only logging
 		fmt.Fprintf(os.Stderr, "warning: failed to initialize file logging: %v\n", err)
-	} else if logPath := mlog.GetLogPath(); logPath != "" {
-		fmt.Printf("  Log file: %s\n", logPath)
 	}
 	defer mlog.Shutdown()
 

--- a/cmd/mithril/node/node.go
+++ b/cmd/mithril/node/node.go
@@ -54,11 +54,11 @@ var (
 		},
 	}
 
-	// Run is the main command for running Mithril as a live verifier.
+	// Run is the main command for running Mithril as a live full node.
 	// This is the primary way most users will run Mithril.
 	Run = cobra.Command{
 		Use:   "run",
-		Short: "Run Mithril as a live verifier (downloads snapshot, builds AccountsDB, verifies blocks)",
+		Short: "Run Mithril full node (downloads snapshot, builds AccountsDB, replays blocks)",
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return initConfigAndBindFlags(cmd)
 		},
@@ -125,7 +125,7 @@ var (
 )
 
 func init() {
-	// flags for verifier mode
+	// flags for verify-range mode
 	// [replay] section flags
 	VerifyRange.Flags().BoolVarP(&loadFromSnapshot, "load-from-snapshot", "s", false, "Load from a full snapshot")
 	VerifyRange.Flags().BoolVarP(&loadFromAccountsDb, "load-from-accounts-db", "a", false, "Load from AccountsDB")
@@ -164,7 +164,7 @@ func init() {
 	// [overcast] section flags
 	VerifyRange.Flags().StringVar(&snapshotDlPath, "download-snapshot-path", "", "Path to download snapshot to")
 
-	// flags for 'mithril run' (live verifier mode)
+	// flags for 'mithril run' (live full node mode)
 	// [bootstrap] section flags
 	Run.Flags().StringVar(&bootstrapMode, "bootstrap-mode", "auto", "Bootstrap mode: 'auto' (use AccountsDB if exists, else snapshot), 'accountsdb' (require existing), 'snapshot' (rebuild from snapshot), 'new-snapshot' (always download fresh)")
 

--- a/cmd/mithril/node/node.go
+++ b/cmd/mithril/node/node.go
@@ -969,33 +969,53 @@ func runLive(c *cobra.Command, args []string) {
 	// Generate run ID early so it's available for logging and state tracking
 	replay.CurrentRunID = replay.GenerateRunID()
 
-	// Initialize file logging
+	// Initialize file logging with defaults
+	// Use config.IsSet() to allow explicit empty/zero values:
+	//   dir = ""          → disable file logging (stdout only)
+	//   max_size_mb = 0   → no limit
+	//   max_age_days = 0  → never delete
+	//   max_backups = 0   → unlimited
 	logCfg := mlog.LogConfig{
-		Dir:        config.GetString("log.dir"),
-		Level:      config.GetString("log.level"),
-		ToStdout:   true, // Default true, override if explicitly set false
-		MaxSizeMB:  config.GetInt("log.max_size_mb"),
-		MaxAgeDays: config.GetInt("log.max_age_days"),
-		MaxBackups: config.GetInt("log.max_backups"),
+		ToStdout: true, // Default true, override if explicitly set false
 	}
-	// Handle to_stdout explicitly (viper returns false for missing bool)
+
+	// Dir: default to /mnt/mithril-logs, but "" disables file logging
+	if config.IsSet("log.dir") {
+		logCfg.Dir = config.GetString("log.dir")
+	} else {
+		logCfg.Dir = "/mnt/mithril-logs"
+	}
+
+	// Level: default to "info"
+	if config.IsSet("log.level") {
+		logCfg.Level = config.GetString("log.level")
+	} else {
+		logCfg.Level = "info"
+	}
+
+	// ToStdout: default true (viper returns false for missing bool)
 	if config.IsSet("log.to_stdout") {
 		logCfg.ToStdout = config.GetBool("log.to_stdout")
 	}
-	// Apply defaults if not set
-	if logCfg.Dir == "" {
-		logCfg.Dir = "/mnt/mithril-logs"
-	}
-	if logCfg.Level == "" {
-		logCfg.Level = "info"
-	}
-	if logCfg.MaxSizeMB == 0 {
+
+	// MaxSizeMB: default 100, but 0 means no limit
+	if config.IsSet("log.max_size_mb") {
+		logCfg.MaxSizeMB = config.GetInt("log.max_size_mb")
+	} else {
 		logCfg.MaxSizeMB = 100
 	}
-	if logCfg.MaxAgeDays == 0 {
+
+	// MaxAgeDays: default 7, but 0 means never delete
+	if config.IsSet("log.max_age_days") {
+		logCfg.MaxAgeDays = config.GetInt("log.max_age_days")
+	} else {
 		logCfg.MaxAgeDays = 7
 	}
-	if logCfg.MaxBackups == 0 {
+
+	// MaxBackups: default 10, but 0 means unlimited
+	if config.IsSet("log.max_backups") {
+		logCfg.MaxBackups = config.GetInt("log.max_backups")
+	} else {
 		logCfg.MaxBackups = 10
 	}
 

--- a/cmd/mithril/node/node.go
+++ b/cmd/mithril/node/node.go
@@ -90,8 +90,8 @@ var (
 	scratchDirectory            string
 	rpcEndpoints                []string
 	cluster                     string   // "mainnet-beta", "testnet", "devnet"
-	blockSource                 string   // "rpc" or "overcast"
-	overcastEndpoint            string
+	blockSource                 string   // "rpc" or "lightbringer"
+	lightbringerEndpoint        string
 	blockMaxRPS                 int      // Rate limit for block fetching
 	blockMaxInflight            int    // Max concurrent block fetch workers
 	blockTipPollIntervalMs      int    // Tip poll interval in milliseconds
@@ -161,7 +161,7 @@ func init() {
 	// [reporting] section flags
 	VerifyRange.Flags().StringVar(&metricsPath, "metrics-path", "", "Filename to write JSONL records of latencies")
 
-	// [overcast] section flags
+	// [lightbringer] section flags
 	VerifyRange.Flags().StringVar(&snapshotDlPath, "download-snapshot-path", "", "Path to download snapshot to")
 
 	// flags for 'mithril run' (live full node mode)
@@ -203,8 +203,8 @@ func init() {
 	Run.Flags().StringVar(&scratchDirectory, "scratch-directory", "/tmp", "Path for downloads (e.g. snapshots) and other temp state")
 
 	// [block] section flags
-	Run.Flags().StringVar(&blockSource, "block-source", "rpc", "Block source: 'rpc' or 'overcast'")
-	Run.Flags().StringVar(&overcastEndpoint, "overcast-endpoint", "", "Address for Overcast endpoint (only used when block-source=overcast)")
+	Run.Flags().StringVar(&blockSource, "block-source", "rpc", "Block source: 'rpc' or 'lightbringer'")
+	Run.Flags().StringVar(&lightbringerEndpoint, "lightbringer-endpoint", "", "Address for Lightbringer endpoint (only used when block-source=lightbringer)")
 	Run.Flags().IntVar(&blockMaxRPS, "block-max-rps", 0, "Max RPC requests per second for block fetching (0 = use default)")
 	Run.Flags().IntVar(&blockMaxInflight, "block-max-inflight", 0, "Max concurrent block fetch workers (0 = use default)")
 	Run.Flags().IntVar(&blockTipPollIntervalMs, "block-tip-poll-ms", 0, "Tip poll interval in milliseconds (0 = use default)")
@@ -431,7 +431,7 @@ func initConfigAndBindFlags(cmd *cobra.Command) error {
 	if blockSource == "" {
 		blockSource = "rpc" // default
 	}
-	overcastEndpoint = getString("overcast-endpoint", "block.overcast_endpoint")
+	lightbringerEndpoint = getString("lightbringer-endpoint", "block.lightbringer_endpoint")
 
 	// Validate: blockSource=rpc requires RPC endpoints
 	if blockSource == "rpc" && len(rpcEndpoints) == 0 {
@@ -977,23 +977,23 @@ func runLive(c *cobra.Command, args []string) {
 	// Now start the metrics server (after banner so errors don't appear first)
 	statsd.StartMetricsServer()
 
-	// Determine if using Overcast based on block source
-	// NOTE: Overcast mode is TEMPORARILY DISABLED. The background block downloader that
-	// wrote Overcast blocks to disk was removed due to reliability issues (panics, race conditions).
-	// Until Overcast streaming is re-implemented with the new parallel fetcher architecture,
-	// all Overcast requests will fall back to RPC mode.
-	// TODO: Re-implement Overcast as a streaming BlockSource (push model -> reorder buffer)
-	useOvercast := blockSource == "overcast"
-	if useOvercast {
-		mlog.Log.Infof("WARNING: block.source=overcast is temporarily disabled - falling back to RPC")
-		mlog.Log.Infof("  The background block downloader was removed. Overcast streaming will be")
+	// Determine if using Lightbringer based on block source
+	// NOTE: Lightbringer mode is TEMPORARILY DISABLED. The background block downloader that
+	// wrote Lightbringer blocks to disk was removed due to reliability issues (panics, race conditions).
+	// Until Lightbringer streaming is re-implemented with the new parallel fetcher architecture,
+	// all Lightbringer requests will fall back to RPC mode.
+	// TODO: Re-implement Lightbringer as a streaming BlockSource (push model -> reorder buffer)
+	useLightbringer := blockSource == "lightbringer"
+	if useLightbringer {
+		mlog.Log.Infof("WARNING: block.source=lightbringer is temporarily disabled - falling back to RPC")
+		mlog.Log.Infof("  The background block downloader was removed. Lightbringer streaming will be")
 		mlog.Log.Infof("  re-implemented in a future PR with the new parallel fetcher architecture.")
-		useOvercast = false
+		useLightbringer = false
 
 		// Validate RPC endpoints since we're falling back to RPC mode
 		// (This check is normally done in loadConfig but only when blockSource == "rpc")
 		if len(rpcEndpoints) == 0 {
-			klog.Fatalf("block.source=overcast requires fallback to RPC, but no RPC endpoints are configured. " +
+			klog.Fatalf("block.source=lightbringer requires fallback to RPC, but no RPC endpoints are configured. " +
 				"Set network.rpc in config, or use --rpc flag.")
 		}
 	}
@@ -1493,7 +1493,7 @@ func runLive(c *cobra.Command, args []string) {
 		NearTipPollMs:    blockNearTipPollMs,
 		NearTipLookahead: blockNearTipLookahead,
 	}
-	result := runReplayWithRecovery(ctx, accountsDb, accountsPath, manifest, resumeState, uint64(startSlot), liveEndSlot, rpcEndpoints, blockstorePath, int(txParallelism), true, useOvercast, dbgOpts, metricsWriter, rpcServer, mithrilState, blockFetchOpts, replayStartTime)
+	result := runReplayWithRecovery(ctx, accountsDb, accountsPath, manifest, resumeState, uint64(startSlot), liveEndSlot, rpcEndpoints, blockstorePath, int(txParallelism), true, useLightbringer, dbgOpts, metricsWriter, rpcServer, mithrilState, blockFetchOpts, replayStartTime)
 
 	// Update state file with last persisted slot and resume context
 	// Skip if already written during cancellation (eliminates timing window)
@@ -1844,8 +1844,8 @@ func printStartupInfo(commandName string) {
 
 	// Block source
 	fmt.Printf("  Block source: %s%s%s", gold, blockSource, reset)
-	if blockSource == "overcast" {
-		// Overcast is temporarily disabled - show this in startup info
+	if blockSource == "lightbringer" {
+		// Lightbringer is temporarily disabled - show this in startup info
 		fmt.Printf(" %s(disabled, using rpc)%s\n", dim, reset)
 	} else {
 		fmt.Println()
@@ -2313,7 +2313,7 @@ func runReplayWithRecovery(
 	blockDir string,
 	txParallelism int,
 	isLive bool,
-	useOvercast bool,
+	useLightbringer bool,
 	dbgOpts *replay.DebugOptions,
 	metricsWriter io.Writer,
 	rpcServer *rpcserver.RpcServer,
@@ -2422,6 +2422,6 @@ func runReplayWithRecovery(
 		}
 	}()
 
-	result = replay.ReplayBlocks(ctx, accountsDb, accountsDbPath, manifest, resumeState, startSlot, endSlot, rpcEndpoints, blockDir, txParallelism, isLive, useOvercast, dbgOpts, metricsWriter, rpcServer, blockFetchOpts, onCancelWriteState)
+	result = replay.ReplayBlocks(ctx, accountsDb, accountsDbPath, manifest, resumeState, startSlot, endSlot, rpcEndpoints, blockDir, txParallelism, isLive, useLightbringer, dbgOpts, metricsWriter, rpcServer, blockFetchOpts, onCancelWriteState)
 	return result
 }

--- a/cmd/mithril/node/node.go
+++ b/cmd/mithril/node/node.go
@@ -1804,7 +1804,7 @@ func printStartupInfo(commandName string) {
 
 				// Slots replayed since snapshot
 				slotsReplayed := mithrilState.LastSlot - mithrilState.SnapshotSlot
-				fmt.Printf("  Replayed:       %s%d slots since snapshot%s\n", dim, slotsReplayed, reset)
+				fmt.Printf("  Replayed:       %s%d slots since snapshot bootstrap%s\n", dim, slotsReplayed, reset)
 			} else {
 				fmt.Printf("  Resume from:    %ssnapshot (fresh start)%s\n", dim, reset)
 			}

--- a/cmd/mithril/node/node.go
+++ b/cmd/mithril/node/node.go
@@ -875,10 +875,11 @@ func runVerifyRange(c *cobra.Command, args []string) {
 		NearTipPollMs:    blockNearTipPollMs,
 		NearTipLookahead: blockNearTipLookahead,
 	}
-	result := runReplayWithRecovery(ctx, accountsDb, accountsDbDir, manifest, resumeState, uint64(startSlot), uint64(endSlot), rpcEndpoints, blockstorePath, int(txParallelism), false, false, dbgOpts, metricsWriter, rpcServer, mithrilState, blockFetchOpts)
+	result := runReplayWithRecovery(ctx, accountsDb, accountsDbDir, manifest, resumeState, uint64(startSlot), uint64(endSlot), rpcEndpoints, blockstorePath, int(txParallelism), false, false, dbgOpts, metricsWriter, rpcServer, mithrilState, blockFetchOpts, replayStartTime)
 
 	// Update state file with last persisted slot and resume context
-	if result.LastPersistedSlot > 0 && mithrilState != nil {
+	// Skip if already written during cancellation (eliminates timing window)
+	if result.LastPersistedSlot > 0 && mithrilState != nil && !result.StateWrittenOnCancel {
 		// Build resume context for graceful shutdown
 		var resumeCtx *state.ResumeContext
 		if result.LastAcctsLtHash != nil {
@@ -1492,10 +1493,11 @@ func runLive(c *cobra.Command, args []string) {
 		NearTipPollMs:    blockNearTipPollMs,
 		NearTipLookahead: blockNearTipLookahead,
 	}
-	result := runReplayWithRecovery(ctx, accountsDb, accountsPath, manifest, resumeState, uint64(startSlot), liveEndSlot, rpcEndpoints, blockstorePath, int(txParallelism), true, useOvercast, dbgOpts, metricsWriter, rpcServer, mithrilState, blockFetchOpts)
+	result := runReplayWithRecovery(ctx, accountsDb, accountsPath, manifest, resumeState, uint64(startSlot), liveEndSlot, rpcEndpoints, blockstorePath, int(txParallelism), true, useOvercast, dbgOpts, metricsWriter, rpcServer, mithrilState, blockFetchOpts, replayStartTime)
 
 	// Update state file with last persisted slot and resume context
-	if result.LastPersistedSlot > 0 && mithrilState != nil {
+	// Skip if already written during cancellation (eliminates timing window)
+	if result.LastPersistedSlot > 0 && mithrilState != nil && !result.StateWrittenOnCancel {
 		var resumeCtx *state.ResumeContext
 		if result.LastAcctsLtHash != nil {
 			// Calculate epoch for the last persisted slot
@@ -2317,8 +2319,65 @@ func runReplayWithRecovery(
 	rpcServer *rpcserver.RpcServer,
 	mithrilState *state.MithrilState,
 	blockFetchOpts *replay.BlockFetchOpts,
+	replayStartTime time.Time, // Start time for resume context
 ) *replay.ReplayResult {
 	var result *replay.ReplayResult
+
+	// Create callback to write state immediately on cancellation
+	// This eliminates the timing window between bankhash persistence and state file update
+	onCancelWriteState := func(r *replay.ReplayResult) error {
+		if mithrilState == nil {
+			return nil
+		}
+
+		// Calculate epoch for the last persisted slot
+		var lastEpoch uint64
+		if sealevel.SysvarCache.EpochSchedule.Sysvar != nil {
+			lastEpoch = sealevel.SysvarCache.EpochSchedule.Sysvar.GetEpoch(r.LastPersistedSlot)
+		}
+
+		// Build resume context
+		var resumeCtx *state.ResumeContext
+		if r.LastAcctsLtHash != nil {
+			resumeCtx = &state.ResumeContext{
+				AcctsLtHash:          base64.StdEncoding.EncodeToString(r.LastAcctsLtHash.Hash()),
+				LamportsPerSignature: r.LastLamportsPerSignature,
+				PrevLamportsPerSig:   r.LastPrevLamportsPerSig,
+				NumSignatures:        r.LastNumSignatures,
+				Epoch:                lastEpoch,
+
+				// Blockhash context
+				RecentBlockhashes: encodeRecentBlockhashes(r.LastRecentBlockhashes),
+				EvictedBlockhash:  base58.Encode(r.LastEvictedBlockhash[:]),
+				LastBlockhash:     base58.Encode(r.LastBlockhash[:]),
+
+				// SlotHashes context
+				SlotHashes: encodeSlotHashes(r.LastSlotHashes),
+
+				// Run tracking
+				RunID:        replay.CurrentRunID,
+				RunStartedAt: replayStartTime,
+
+				// Writer info
+				WriterVersion: getVersion(),
+				WriterCommit:  getCommitHash(),
+
+				// Shutdown tracking - this is always a cancel (Ctrl+C)
+				ShutdownReason: state.ShutdownReasonNormal,
+			}
+		}
+
+		// Write state immediately
+		if err := mithrilState.UpdateLastSlotWithContext(accountsDbPath, r.LastPersistedSlot, r.LastPersistedBankhash, resumeCtx); err != nil {
+			return err
+		}
+
+		// Record shutdown in history
+		state.RecordShutdown(accountsDbPath, r.LastPersistedSlot, base58.Encode(r.LastPersistedBankhash), replay.CurrentRunID, getVersion(), getCommit(), state.ShutdownReasonNormal)
+
+		mlog.Log.Infof("state written immediately on cancel at slot %d", r.LastPersistedSlot)
+		return nil
+	}
 
 	defer func() {
 		if r := recover(); r != nil {
@@ -2363,6 +2422,6 @@ func runReplayWithRecovery(
 		}
 	}()
 
-	result = replay.ReplayBlocks(ctx, accountsDb, accountsDbPath, manifest, resumeState, startSlot, endSlot, rpcEndpoints, blockDir, txParallelism, isLive, useOvercast, dbgOpts, metricsWriter, rpcServer, blockFetchOpts)
+	result = replay.ReplayBlocks(ctx, accountsDb, accountsDbPath, manifest, resumeState, startSlot, endSlot, rpcEndpoints, blockDir, txParallelism, isLive, useOvercast, dbgOpts, metricsWriter, rpcServer, blockFetchOpts, onCancelWriteState)
 	return result
 }

--- a/cmd/mithril/statecmd/statecmd.go
+++ b/cmd/mithril/statecmd/statecmd.go
@@ -1,0 +1,361 @@
+package statecmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/Overclock-Validator/mithril/pkg/config"
+	"github.com/Overclock-Validator/mithril/pkg/state"
+	"github.com/spf13/cobra"
+)
+
+var (
+	// StateCmd is the parent command for state-related subcommands
+	StateCmd = cobra.Command{
+		Use:   "state",
+		Short: "State file inspection and management",
+		Long: `Inspect and manage the mithril_state.json file.
+
+The state file tracks AccountsDB validity, replay progress, and cluster info.
+Use this command to debug issues or share state information.
+
+Examples:
+  mithril state                    # Show state summary
+  mithril state show               # Same as above
+  mithril state --json             # Full JSON dump
+  mithril state --full             # Include resume context
+  mithril state history            # Show recent events
+  mithril state validate           # Validate against AccountsDB`,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			return config.InitConfig()
+		},
+		Run: func(cmd *cobra.Command, args []string) {
+			runStateShow(cmd)
+		},
+	}
+
+	// ShowCmd displays state information
+	ShowCmd = cobra.Command{
+		Use:   "show",
+		Short: "Display state file summary",
+		Run: func(cmd *cobra.Command, args []string) {
+			runStateShow(cmd)
+		},
+	}
+
+	// HistoryCmd displays state history
+	HistoryCmd = cobra.Command{
+		Use:   "history",
+		Short: "Display state change history",
+		Long: `Display the history of state changes (bootstrap, shutdown, corruption events).
+
+Examples:
+  mithril state history           # Show last 10 entries
+  mithril state history --all     # Show all entries
+  mithril state history --json    # Raw JSONL output`,
+		Run: func(cmd *cobra.Command, args []string) {
+			runStateHistory(cmd)
+		},
+	}
+
+	// ValidateCmd validates state against AccountsDB
+	ValidateCmd = cobra.Command{
+		Use:   "validate",
+		Short: "Validate state file against AccountsDB",
+		Long: `Validates that the state file is consistent with the bankhash database.
+
+This checks:
+- State file exists and is valid
+- Last slot matches bankhash database
+- No slots beyond last_slot exist in database`,
+		Run: func(cmd *cobra.Command, args []string) {
+			runStateValidate(cmd)
+		},
+	}
+
+	// Flags
+	jsonOutput bool
+	fullOutput bool
+	allHistory bool
+)
+
+func init() {
+	// Flags for show command
+	StateCmd.Flags().BoolVar(&jsonOutput, "json", false, "Output full JSON")
+	StateCmd.Flags().BoolVar(&fullOutput, "full", false, "Include resume context and blockhash details")
+	ShowCmd.Flags().BoolVar(&jsonOutput, "json", false, "Output full JSON")
+	ShowCmd.Flags().BoolVar(&fullOutput, "full", false, "Include resume context and blockhash details")
+
+	// Flags for history command
+	HistoryCmd.Flags().BoolVar(&jsonOutput, "json", false, "Output raw JSONL")
+	HistoryCmd.Flags().BoolVar(&allHistory, "all", false, "Show all history entries")
+
+	// Add subcommands
+	StateCmd.AddCommand(&ShowCmd)
+	StateCmd.AddCommand(&HistoryCmd)
+	StateCmd.AddCommand(&ValidateCmd)
+}
+
+func getAccountsPath() string {
+	// Try config file first
+	path := config.GetString("storage.accounts")
+	if path == "" {
+		path = config.GetString("ledger.accounts_path") // Legacy fallback
+	}
+	if path == "" {
+		fmt.Println("Error: storage.accounts not configured")
+		fmt.Println("Use: mithril state --config config.toml")
+		os.Exit(1)
+	}
+	return path
+}
+
+func runStateShow(cmd *cobra.Command) {
+	accountsPath := getAccountsPath()
+
+	s, err := state.LoadState(accountsPath)
+	if err != nil {
+		fmt.Printf("Error loading state: %v\n", err)
+		os.Exit(1)
+	}
+
+	if s == nil {
+		fmt.Printf("No state file found at %s\n", filepath.Join(accountsPath, state.StateFileName))
+		os.Exit(1)
+	}
+
+	if jsonOutput {
+		data, _ := json.MarshalIndent(s, "", "  ")
+		fmt.Println(string(data))
+		return
+	}
+
+	// Pretty print
+	stateFile := filepath.Join(accountsPath, state.StateFileName)
+	fmt.Println("=== Mithril State ===")
+	fmt.Printf("Path: %s\n", stateFile)
+	fmt.Printf("Stage: %s\n", s.Stage)
+	fmt.Printf("Schema Version: %d\n", s.StateSchemaVersion)
+	fmt.Println()
+
+	// Snapshot info
+	fmt.Println("Snapshot:")
+	fmt.Printf("  Slot: %d (epoch %d)\n", s.SnapshotSlot, s.SnapshotEpoch)
+	if s.FullSnapshot != nil {
+		fmt.Printf("  Full: %s\n", s.FullSnapshot.Path)
+	}
+	if s.IncrSnapshot != nil {
+		fmt.Printf("  Incremental: %s (base %d)\n", s.IncrSnapshot.Path, s.IncrSnapshot.BaseSlot)
+	}
+	fmt.Println()
+
+	// Replay progress
+	fmt.Println("Replay Progress:")
+	if s.LastSlot > 0 {
+		fmt.Printf("  Last slot: %d (epoch %d)\n", s.LastSlot, s.LastEpoch)
+		fmt.Printf("  Last bankhash: %s\n", truncateHash(s.LastBankhash))
+		fmt.Printf("  Slots replayed: %d\n", s.LastSlot-s.SnapshotSlot)
+	} else {
+		fmt.Printf("  No replay yet (fresh from snapshot)\n")
+	}
+	fmt.Println()
+
+	// Cluster info
+	if s.Cluster != "" || s.GenesisHash != "" {
+		fmt.Println("Cluster:")
+		if s.Cluster != "" {
+			fmt.Printf("  Network: %s\n", s.Cluster)
+		}
+		if s.GenesisHash != "" {
+			fmt.Printf("  Genesis: %s\n", truncateHash(s.GenesisHash))
+		}
+		fmt.Println()
+	}
+
+	// Writer info
+	fmt.Println("Writer:")
+	if s.LastWriterVersion != "" {
+		fmt.Printf("  Version: %s\n", s.LastWriterVersion)
+	}
+	commit := s.LastWriterCommit
+	if commit == "" {
+		commit = s.LastCommit // Legacy fallback
+	}
+	if commit != "" {
+		fmt.Printf("  Commit: %s\n", commit)
+	}
+	fmt.Println()
+
+	// Run info
+	if s.LastRunID != "" {
+		fmt.Println("Last Run:")
+		fmt.Printf("  ID: %s\n", s.LastRunID)
+		if !s.LastRunAt.IsZero() {
+			fmt.Printf("  Started: %s (%s ago)\n", s.LastRunAt.Format(time.RFC3339), formatDuration(time.Since(s.LastRunAt)))
+		}
+		if s.LastShutdownReason != "" {
+			fmt.Printf("  Shutdown: %s\n", s.LastShutdownReason)
+		}
+		fmt.Println()
+	}
+
+	// Corruption info (if applicable)
+	if s.IsCorrupted() {
+		fmt.Println("CORRUPTION:")
+		fmt.Printf("  Reason: %s\n", s.CorruptionReason)
+		if !s.CorruptionDetectedAt.IsZero() {
+			fmt.Printf("  Detected: %s\n", s.CorruptionDetectedAt.Format(time.RFC3339))
+		}
+		fmt.Println()
+	}
+
+	// Full details (resume context)
+	if fullOutput && s.HasResumeContext() {
+		fmt.Println("Resume Context:")
+		fmt.Printf("  AcctsLtHash: %s...\n", truncate(s.LastAcctsLtHash, 20))
+		fmt.Printf("  LamportsPerSig: %d\n", s.LastLamportsPerSignature)
+		fmt.Printf("  NumSignatures: %d\n", s.LastNumSignatures)
+		fmt.Printf("  RecentBlockhashes: %d entries\n", len(s.LastRecentBlockhashes))
+		fmt.Printf("  SlotHashes: %d entries\n", len(s.LastSlotHashes))
+		fmt.Println()
+	}
+}
+
+func runStateHistory(cmd *cobra.Command) {
+	accountsPath := getAccountsPath()
+
+	var entries []state.StateHistoryEntry
+	var err error
+
+	if allHistory {
+		entries, err = state.LoadHistory(accountsPath)
+	} else {
+		entries, err = state.GetRecentHistory(accountsPath, 10)
+	}
+
+	if err != nil {
+		fmt.Printf("Error loading history: %v\n", err)
+		os.Exit(1)
+	}
+
+	if len(entries) == 0 {
+		fmt.Println("No history entries found")
+		return
+	}
+
+	if jsonOutput {
+		for _, entry := range entries {
+			data, _ := json.Marshal(entry)
+			fmt.Println(string(data))
+		}
+		return
+	}
+
+	fmt.Printf("=== State History (%d entries) ===\n\n", len(entries))
+	for i := len(entries) - 1; i >= 0; i-- {
+		entry := entries[i]
+		fmt.Printf("[%s] %s\n", entry.Timestamp.Format("2006-01-02 15:04:05"), entry.Event)
+		fmt.Printf("  Slot: %d\n", entry.Slot)
+		if entry.RunID != "" {
+			fmt.Printf("  Run: %s\n", entry.RunID)
+		}
+		if entry.Version != "" || entry.Commit != "" {
+			fmt.Printf("  Writer: %s (%s)\n", entry.Version, entry.Commit)
+		}
+		if entry.Reason != "" {
+			fmt.Printf("  Reason: %s\n", entry.Reason)
+		}
+		fmt.Println()
+	}
+}
+
+func runStateValidate(cmd *cobra.Command) {
+	accountsPath := getAccountsPath()
+
+	s, err := state.LoadState(accountsPath)
+	if err != nil {
+		fmt.Printf("Error loading state: %v\n", err)
+		os.Exit(1)
+	}
+
+	if s == nil {
+		fmt.Printf("No state file found at %s\n", filepath.Join(accountsPath, state.StateFileName))
+		os.Exit(1)
+	}
+
+	fmt.Println("State file validation:")
+	fmt.Printf("  Stage: %s\n", s.Stage)
+
+	if s.IsCorrupted() {
+		fmt.Printf("  Status: CORRUPTED\n")
+		fmt.Printf("  Reason: %s\n", s.CorruptionReason)
+		os.Exit(1)
+	}
+
+	if !s.IsReady() {
+		fmt.Printf("  Status: NOT READY (stage=%s)\n", s.Stage)
+		os.Exit(1)
+	}
+
+	// Check artifacts exist
+	if err := state.ValidateAccountsDbArtifacts(accountsPath); err != nil {
+		fmt.Printf("  Status: ARTIFACTS MISSING\n")
+		fmt.Printf("  Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("  Status: OK\n")
+	fmt.Printf("  Snapshot: %d (epoch %d)\n", s.SnapshotSlot, s.SnapshotEpoch)
+	if s.LastSlot > 0 {
+		fmt.Printf("  Last slot: %d (epoch %d)\n", s.LastSlot, s.LastEpoch)
+	}
+
+	// Note: Full bankhash validation requires opening the AccountsDB
+	// which is expensive. For now, just validate artifacts exist.
+	fmt.Println("\nNote: Use 'mithril run' to perform full bankhash validation.")
+}
+
+// Helper functions
+
+func truncateHash(hash string) string {
+	if len(hash) > 12 {
+		return hash[:8] + "..." + hash[len(hash)-4:]
+	}
+	return hash
+}
+
+func truncate(s string, n int) string {
+	if len(s) > n {
+		return s[:n]
+	}
+	return s
+}
+
+func formatDuration(d time.Duration) string {
+	if d < time.Minute {
+		return "< 1m"
+	}
+
+	days := int(d.Hours() / 24)
+	hours := int(d.Hours()) % 24
+	minutes := int(d.Minutes()) % 60
+
+	if days > 0 {
+		if hours > 0 {
+			return fmt.Sprintf("%dd %dh", days, hours)
+		}
+		return fmt.Sprintf("%dd", days)
+	}
+
+	if hours > 0 {
+		if minutes > 0 {
+			return fmt.Sprintf("%dh %dm", hours, minutes)
+		}
+		return fmt.Sprintf("%dh", hours)
+	}
+
+	return fmt.Sprintf("%dm", minutes)
+}

--- a/cmd/mithril/statecmd/statecmd.go
+++ b/cmd/mithril/statecmd/statecmd.go
@@ -29,7 +29,11 @@ Examples:
   mithril state --full             # Include resume context
   mithril state history            # Show recent events
   mithril state validate           # Validate against AccountsDB`,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			// Skip config loading if --accounts flag is provided
+			if accountsFlag != "" {
+				return nil
+			}
 			return config.InitConfig()
 		},
 		Run: func(cmd *cobra.Command, args []string) {
@@ -77,12 +81,16 @@ This checks:
 	}
 
 	// Flags
-	jsonOutput bool
-	fullOutput bool
-	allHistory bool
+	jsonOutput   bool
+	fullOutput   bool
+	allHistory   bool
+	accountsFlag string // Override for accounts path (allows config-less usage)
 )
 
 func init() {
+	// Persistent flag for accounts path (works on all subcommands)
+	StateCmd.PersistentFlags().StringVar(&accountsFlag, "accounts", "", "Path to AccountsDB directory (overrides config)")
+
 	// Flags for show command
 	StateCmd.Flags().BoolVar(&jsonOutput, "json", false, "Output full JSON")
 	StateCmd.Flags().BoolVar(&fullOutput, "full", false, "Include resume context and blockhash details")
@@ -100,7 +108,12 @@ func init() {
 }
 
 func getAccountsPath() string {
-	// Try config file first
+	// Check --accounts flag first (allows config-less usage)
+	if accountsFlag != "" {
+		return accountsFlag
+	}
+
+	// Fall back to config file
 	path := config.GetString("storage.accounts")
 	if path == "" {
 		path = config.GetString("ledger.accounts_path") // Legacy fallback
@@ -108,6 +121,7 @@ func getAccountsPath() string {
 	if path == "" {
 		fmt.Println("Error: storage.accounts not configured")
 		fmt.Println("Use: mithril state --config config.toml")
+		fmt.Println("  or: mithril state --accounts /path/to/accountsdb")
 		os.Exit(1)
 	}
 	return path

--- a/cmd/mithril/statecmd/statecmd.go
+++ b/cmd/mithril/statecmd/statecmd.go
@@ -68,13 +68,15 @@ Examples:
 	// ValidateCmd validates state against AccountsDB
 	ValidateCmd = cobra.Command{
 		Use:   "validate",
-		Short: "Validate state file against AccountsDB",
-		Long: `Validates that the state file is consistent with the bankhash database.
+		Short: "Validate state file and AccountsDB artifacts",
+		Long: `Validates that the state file and AccountsDB are in a consistent state.
 
 This checks:
-- State file exists and is valid
-- Last slot matches bankhash database
-- No slots beyond last_slot exist in database`,
+- State file exists and is parseable
+- Stage is "ready" (not corrupted or building)
+- Required AccountsDB artifacts exist on disk
+
+Note: Full bankhash database validation is not yet implemented.`,
 		Run: func(cmd *cobra.Command, args []string) {
 			runStateValidate(cmd)
 		},

--- a/cmd/mithril/version.go
+++ b/cmd/mithril/version.go
@@ -1,0 +1,7 @@
+package main
+
+var (
+	Version   = "dev"
+	GitCommit = "unknown"
+	BuildDate = "unknown"
+)

--- a/cmd/mithril/version.go
+++ b/cmd/mithril/version.go
@@ -1,7 +1,11 @@
 package main
 
+import "github.com/Overclock-Validator/mithril/pkg/version"
+
+// Re-export version variables for CLI usage
+// These are set via ldflags at build time in pkg/version
 var (
-	Version   = "dev"
-	GitCommit = "unknown"
-	BuildDate = "unknown"
+	Version   = version.Version
+	GitCommit = version.GitCommit
+	BuildDate = version.BuildDate
 )

--- a/config.example.toml
+++ b/config.example.toml
@@ -221,7 +221,7 @@ name = "mithril"
 # [rpc] - Mithril RPC Server
 # ============================================================================
 #
-# Mithril exposes a Solana-compatible JSON-RPC interface on localhost,
+# Mithril exposes a Solana-compatible JSON-RPC interface on all interfaces,
 # allowing other tools to query Mithril's account state directly.
 #
 # Query with: curl http://localhost:8899 -X POST -H "Content-Type: application/json" \

--- a/config.example.toml
+++ b/config.example.toml
@@ -32,8 +32,8 @@ name = "mithril"
 #                    Cleans AccountsDB and snapshot directories before starting.
 #   "accountsdb"   - Require existing valid AccountsDB, fail fast if missing.
 #
-# The default is "snapshot" which is recommended while Mithril is in early
-# development. Once stable, "auto" is a good choice for production.
+# The default is "auto" which tries to resume from existing AccountsDB if valid,
+# or downloads a fresh snapshot if needed. Use "snapshot" to always check freshness.
 
 [bootstrap]
     mode = "auto"
@@ -413,3 +413,30 @@ name = "mithril"
     # At 2 MB/s: ~8 minutes for 1GB (acceptable)
     # Set to 0 to disable speed filtering.
     min_incremental_speed_mbs = 2.0
+
+# ============================================================================
+# [log] - Logging Configuration
+# ============================================================================
+#
+# Mithril writes logs to files for easy debugging and sharing.
+# Each run creates a new log file with timestamp and run ID.
+
+[log]
+    # Directory for log files (created if missing)
+    # Set to "" to disable file logging (stdout only)
+    dir = "/mnt/mithril-logs"
+
+    # Log level: "debug" | "info" | "warn" | "error"
+    level = "info"
+
+    # Also write to stdout (set to false for daemon/service mode)
+    to_stdout = true
+
+    # Maximum log file size in MB before rotation (0 = no limit)
+    max_size_mb = 100
+
+    # Delete log files older than this many days (0 = never delete)
+    max_age_days = 7
+
+    # Maximum number of old log files to keep (0 = unlimited)
+    max_backups = 10

--- a/config.example.toml
+++ b/config.example.toml
@@ -55,7 +55,7 @@ name = "mithril"
 #     one on first run to bootstrap AccountsDB.
 #
 #   Blockstore (varies)
-#     Incoming blocks from RPC/Overcast. Size depends on how much history
+#     Incoming blocks from RPC/Lightbringer. Size depends on how much history
 #     you want to keep (0 to hundreds of GB).
 #     NOTE: Block download to disk is TEMPORARILY DISABLED. Blocks are
 #     currently streamed directly from RPC and not persisted to disk.
@@ -75,7 +75,7 @@ name = "mithril"
     # Put this on your fastest NVMe due to heavy random I/O.
     accounts = "/mnt/mithril-accounts"
 
-    # Blockstore - incoming blocks from RPC/Overcast
+    # Blockstore - incoming blocks from RPC/Lightbringer
     # Size depends on how much block history you keep.
     # NOTE: Block persistence is temporarily disabled. Blocks are streamed
     # directly from RPC without saving to disk. This setting is reserved
@@ -119,16 +119,16 @@ name = "mithril"
 
 [block]
     # Where to stream new blocks from:
-    #   "rpc"      - Fetch blocks via RPC (uses endpoints from [network].rpc)
-    #   "overcast" - Stream blocks from an Overcast endpoint (faster, lower latency)
-    #                NOTE: Overcast mode is TEMPORARILY DISABLED and will fall back to RPC.
-    #                The background downloader was removed; Overcast streaming will be
-    #                re-implemented in a future release.
+    #   "rpc"          - Fetch blocks via RPC (uses endpoints from [network].rpc)
+    #   "lightbringer" - Stream blocks from a Lightbringer endpoint (faster, lower latency)
+    #                    NOTE: Lightbringer mode is TEMPORARILY DISABLED and will fall back to RPC.
+    #                    The background downloader was removed; Lightbringer streaming will be
+    #                    re-implemented in a future release.
     source = "rpc"
 
-    # Overcast endpoint address (only used when source = "overcast")
-    # NOTE: Currently unused - Overcast mode is temporarily disabled (see above)
-    # overcast_endpoint = "localhost:9000"
+    # Lightbringer endpoint address (only used when source = "lightbringer")
+    # NOTE: Currently unused - Lightbringer mode is temporarily disabled (see above)
+    # lightbringer_endpoint = "localhost:9000"
 
     # =========================================================================
     # Global Fetch Tuning

--- a/config.example.toml
+++ b/config.example.toml
@@ -99,6 +99,11 @@ name = "mithril"
 # probes the primary and restores to it when healthy.
 
 [network]
+    # Solana cluster (required): "mainnet-beta", "testnet", or "devnet"
+    # This is validated against the RPC's genesis hash to prevent accidentally
+    # running mainnet state against testnet, or vice versa.
+    cluster = "mainnet-beta"
+
     # RPC endpoints in priority order (first = primary, rest = fallbacks)
     #
     # Example with primary + fallback:

--- a/config.example.toml
+++ b/config.example.toml
@@ -380,8 +380,8 @@ name = "mithril"
     # TCP connection timeout for pre-check (milliseconds)
     tcp_timeout_ms = 1000
 
-    # Minimum Solana version required (e.g., "2.2.0", empty = no filter)
-    # min_node_version = "2.2.0"
+    # Minimum Solana version required (e.g., "3.0.0", empty = no filter)
+    # min_node_version = "3.0.0"
 
     # Allowed Solana versions (empty = all versions allowed)
     # Example: allowed_node_versions = ["2.2.0", "3.0.0"]

--- a/docs/snapshot.md
+++ b/docs/snapshot.md
@@ -75,7 +75,7 @@ The snapshot finder uses a two-stage algorithm to efficiently find the fastest n
 
 Before speed testing, nodes are filtered by:
 
-- **Version**: `min_node_version` (default: "2.2.0"), `allowed_node_versions` (optional whitelist)
+- **Version**: `min_node_version` (default: "3.0.0"), `allowed_node_versions` (optional whitelist)
 - **RTT**: `max_rtt_ms` (default: 200 ms)
 - **TCP Connectivity**: `tcp_timeout_ms` (default: 1000 ms)
 - **Snapshot Age**: `full_threshold` (default: 100000 slots), `incremental_threshold` (default: 200 slots)
@@ -228,8 +228,8 @@ All configuration options can be set in `config.toml` under the `[snapshot]` sec
     # TCP connection timeout for pre-check (milliseconds)
     # tcp_timeout_ms = 1000
 
-    # Minimum Solana version required (e.g., "2.2.0", empty = no filter)
-    # min_node_version = "2.2.0"
+    # Minimum Solana version required (e.g., "3.0.0", empty = no filter)
+    # min_node_version = "3.0.0"
 
     # Allowed Solana versions (empty = all versions allowed)
     # allowed_node_versions = []
@@ -293,7 +293,7 @@ All configuration options can be set in `config.toml` under the `[snapshot]` sec
 | `stage2_min_abs_mbs` | `0.0` | Disabled |
 | `max_rtt_ms` | `200` | 200ms max RTT |
 | `tcp_timeout_ms` | `1000` | 1 second TCP check |
-| `min_node_version` | `"2.2.0"` | Minimum Agave 2.2.0 |
+| `min_node_version` | `"3.0.0"` | Minimum Agave 3.0.0 |
 | `full_threshold` | `100000` | ~11 hours old |
 | `incremental_threshold` | `200` | ~80 seconds old |
 | `safety_margin_slots` | `5000` | Warn if close to expiration |

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/vbauerster/mpb/v8 v8.4.0
 	golang.org/x/sync v0.17.0
 	golang.org/x/sys v0.39.0
+	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/klog/v2 v2.100.1
 )
@@ -64,7 +65,6 @@ require (
 	github.com/Overclock-Validator/weightedrand v0.0.0-20251113203832-5ac028321d0a
 	github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da // indirect
 	github.com/bits-and-blooms/bitset v1.22.0 // indirect
-	github.com/buger/jsonparser v1.1.1 // indirect
 	github.com/cespare/xxhash v1.1.0
 	github.com/consensys/bavard v0.1.31-0.20250406004941-2db259e4b582 // indirect
 	github.com/dchest/blake2b v1.0.0 // indirect
@@ -75,7 +75,6 @@ require (
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/google/uuid v1.6.0 // indirect
-	github.com/gorilla/rpc v1.2.0 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/holiman/uint256 v1.3.2 // indirect
@@ -127,7 +126,6 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/gtank/merlin v0.1.1
 	github.com/gtank/ristretto255 v0.1.2
-	github.com/helius-labs/laserstream-sdk/go v0.0.5
 	github.com/iden3/go-iden3-crypto v0.0.16
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
@@ -163,6 +161,6 @@ require (
 	golang.org/x/exp v0.0.0-20240904232852-e7e105dedf7e // indirect
 	golang.org/x/net v0.46.0 // indirect
 	golang.org/x/term v0.38.0
-	golang.org/x/time v0.9.0 // indirect
+	golang.org/x/time v0.9.0
 	google.golang.org/protobuf v1.36.10
 )

--- a/go.sum
+++ b/go.sum
@@ -45,8 +45,6 @@ github.com/bits-and-blooms/bitset v1.22.0 h1:Tquv9S8+SGaS3EhyA+up3FXzmkhxPGjQQCk
 github.com/bits-and-blooms/bitset v1.22.0/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
 github.com/blendle/zapdriver v1.3.1 h1:C3dydBOWYRiOk+B8X9IVZ5IOe+7cl+tGOexN4QqHfpE=
 github.com/blendle/zapdriver v1.3.1/go.mod h1:mdXfREi6u5MArG4j9fewC+FGnXaBR+T4Ox4J2u4eHCc=
-github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
-github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
@@ -150,8 +148,6 @@ github.com/google/subcommands v1.2.0/go.mod h1:ZjhPrFU+Olkh9WazFPsl27BQ4UPiG37m3
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/gorilla/rpc v1.2.0 h1:WvvdC2lNeT1SP32zrIce5l0ECBfbAlmrmSBsuc57wfk=
-github.com/gorilla/rpc v1.2.0/go.mod h1:V4h9r+4sF5HnzqbwIez0fKSpANP0zlYd3qR7p36jkTQ=
 github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gtank/merlin v0.1.1 h1:eQ90iG7K9pOhtereWsmyRJ6RAwcP4tHTDBHXNg+u5is=
@@ -160,8 +156,6 @@ github.com/gtank/ristretto255 v0.1.2 h1:JEqUCPA1NvLq5DwYtuzigd7ss8fwbYay9fi4/5uM
 github.com/gtank/ristretto255 v0.1.2/go.mod h1:Ph5OpO6c7xKUGROZfWVLiJf9icMDwUeIvY4OmlYW69o=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
-github.com/helius-labs/laserstream-sdk/go v0.0.5 h1:0vPOqwvvdU/vIRNwuBVEnDdR6p1CEv7+iHXWu13HFq0=
-github.com/helius-labs/laserstream-sdk/go v0.0.5/go.mod h1:2/6r7nHolrs67rQYNuap5GXgUtz7MrQz6jYM88WUAPU=
 github.com/holiman/uint256 v1.3.2 h1:a9EgMPSC1AAaj1SZL5zIQD3WbwTuHrMGOerLjGmM/TA=
 github.com/holiman/uint256 v1.3.2/go.mod h1:EOMSn4q6Nyt9P6efbI3bueV4e1b3dGlUCXeiRV4ng7E=
 github.com/iden3/go-iden3-crypto v0.0.16 h1:zN867xiz6HgErXVIV/6WyteGcOukE9gybYTorBMEdsk=
@@ -510,6 +504,8 @@ gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntN
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/ini.v1 v1.67.0 h1:Dgnx+6+nfE+IfzjUEISNeydPJh9AXNNsWbGP9KzCsOA=
 gopkg.in/ini.v1 v1.67.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
+gopkg.in/natefinch/lumberjack.v2 v2.2.1 h1:bBRl1b0OH9s/DuPhuXpNl+VtCaJXFZ5/uEFST95x9zc=
+gopkg.in/natefinch/lumberjack.v2 v2.2.1/go.mod h1:YD8tP3GAjkrDg1eZH7EGmyESg/lsYskCTPBJVb9jqSc=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/instructions.md
+++ b/instructions.md
@@ -28,16 +28,16 @@ example with multiple endpoints:
 go build ./cmd/mithril ; ./mithril verify-live --accounts-path /mnt/accounts_db/ -r http://rpc1,http://rpc2,http://rpc3 --txpar 96
 ```
 
-### Using Overcast block source:
+### Using Lightbringer block source:
 
-Set block source to overcast in config.toml:
+Set block source to lightbringer in config.toml:
 ```toml
 [block]
-    source = "overcast"
-    overcast_endpoint = "localhost:9000"
+    source = "lightbringer"
+    lightbringer_endpoint = "localhost:9000"
 ```
 
 Or via CLI:
 ```
-./mithril verify-live --config config.toml --block-source overcast --overcast-endpoint localhost:9000
+./mithril verify-live --config config.toml --block-source lightbringer --lightbringer-endpoint localhost:9000
 ```

--- a/pkg/accountsdb/accountsdb.go
+++ b/pkg/accountsdb/accountsdb.go
@@ -119,8 +119,7 @@ func (accountsDb *AccountsDb) CloseDb() {
 	if err := accountsDb.BankHashStore.Close(); err != nil {
 		mlog.Log.Errorf("CloseDb: BankHashStore.Close() error: %v", err)
 	}
-	mlog.Log.Infof("CloseDb: done")
-	fmt.Println() // spacing after close
+	mlog.Log.Infof("CloseDb: done\n") // extra newline for spacing after close
 }
 
 func (accountsDb *AccountsDb) InitCaches() {

--- a/pkg/block/block.go
+++ b/pkg/block/block.go
@@ -46,6 +46,7 @@ type Block struct {
 	PrevFeeRateGovernor                 *sealevel.FeeRateGovernor
 	FeeRateGovernor                     *sealevel.FeeRateGovernor
 	FromLightbringer                    bool
+	IsSkipped                           bool // True for slots that were skipped by the leader
 }
 
 func (b *Block) FixupTxVersions() {

--- a/pkg/block/block.go
+++ b/pkg/block/block.go
@@ -45,7 +45,7 @@ type Block struct {
 	LatestEvictedBlockhash              [32]byte
 	PrevFeeRateGovernor                 *sealevel.FeeRateGovernor
 	FeeRateGovernor                     *sealevel.FeeRateGovernor
-	FromOvercast                        bool
+	FromLightbringer                    bool
 }
 
 func (b *Block) FixupTxVersions() {

--- a/pkg/block/overcast.go
+++ b/pkg/block/overcast.go
@@ -6,7 +6,7 @@ import (
 	"github.com/gagliardetto/solana-go"
 )
 
-func FromOvercastStreamMsg(resp *overcast.SlotResponse) *Block {
+func FromLightbringerStreamMsg(resp *overcast.SlotResponse) *Block {
 	block := new(Block)
 	block.Slot = resp.Slot
 	block.Transactions = make([]*solana.Transaction, 0, 2000)
@@ -39,7 +39,7 @@ func FromOvercastStreamMsg(resp *overcast.SlotResponse) *Block {
 
 	block.Blockhash = solana.HashFromBytes(resp.Entries[len(resp.Entries)-1].Hash[:])
 	block.BlockHeight = global.BlockHeight()
-	block.FromOvercast = true
+	block.FromLightbringer = true
 
 	return block
 }

--- a/pkg/blockstream/block_source.go
+++ b/pkg/blockstream/block_source.go
@@ -1254,9 +1254,20 @@ func (bs *BlockSource) emitOrderedBlocks() {
 				bs.reorderMu.Lock()
 				bs.nextSlotToSend++
 			} else if bs.skippedSlots[bs.nextSlotToSend] {
-				// Slot was skipped (SlotSkipped from RPC), advance without emitting
-				delete(bs.skippedSlots, bs.nextSlotToSend)
-				// Also update progress - skipped slots count as progress
+				// Slot was skipped (SlotSkipped from RPC) - emit a skip marker block
+				skippedSlot := bs.nextSlotToSend
+				delete(bs.skippedSlots, skippedSlot)
+				bs.nextSlotToSend++
+				bs.reorderMu.Unlock()
+
+				// Emit a minimal block with IsSkipped=true for logging
+				skipBlock := &b.Block{
+					Slot:      skippedSlot,
+					IsSkipped: true,
+				}
+				bs.streamChan <- skipBlock
+
+				// Update progress - skipped slots count as progress
 				bs.lastProgress.Store(time.Now().Unix())
 
 				// Track slots since failover for primary retry (skipped slots count too)
@@ -1267,7 +1278,7 @@ func (bs *BlockSource) emitOrderedBlocks() {
 					}
 				}
 
-				bs.nextSlotToSend++
+				bs.reorderMu.Lock()
 			} else {
 				break
 			}

--- a/pkg/blockstream/block_source.go
+++ b/pkg/blockstream/block_source.go
@@ -219,10 +219,11 @@ type BlockSource struct {
 	stallError   atomic.Bool // Set when stall timeout triggers
 
 	// Stall diagnostics
-	waitingSlotErrorsMu sync.Mutex
-	waitingSlotErrors   map[uint64]*slotErrorInfo // Per-slot error tracking
-	lastStallHeartbeat  atomic.Int64              // Unix timestamp of last stall heartbeat log
-	lastFailoverTime    atomic.Int64              // Unix timestamp of last RPC failover
+	waitingSlotErrorsMu     sync.Mutex
+	waitingSlotErrors       map[uint64]*slotErrorInfo // Per-slot error tracking
+	lastStallHeartbeat      atomic.Int64              // Unix timestamp of last stall heartbeat log
+	lastFailoverTime        atomic.Int64              // Unix timestamp of last RPC failover
+	lastPriorityBlockedLog  atomic.Int64              // Unix timestamp of last "priority slot blocked" log
 
 	// Near-tip mode tracking
 	isNearTip        atomic.Bool // True when close to confirmed tip
@@ -406,13 +407,15 @@ func (bs *BlockSource) updateMode() {
 		// Currently in near-tip mode - switch to catchup if gap exceeds threshold
 		if gap >= bs.catchupThreshold {
 			bs.isNearTip.Store(false)
-			mlog.Log.Infof("Switching to CATCHUP mode (gap=%d slots, threshold=%d)", gap, bs.catchupThreshold)
+			mlog.Log.Infof("MODE SWITCH: near-tip → CATCHUP | gap=%d (threshold=%d) | exec_slot=%d | tip=%d",
+				gap, bs.catchupThreshold, lastExecuted, tip)
 		}
 	} else {
 		// Currently in catchup mode - switch to near-tip if gap is small
 		if gap <= bs.nearTipThreshold {
 			bs.isNearTip.Store(true)
-			mlog.Log.Infof("Switching to NEAR-TIP mode (gap=%d slots, threshold=%d)", gap, bs.nearTipThreshold)
+			mlog.Log.Infof("MODE SWITCH: catchup → NEAR-TIP | gap=%d (threshold=%d) | exec_slot=%d | tip=%d",
+				gap, bs.nearTipThreshold, lastExecuted, tip)
 		}
 	}
 }
@@ -1519,6 +1522,33 @@ func (bs *BlockSource) scheduler() {
 				}
 			}
 
+			// Check for priority slot blocked condition (rate-limited to once per 2s)
+			// This detects when the waiting slot keeps getting retried but isn't making progress
+			bs.waitingSlotErrorsMu.Lock()
+			waitingSlotInfo := bs.waitingSlotErrors[waitingSlot]
+			bs.waitingSlotErrorsMu.Unlock()
+
+			if waitingSlotInfo != nil && waitingSlotInfo.retryCount >= 3 {
+				bs.slotStateMu.Lock()
+				state, exists := bs.slotState[waitingSlot]
+				isInflight := exists && state == slotInflight
+				bs.slotStateMu.Unlock()
+
+				// Only log if slot is not currently inflight (stuck in retry cycle)
+				if !isInflight {
+					lastLog := time.Unix(bs.lastPriorityBlockedLog.Load(), 0)
+					if time.Since(lastLog) >= 2*time.Second {
+						bs.lastPriorityBlockedLog.Store(time.Now().Unix())
+						modeStr := "catchup"
+						if bs.isNearTip.Load() {
+							modeStr = "near-tip"
+						}
+						mlog.Log.Warnf("priority slot blocked: slot %d retried %d times but not inflight | mode: %s | last_err: %s",
+							waitingSlot, waitingSlotInfo.retryCount, modeStr, waitingSlotInfo.lastErrorClass)
+					}
+				}
+			}
+
 			// Send backup requests for stale slots (>1 second old)
 			for _, slot := range bs.getStaleSlots(1 * time.Second) {
 				if !backupSent[slot] {
@@ -1710,6 +1740,11 @@ type FetchStatsSnapshot struct {
 	GetBlockRPS float64 // getBlock calls per second over the stats window
 	SuccessRate float64 // Percentage of fetches that returned block data (vs skipped)
 	WindowSecs  float64 // How long the stats window has been open
+	// Stall diagnostics (for STALL log in replay loop)
+	WaitingSlotState   string // "inflight", "done", "pending", "missing"
+	WaitingSlotRetries int    // How many times the waiting slot has been retried
+	InflightCount      int    // Number of slots currently being fetched
+	RetryQueueLen      int    // Number of slots waiting to be retried
 }
 
 // GetFetchStats returns a snapshot of current fetch statistics
@@ -1728,6 +1763,40 @@ func (bs *BlockSource) GetFetchStats() FetchStatsSnapshot {
 	nextSlot := bs.nextSlotToSend
 	reorderLen := len(bs.reorderBuffer)
 	bs.reorderMu.Unlock()
+
+	// Stall diagnostics: waiting slot state and retry info
+	var waitingSlotState string
+	var inflightCount int
+	bs.slotStateMu.Lock()
+	if state, exists := bs.slotState[nextSlot]; exists {
+		switch state {
+		case slotInflight:
+			waitingSlotState = "inflight"
+		case slotDone:
+			waitingSlotState = "done"
+		case slotPending:
+			waitingSlotState = "pending"
+		}
+	} else {
+		waitingSlotState = "missing"
+	}
+	for _, state := range bs.slotState {
+		if state == slotInflight {
+			inflightCount++
+		}
+	}
+	bs.slotStateMu.Unlock()
+
+	var waitingSlotRetries int
+	bs.waitingSlotErrorsMu.Lock()
+	if info, exists := bs.waitingSlotErrors[nextSlot]; exists {
+		waitingSlotRetries = info.retryCount
+	}
+	bs.waitingSlotErrorsMu.Unlock()
+
+	bs.retryMu.Lock()
+	retryQueueLen := len(bs.retrySlots)
+	bs.retryMu.Unlock()
 
 	maxBuffered := bs.stats.MaxBufferedSlot.Load()
 	var leadSlots int64
@@ -1787,6 +1856,11 @@ func (bs *BlockSource) GetFetchStats() FetchStatsSnapshot {
 		GetBlockRPS:        getBlockRPS,
 		SuccessRate:        successRate,
 		WindowSecs:         windowSecs,
+		// Stall diagnostics
+		WaitingSlotState:   waitingSlotState,
+		WaitingSlotRetries: waitingSlotRetries,
+		InflightCount:      inflightCount,
+		RetryQueueLen:      retryQueueLen,
 	}
 }
 

--- a/pkg/blockstream/block_source.go
+++ b/pkg/blockstream/block_source.go
@@ -24,7 +24,7 @@ type BlockSourceType int
 const (
 	BlockSourceRpc = iota
 	BlockSourceFile
-	BlockSourceOvercast
+	BlockSourceLightbringer
 )
 
 type BlockSourceOpts struct {
@@ -1632,12 +1632,12 @@ func (bs *BlockSource) fetchAndParseBlockSequential(slot uint64) (*b.Block, erro
 			}
 			blk = block.FromBlockResult(blockResult, slot, rpc)
 		}
-	} else if bs.sourceType == BlockSourceOvercast {
-		// NOTE: BlockSourceOvercast is TEMPORARILY NON-FUNCTIONAL.
+	} else if bs.sourceType == BlockSourceLightbringer {
+		// NOTE: BlockSourceLightbringer is TEMPORARILY NON-FUNCTIONAL.
 		// The background block downloader that populated files for this path was removed.
-		// This code path will return SlotSkipped for every slot until Overcast streaming
+		// This code path will return SlotSkipped for every slot until Lightbringer streaming
 		// is re-implemented as a push-based source feeding directly into the reorder buffer.
-		// TODO: Implement Overcast as a streaming source (gRPC stream -> reorder buffer)
+		// TODO: Implement Lightbringer as a streaming source (gRPC stream -> reorder buffer)
 		blk, err = bs.tryGetBlockFromFile(slot)
 		if err != nil {
 			return nil, rpcclient.SlotSkipped

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -61,8 +61,8 @@ type ReportingConfig struct {
 
 // BlockConfig holds block source configuration
 type BlockConfig struct {
-	Source           string `toml:"source" mapstructure:"source"`                       // "rpc" or "overcast"
-	OvercastEndpoint string `toml:"overcast_endpoint" mapstructure:"overcast_endpoint"` // Overcast endpoint (optional)
+	Source              string `toml:"source" mapstructure:"source"`                             // "rpc" or "lightbringer"
+	LightbringerEndpoint string `toml:"lightbringer_endpoint" mapstructure:"lightbringer_endpoint"` // Lightbringer endpoint (optional)
 
 	// Global fetch tuning
 	MaxRPS          int `toml:"max_rps" mapstructure:"max_rps"`                       // Rate limit (requests per second)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -133,6 +133,16 @@ type SnapshotConfig struct {
 	MinIncrementalSpeedMBs float64 `toml:"min_incremental_speed_mbs" mapstructure:"min_incremental_speed_mbs"`
 }
 
+// LogConfig holds logging configuration
+type LogConfig struct {
+	Dir        string `toml:"dir" mapstructure:"dir"`                 // Log directory (default: /mnt/mithril-logs)
+	Level      string `toml:"level" mapstructure:"level"`             // Log level: debug, info, warn, error
+	ToStdout   bool   `toml:"to_stdout" mapstructure:"to_stdout"`     // Also write to stdout (default: true)
+	MaxSizeMB  int    `toml:"max_size_mb" mapstructure:"max_size_mb"` // Max log file size in MB before rotation
+	MaxAgeDays int    `toml:"max_age_days" mapstructure:"max_age_days"` // Delete logs older than this many days
+	MaxBackups int    `toml:"max_backups" mapstructure:"max_backups"` // Keep up to N old log files
+}
+
 // Config holds all configuration options for Mithril (Firedancer-style hierarchy)
 type Config struct {
 	// Top-level (matches Firedancer style)
@@ -147,6 +157,7 @@ type Config struct {
 	Snapshot    SnapshotConfig    `toml:"snapshot" mapstructure:"snapshot"`
 	Development DevelopmentConfig `toml:"development" mapstructure:"development"`
 	Reporting   ReportingConfig   `toml:"reporting" mapstructure:"reporting"`
+	Log         LogConfig         `toml:"log" mapstructure:"log"`
 }
 
 // ConfigFile holds the path to the config file (set via --config flag)

--- a/pkg/mlog/mlog.go
+++ b/pkg/mlog/mlog.go
@@ -323,12 +323,13 @@ func (l *logger) Infof(format string, args ...interface{}) {
 }
 
 // InfofPrecise logs with millisecond precision timing (for block replay)
+// Flushes immediately to ensure real-time output during replay
 func (l *logger) InfofPrecise(format string, args ...interface{}) {
 	if l.level > LevelInfo {
 		return
 	}
 	msg := fmt.Sprintf("%s%s\n", relativePrefixPrecise(), fmt.Sprintf(format, args...))
-	l.write(msg)
+	l.writeImmediate(msg)
 }
 
 func (l *logger) Warnf(format string, args ...interface{}) {

--- a/pkg/mlog/mlog.go
+++ b/pkg/mlog/mlog.go
@@ -78,9 +78,9 @@ func Initialize(cfg LogConfig, runID string) error {
 	Log.toStdout = cfg.ToStdout
 	Log.level = parseLevel(cfg.Level)
 
-	// If no dir specified, stdout only
+	// If no dir specified, stderr only (stderr to avoid breaking progress bar cursor positioning)
 	if cfg.Dir == "" {
-		Log.writer = os.Stdout
+		Log.writer = os.Stderr
 		Log.initialized = true
 		return nil
 	}
@@ -109,9 +109,9 @@ func Initialize(cfg LogConfig, runID string) error {
 		Compress:   true,  // gzip old logs
 	}
 
-	// Create multi-writer if stdout is enabled
+	// Create multi-writer if console output is enabled (use stderr to share stream with progress bars)
 	if cfg.ToStdout {
-		Log.writer = io.MultiWriter(os.Stdout, Log.fileWriter)
+		Log.writer = io.MultiWriter(os.Stderr, Log.fileWriter)
 	} else {
 		Log.writer = Log.fileWriter
 	}
@@ -286,8 +286,8 @@ func (l *logger) write(msg string) {
 	} else if l.writer != nil {
 		l.writer.Write([]byte(msg))
 	} else {
-		// Fallback to stdout if not initialized
-		fmt.Print(msg)
+		// Fallback to stderr if not initialized
+		fmt.Fprint(os.Stderr, msg)
 	}
 }
 
@@ -302,7 +302,7 @@ func (l *logger) writeImmediate(msg string) {
 	} else if l.writer != nil {
 		l.writer.Write([]byte(msg))
 	} else {
-		fmt.Print(msg)
+		fmt.Fprint(os.Stderr, msg)
 	}
 }
 

--- a/pkg/mlog/mlog.go
+++ b/pkg/mlog/mlog.go
@@ -1,18 +1,233 @@
 package mlog
 
 import (
+	"bufio"
 	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
 	"sync/atomic"
 	"time"
+
+	"gopkg.in/natefinch/lumberjack.v2"
 )
 
 var programStartTime = time.Now()
 
-type logger struct {
-	enableVerbose *atomic.Bool
+// LogLevel represents the logging level
+type LogLevel int
+
+const (
+	LevelDebug LogLevel = iota
+	LevelInfo
+	LevelWarn
+	LevelError
+)
+
+// LogConfig holds logging configuration (mirrors config.LogConfig)
+type LogConfig struct {
+	Dir        string // Log directory (default: /mnt/mithril-logs)
+	Level      string // Log level: debug, info, warn, error
+	ToStdout   bool   // Also write to stdout (default: true)
+	MaxSizeMB  int    // Max log file size in MB before rotation
+	MaxAgeDays int    // Delete logs older than this many days
+	MaxBackups int    // Keep up to N old log files
 }
 
-var Log = logger{&atomic.Bool{}}
+type logger struct {
+	mu            sync.Mutex
+	enableVerbose *atomic.Bool
+	level         LogLevel
+	toStdout      bool
+	writer        io.Writer // combined writer (file + optional stdout)
+	bufWriter     *bufio.Writer
+	fileWriter    *lumberjack.Logger
+	logPath       string
+	runID         string
+	initialized   bool
+	stopCh        chan struct{}
+	wg            sync.WaitGroup
+}
+
+var Log = logger{enableVerbose: &atomic.Bool{}, toStdout: true}
+
+// DefaultConfig returns sensible defaults for logging
+func DefaultConfig() LogConfig {
+	return LogConfig{
+		Dir:        "/mnt/mithril-logs",
+		Level:      "info",
+		ToStdout:   true,
+		MaxSizeMB:  100,
+		MaxAgeDays: 7,
+		MaxBackups: 10,
+	}
+}
+
+// Initialize sets up file logging with the given config and run ID.
+// If dir is empty, only stdout logging is used.
+func Initialize(cfg LogConfig, runID string) error {
+	Log.mu.Lock()
+	defer Log.mu.Unlock()
+
+	if Log.initialized {
+		return nil // Already initialized
+	}
+
+	Log.runID = runID
+	Log.toStdout = cfg.ToStdout
+	Log.level = parseLevel(cfg.Level)
+
+	// If no dir specified, stdout only
+	if cfg.Dir == "" {
+		Log.writer = os.Stdout
+		Log.initialized = true
+		return nil
+	}
+
+	// Create log directory if it doesn't exist
+	if err := os.MkdirAll(cfg.Dir, 0755); err != nil {
+		return fmt.Errorf("failed to create log directory %s: %w", cfg.Dir, err)
+	}
+
+	// Generate log filename: mithril-YYYYMMDD-HHMMSSZ-<runid>.log
+	now := time.Now().UTC()
+	shortRunID := runID
+	if len(shortRunID) > 8 {
+		shortRunID = shortRunID[:8]
+	}
+	filename := fmt.Sprintf("mithril-%s-%s.log", now.Format("20060102-150405Z"), shortRunID)
+	Log.logPath = filepath.Join(cfg.Dir, filename)
+
+	// Set up lumberjack for rotation
+	Log.fileWriter = &lumberjack.Logger{
+		Filename:   Log.logPath,
+		MaxSize:    cfg.MaxSizeMB,
+		MaxAge:     cfg.MaxAgeDays,
+		MaxBackups: cfg.MaxBackups,
+		LocalTime:  false, // Use UTC
+		Compress:   true,  // gzip old logs
+	}
+
+	// Create multi-writer if stdout is enabled
+	if cfg.ToStdout {
+		Log.writer = io.MultiWriter(os.Stdout, Log.fileWriter)
+	} else {
+		Log.writer = Log.fileWriter
+	}
+
+	// Wrap with buffered writer for performance
+	Log.bufWriter = bufio.NewWriterSize(Log.writer, 16*1024) // 16KB buffer
+
+	// Create symlink to latest log
+	symlinkPath := filepath.Join(cfg.Dir, "mithril-latest.log")
+	os.Remove(symlinkPath) // Ignore error if doesn't exist
+	if err := os.Symlink(filename, symlinkPath); err != nil {
+		// Non-fatal, just log to stdout
+		fmt.Fprintf(os.Stderr, "warning: failed to create symlink %s: %v\n", symlinkPath, err)
+	}
+
+	// Start background flush goroutine
+	Log.stopCh = make(chan struct{})
+	Log.wg.Add(1)
+	go Log.flushLoop()
+
+	Log.initialized = true
+	return nil
+}
+
+// flushLoop periodically flushes the buffer and syncs to disk
+func (l *logger) flushLoop() {
+	defer l.wg.Done()
+
+	flushTicker := time.NewTicker(2 * time.Second)
+	syncTicker := time.NewTicker(30 * time.Second)
+	defer flushTicker.Stop()
+	defer syncTicker.Stop()
+
+	for {
+		select {
+		case <-l.stopCh:
+			return
+		case <-flushTicker.C:
+			l.flush()
+		case <-syncTicker.C:
+			l.flushAndSync()
+		}
+	}
+}
+
+// flush flushes the buffer without syncing
+func (l *logger) flush() {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.bufWriter != nil {
+		l.bufWriter.Flush()
+	}
+}
+
+// flushAndSync flushes and syncs to disk
+func (l *logger) flushAndSync() {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.bufWriter != nil {
+		l.bufWriter.Flush()
+	}
+	// lumberjack doesn't expose Sync, but flush is sufficient for most cases
+}
+
+// Shutdown flushes all pending writes and closes the log file
+func Shutdown() {
+	Log.mu.Lock()
+	defer Log.mu.Unlock()
+
+	if !Log.initialized {
+		return
+	}
+
+	// Stop the flush goroutine
+	if Log.stopCh != nil {
+		close(Log.stopCh)
+		Log.mu.Unlock()
+		Log.wg.Wait()
+		Log.mu.Lock()
+	}
+
+	// Final flush
+	if Log.bufWriter != nil {
+		Log.bufWriter.Flush()
+	}
+
+	// Close lumberjack
+	if Log.fileWriter != nil {
+		Log.fileWriter.Close()
+	}
+
+	Log.initialized = false
+}
+
+// GetLogPath returns the path to the current log file
+func GetLogPath() string {
+	Log.mu.Lock()
+	defer Log.mu.Unlock()
+	return Log.logPath
+}
+
+// parseLevel converts a string level to LogLevel
+func parseLevel(level string) LogLevel {
+	switch level {
+	case "debug":
+		return LevelDebug
+	case "info":
+		return LevelInfo
+	case "warn":
+		return LevelWarn
+	case "error":
+		return LevelError
+	default:
+		return LevelInfo
+	}
+}
 
 // relativePrefix returns the elapsed time since program start as a prefix (no milliseconds)
 func relativePrefix() string {
@@ -61,29 +276,78 @@ func relativePrefixPrecise() string {
 	return fmt.Sprintf("(+%s) ", timeStr)
 }
 
-func (log *logger) Debugf(format string, args ...interface{}) {
-	if log.enableVerbose.Load() {
-		fmt.Printf("%s%s\n", relativePrefix(), fmt.Sprintf(format, args...))
+// write outputs a log message to the configured writer(s)
+func (l *logger) write(msg string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if l.bufWriter != nil {
+		l.bufWriter.WriteString(msg)
+	} else if l.writer != nil {
+		l.writer.Write([]byte(msg))
+	} else {
+		// Fallback to stdout if not initialized
+		fmt.Print(msg)
 	}
 }
 
-func (log *logger) Infof(format string, args ...interface{}) {
-	fmt.Printf("%s%s\n", relativePrefix(), fmt.Sprintf(format, args...))
+// writeImmediate outputs a log message and immediately flushes (for errors)
+func (l *logger) writeImmediate(msg string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if l.bufWriter != nil {
+		l.bufWriter.WriteString(msg)
+		l.bufWriter.Flush()
+	} else if l.writer != nil {
+		l.writer.Write([]byte(msg))
+	} else {
+		fmt.Print(msg)
+	}
+}
+
+func (l *logger) Debugf(format string, args ...interface{}) {
+	if l.level > LevelDebug && !l.enableVerbose.Load() {
+		return
+	}
+	msg := fmt.Sprintf("%s%s\n", relativePrefix(), fmt.Sprintf(format, args...))
+	l.write(msg)
+}
+
+func (l *logger) Infof(format string, args ...interface{}) {
+	if l.level > LevelInfo {
+		return
+	}
+	msg := fmt.Sprintf("%s%s\n", relativePrefix(), fmt.Sprintf(format, args...))
+	l.write(msg)
 }
 
 // InfofPrecise logs with millisecond precision timing (for block replay)
-func (log *logger) InfofPrecise(format string, args ...interface{}) {
-	fmt.Printf("%s%s\n", relativePrefixPrecise(), fmt.Sprintf(format, args...))
+func (l *logger) InfofPrecise(format string, args ...interface{}) {
+	if l.level > LevelInfo {
+		return
+	}
+	msg := fmt.Sprintf("%s%s\n", relativePrefixPrecise(), fmt.Sprintf(format, args...))
+	l.write(msg)
 }
 
-func (log *logger) Errorf(format string, args ...interface{}) {
-	fmt.Printf("%sERROR: %s\n", relativePrefix(), fmt.Sprintf(format, args...))
+func (l *logger) Warnf(format string, args ...interface{}) {
+	if l.level > LevelWarn {
+		return
+	}
+	msg := fmt.Sprintf("%sWARN: %s\n", relativePrefix(), fmt.Sprintf(format, args...))
+	l.writeImmediate(msg) // Warnings flush immediately
 }
 
-func (log *logger) EnableInfLogging() {
-	log.enableVerbose.Store(true)
+func (l *logger) Errorf(format string, args ...interface{}) {
+	msg := fmt.Sprintf("%sERROR: %s\n", relativePrefix(), fmt.Sprintf(format, args...))
+	l.writeImmediate(msg) // Errors always flush immediately
 }
 
-func (log *logger) DisableInfLogging() {
-	log.enableVerbose.Store(false)
+func (l *logger) EnableInfLogging() {
+	l.enableVerbose.Store(true)
+}
+
+func (l *logger) DisableInfLogging() {
+	l.enableVerbose.Store(false)
 }

--- a/pkg/mlog/mlog.go
+++ b/pkg/mlog/mlog.go
@@ -306,6 +306,19 @@ func (l *logger) writeImmediate(msg string) {
 	}
 }
 
+// writeFileOnly outputs a log message only to the file, not to stdout/stderr.
+// Used for diagnostics that should be captured for debugging but not clutter the terminal.
+func (l *logger) writeFileOnly(msg string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	// Write only to file writer, bypassing the multi-writer
+	if l.fileWriter != nil {
+		l.fileWriter.Write([]byte(msg))
+	}
+	// If no file writer, silently discard (file-only logging disabled)
+}
+
 func (l *logger) Debugf(format string, args ...interface{}) {
 	if l.level > LevelDebug && !l.enableVerbose.Load() {
 		return
@@ -320,6 +333,16 @@ func (l *logger) Infof(format string, args ...interface{}) {
 	}
 	msg := fmt.Sprintf("%s%s\n", relativePrefix(), fmt.Sprintf(format, args...))
 	l.write(msg)
+}
+
+// FileOnlyf logs a message only to the log file, not to the terminal.
+// Used for diagnostics that should be captured for debugging but not clutter the terminal.
+func (l *logger) FileOnlyf(format string, args ...interface{}) {
+	if l.level > LevelInfo {
+		return
+	}
+	msg := fmt.Sprintf("%s%s\n", relativePrefix(), fmt.Sprintf(format, args...))
+	l.writeFileOnly(msg)
 }
 
 // InfofPrecise logs with millisecond precision timing (for block replay)

--- a/pkg/progress/progress.go
+++ b/pkg/progress/progress.go
@@ -130,15 +130,17 @@ func (p *ProgressBar) Render(useColor bool) string {
 
 	throughput := p.updateThroughput()
 
-	// Calculate ETA
-	var eta string
-	if throughput > 0 && total > current {
+	// Calculate ETA or show elapsed time if complete
+	elapsed := time.Since(p.startTime)
+	var etaStr string
+	if current >= total && total > 0 {
+		// Complete - show how long it took
+		etaStr = fmt.Sprintf("Finished in %s", formatDurationRounded(elapsed))
+	} else if throughput > 0 && total > current {
 		remaining := float64(total-current) / throughput
-		eta = formatDuration(time.Duration(remaining * float64(time.Second)))
-	} else if current >= total && total > 0 {
-		eta = "done"
+		etaStr = fmt.Sprintf("ETA %s", formatDuration(time.Duration(remaining*float64(time.Second))))
 	} else {
-		eta = "--:--"
+		etaStr = "ETA --:--"
 	}
 
 	// Build the bar
@@ -156,13 +158,13 @@ func (p *ProgressBar) Render(useColor bool) string {
 
 	// Build the line with size progress
 	if useColor {
-		return fmt.Sprintf("%s%-24s%s [%s%s%s] %5.1f%% %13s %8s  ETA %s",
+		return fmt.Sprintf("%s%-24s%s [%s%s%s] %5.1f%% %13s %8s  %s",
 			colorTeal, p.label, colorReset,
 			colorTeal, bar, colorReset,
-			percent, sizeStr, throughputStr, eta)
+			percent, sizeStr, throughputStr, etaStr)
 	}
-	return fmt.Sprintf("%-24s [%s] %5.1f%% %13s %8s  ETA %s",
-		p.label, bar, percent, sizeStr, throughputStr, eta)
+	return fmt.Sprintf("%-24s [%s] %5.1f%% %13s %8s  %s",
+		p.label, bar, percent, sizeStr, throughputStr, etaStr)
 }
 
 func formatThroughput(bytesPerSec float64) string {
@@ -203,6 +205,31 @@ func formatDuration(d time.Duration) string {
 		return fmt.Sprintf("%dh%02dm", h, m)
 	}
 	return fmt.Sprintf("%dm%02ds", m, s)
+}
+
+// formatDurationRounded formats duration with friendlier spacing and rounds up to nearest second
+func formatDurationRounded(d time.Duration) string {
+	if d < 0 {
+		return "0s"
+	}
+	// Round up to nearest second
+	if d%time.Second != 0 {
+		d = d.Truncate(time.Second) + time.Second
+	}
+
+	h := d / time.Hour
+	d -= h * time.Hour
+	m := d / time.Minute
+	d -= m * time.Minute
+	s := d / time.Second
+
+	if h > 0 {
+		return fmt.Sprintf("%dh %dm", h, m)
+	}
+	if m > 0 {
+		return fmt.Sprintf("%dm %ds", m, s)
+	}
+	return fmt.Sprintf("%ds", s)
 }
 
 // DualProgress manages two progress bars displayed simultaneously:
@@ -448,24 +475,25 @@ func (p *IndexingProgress) Update(completed, total int) {
 	bar := strings.Repeat("█", filled) + strings.Repeat("░", barWidth-filled)
 
 	elapsed := time.Since(p.startTime)
-	var eta string
-	if completed > 0 && completed < total {
+	var etaStr string
+	if completed >= total {
+		// Complete - show how long it took
+		etaStr = fmt.Sprintf("Finished in %s", formatDurationRounded(elapsed))
+	} else if completed > 0 && completed < total {
 		remaining := elapsed * time.Duration(total-completed) / time.Duration(completed)
-		eta = formatDuration(remaining)
-	} else if completed >= total {
-		eta = "done"
+		etaStr = fmt.Sprintf("ETA %s", formatDuration(remaining))
 	} else {
-		eta = "--:--"
+		etaStr = "ETA --:--"
 	}
 
 	if p.useColor {
-		fmt.Fprintf(p.output, "%s%-24s%s [%s%s%s] %5.1f%% %4d/%-4d shards  ETA %s\n",
+		fmt.Fprintf(p.output, "%s%-24s%s [%s%s%s] %5.1f%% %4d/%-4d shards  %s\n",
 			colorTeal, p.label, colorReset,
 			colorTeal, bar, colorReset,
-			percent, completed, total, eta)
+			percent, completed, total, etaStr)
 	} else {
-		fmt.Fprintf(p.output, "%-24s [%s] %5.1f%% %4d/%-4d shards  ETA %s\n",
-			p.label, bar, percent, completed, total, eta)
+		fmt.Fprintf(p.output, "%-24s [%s] %5.1f%% %4d/%-4d shards  %s\n",
+			p.label, bar, percent, completed, total, etaStr)
 	}
 }
 

--- a/pkg/progress/progress.go
+++ b/pkg/progress/progress.go
@@ -344,6 +344,11 @@ func (d *DualProgress) updateLoop() {
 			d.render()
 			return
 		case <-ticker.C:
+			// Skip rendering until we have actual data to show
+			// This prevents duplicate empty 0% bars from appearing
+			if d.Download.Total() == 0 {
+				continue
+			}
 			d.updateEstimates()
 			d.render()
 		}

--- a/pkg/progress/progress.go
+++ b/pkg/progress/progress.go
@@ -999,17 +999,29 @@ func PromptStaleAccountsDB(info StaleInfo) int {
 		r = colorReset
 	}
 
-	// Print the prompt box
+	// Format slot values
+	accountsSlot := formatSlots(info.AccountsDBSlot)
+	latestSlot := formatSlots(info.LatestSnapshotSlot)
+	slotsBehind := formatSlots(info.SlotsBehind)
+
+	// Build option 1 text and calculate padding
+	opt1Text := fmt.Sprintf("  [1] Continue from AccountsDB (replay %s slots)", slotsBehind)
+	opt1Padding := 76 - len(opt1Text)
+	if opt1Padding < 0 {
+		opt1Padding = 0
+	}
+
+	// Print the prompt box (76 chars inner width)
 	fmt.Println()
 	fmt.Printf("%s┌──────────────────────────────────────────────────────────────────────────────┐%s\n", c, r)
 	fmt.Printf("%s│%s ACCOUNTSDB BEHIND CHAIN TIP                                                  %s│%s\n", c, r, c, r)
 	fmt.Printf("%s├──────────────────────────────────────────────────────────────────────────────┤%s\n", c, r)
-	fmt.Printf("%s│%s %-24s%-52s%s│%s\n", c, r, "AccountsDB last slot:", formatSlots(info.AccountsDBSlot), c, r)
-	fmt.Printf("%s│%s %-24s%-52s%s│%s\n", c, r, "Latest snapshot slot:", formatSlots(info.LatestSnapshotSlot), c, r)
-	fmt.Printf("%s│%s %-24s%-52s%s│%s\n", c, r, "Slots behind:", formatSlots(info.SlotsBehind), c, r)
+	fmt.Printf("%s│%s %-24s%-52s %s│%s\n", c, r, "AccountsDB last slot:", accountsSlot, c, r)
+	fmt.Printf("%s│%s %-24s%-52s %s│%s\n", c, r, "Chain tip slot:", latestSlot, c, r)
+	fmt.Printf("%s│%s %-24s%-52s %s│%s\n", c, r, "Slots behind:", slotsBehind, c, r)
 	fmt.Printf("%s├──────────────────────────────────────────────────────────────────────────────┤%s\n", c, r)
 	fmt.Printf("%s│%s OPTIONS:                                                                     %s│%s\n", c, r, c, r)
-	fmt.Printf("%s│%s   [1] Continue from AccountsDB (replay %s slots)%-26s%s│%s\n", c, r, formatSlots(info.SlotsBehind), "", c, r)
+	fmt.Printf("%s│%s%s%*s %s│%s\n", c, r, opt1Text, opt1Padding, "", c, r)
 	fmt.Printf("%s│%s   [2] Start fresh from latest snapshot (faster to catch up)                 %s│%s\n", c, r, c, r)
 	fmt.Printf("%s│%s                                                                              %s│%s\n", c, r, c, r)
 	fmt.Printf("%s└──────────────────────────────────────────────────────────────────────────────┘%s\n", c, r)

--- a/pkg/progress/progress.go
+++ b/pkg/progress/progress.go
@@ -322,7 +322,6 @@ func (d *DualProgress) Start() {
 	if d.useColor {
 		fmt.Fprintf(d.output, "%s", colorReset)
 	}
-	fmt.Fprintln(d.output)
 
 	// Print initial empty lines for progress bars (2 bars)
 	fmt.Fprintln(d.output)

--- a/pkg/progress/progress.go
+++ b/pkg/progress/progress.go
@@ -252,15 +252,15 @@ type DualProgress struct {
 
 // NewDualProgress creates a new dual progress display
 func NewDualProgress() *DualProgress {
-	// Check if stdout is a TTY
-	useColor := term.IsTerminal(int(os.Stdout.Fd()))
+	// Use stderr for progress bars to avoid interleaving with log output on stdout
+	useColor := term.IsTerminal(int(os.Stderr.Fd()))
 
 	return &DualProgress{
 		Download: NewProgressBar("Snapshot Read (.tar.zst)"),
 		Extract:  NewProgressBar("Extract (AppendVecs)"),
 		stopCh:   make(chan struct{}),
 		doneCh:   make(chan struct{}),
-		output:   os.Stdout,
+		output:   os.Stderr,
 		useColor: useColor,
 	}
 }
@@ -437,11 +437,12 @@ type IndexingProgress struct {
 
 // NewIndexingProgress creates a new indexing progress display
 func NewIndexingProgress(label string) *IndexingProgress {
+	// Use stderr for progress bars to avoid interleaving with log output on stdout
 	return &IndexingProgress{
 		label:     label,
 		startTime: time.Now(),
-		output:    os.Stdout,
-		useColor:  term.IsTerminal(int(os.Stdout.Fd())),
+		output:    os.Stderr,
+		useColor:  term.IsTerminal(int(os.Stderr.Fd())),
 	}
 }
 

--- a/pkg/replay/block.go
+++ b/pkg/replay/block.go
@@ -1073,15 +1073,24 @@ func ReplayBlocks(
 			continue // Skip all execution - no state changes for skipped slots
 		}
 
-		// Stall detection: warn if waited too long for a block
-		// Threshold is 10s because backup requests are sent at 1s for slow slots.
-		// Skip first block (startup has TLS/connection overhead)
-		if waitTime > 10*time.Second && len(execTimes) > 0 {
+		// Stall detection: log if waited too long for a block
+		// 2-5s: log to file only (FileOnlyf) for diagnostics without terminal noise
+		// >5s: log to terminal too (Warnf) because something is definitely wrong
+		// Don't log for first block - startup has TLS/connection overhead that causes false positives
+		if waitTime > 2*time.Second && len(execTimes) > 0 {
 			stats := blockStream.GetFetchStats()
-			mlog.Log.Errorf("STALL: waited %.1fs for slot %d (max fetched: %d) | buffer: %d | lead: %d | tip: %d | errs: na:%d rl:%d bt:%d tr:%d | wq:%d ro:%d",
-				waitTime.Seconds(), stats.NextSlot, stats.MaxBuffered, stats.BufferDepth, stats.LeadSlots, stats.ConfirmedTip,
-				stats.ErrNotAvail, stats.ErrRateLimit, stats.ErrBeyondTip, stats.ErrTransient,
-				stats.WorkQueueLen, stats.ReorderBufLen)
+			modeStr := "catchup"
+			if stats.IsNearTip {
+				modeStr = "near-tip"
+			}
+			stallMsg := fmt.Sprintf("STALL: waited %.1fs for slot %d | mode: %s | tip_stale: %ds | state: %s | retries: %d | inflight: %d | retry_q: %d | tip: %d",
+				waitTime.Seconds(), stats.NextSlot, modeStr, stats.TipStaleSecs, stats.WaitingSlotState,
+				stats.WaitingSlotRetries, stats.InflightCount, stats.RetryQueueLen, stats.ConfirmedTip)
+			if waitTime > 5*time.Second {
+				mlog.Log.Warnf("%s", stallMsg) // Terminal + log file
+			} else {
+				mlog.Log.FileOnlyf("%s", stallMsg) // Log file only
+			}
 		}
 
 		if ctx.Err() != nil {

--- a/pkg/replay/block.go
+++ b/pkg/replay/block.go
@@ -116,7 +116,15 @@ type ReplayResult struct {
 
 	// SlotHashes context - same issue, vote program needs accurate slot→hash mappings
 	LastSlotHashes *sealevel.SysvarSlotHashes
+
+	// StateWrittenOnCancel indicates that the state file was already written during
+	// cancellation handling, so the caller should skip the final write
+	StateWrittenOnCancel bool
 }
+
+// OnCancelWriteState is a callback that writes state immediately on cancellation.
+// This eliminates the timing window between bankhash persistence and state file update.
+type OnCancelWriteState func(result *ReplayResult) error
 
 // ResumeState contains the state needed to properly configure the first block when resuming.
 // This is passed to ReplayBlocks when resuming from a previous run.
@@ -919,6 +927,7 @@ func ReplayBlocks(
 	metricsWriter io.Writer,
 	rpcServer *rpcserver.RpcServer,
 	blockFetchOpts *BlockFetchOpts,
+	onCancelWriteState OnCancelWriteState, // callback to write state immediately on cancellation (can be nil)
 ) *ReplayResult {
 	result := &ReplayResult{}
 
@@ -1178,6 +1187,34 @@ func ReplayBlocks(
 		if ctx.Err() != nil {
 			mlog.Log.Infof("context cancelled after slot %d, exiting replay loop", block.Slot)
 			result.WasCancelled = true
+
+			// Populate result immediately for state write
+			result.LastPersistedSlot = lastPersistedSlot
+			result.LastPersistedBankhash = lastPersistedBankhash
+
+			// Capture resume context from the last slot context
+			if lastSlotCtx != nil {
+				result.LastAcctsLtHash = lastSlotCtx.AcctsLtHash
+				if lastSlotCtx.FeeRateGovernor != nil {
+					result.LastLamportsPerSignature = lastSlotCtx.FeeRateGovernor.LamportsPerSignature
+					result.LastPrevLamportsPerSig = lastSlotCtx.FeeRateGovernor.PrevLamportsPerSignature
+				}
+				result.LastNumSignatures = lastSlotCtx.NumSignatures
+				result.LastRecentBlockhashes = sealevel.SysvarCache.RecentBlockHashes.Sysvar
+				result.LastEvictedBlockhash = lastSlotCtx.LatestEvictedBlockhash
+				result.LastBlockhash = lastSlotCtx.Blockhash
+				result.LastSlotHashes = sealevel.SysvarCache.SlotHashes.Sysvar
+			}
+
+			// Write state immediately via callback (eliminates timing window for hard kills)
+			if onCancelWriteState != nil {
+				if err := onCancelWriteState(result); err != nil {
+					mlog.Log.Errorf("failed to write state on cancel: %v", err)
+				} else {
+					result.StateWrittenOnCancel = true
+				}
+			}
+
 			break
 		}
 

--- a/pkg/replay/block.go
+++ b/pkg/replay/block.go
@@ -1102,8 +1102,8 @@ func ReplayBlocks(
 				leaderStr = leader.String()
 			}
 			// Log skipped slot in same format as regular blocks (with N/A for missing values)
-			// Padding matches normal format: cu=10 chars, txns=16 chars (v:%-5d nv:%-5d), exec=no padding
-			mlog.Log.InfofPrecise("slot %-10d | leader: %-44s | cu: N/A       | txns: N/A             | exec: N/A | total: %.3fs (skipped)",
+			// Padding: cu=10 chars + space, txns=16 chars + space, exec=variable (matches normal format)
+			mlog.Log.InfofPrecise("slot %-10d | leader: %-44s | cu: N/A        | txns: N/A              | exec: N/A | total: %.3fs (skipped)",
 				block.Slot, leaderStr, waitTime.Seconds())
 			skippedSlotsCount++
 			continue // Skip all execution - no state changes for skipped slots

--- a/pkg/replay/block.go
+++ b/pkg/replay/block.go
@@ -1052,9 +1052,44 @@ func ReplayBlocks(
 	var skippedSlotsCount int // Track skipped slots for 100-slot summary
 
 	for {
+		// Start stall monitor goroutine (only after first block to avoid startup false positives)
+		// Logs to file every second while waiting for a block
+		var stallDone chan struct{}
+		if len(execTimes) > 0 {
+			stallDone = make(chan struct{})
+			go func() {
+				ticker := time.NewTicker(1 * time.Second)
+				defer ticker.Stop()
+				secondsWaiting := 0
+				for {
+					select {
+					case <-stallDone:
+						return
+					case <-ticker.C:
+						secondsWaiting++
+						stats := blockStream.GetFetchStats()
+						modeStr := "catchup"
+						if stats.IsNearTip {
+							modeStr = "near-tip"
+						}
+						stallMsg := fmt.Sprintf("STALL: waiting %ds for slot %d | mode: %s | tip_stale: %ds | state: %s | retries: %d | inflight: %d | retry_q: %d | tip: %d",
+							secondsWaiting, stats.NextSlot, modeStr, stats.TipStaleSecs, stats.WaitingSlotState,
+							stats.WaitingSlotRetries, stats.InflightCount, stats.RetryQueueLen, stats.ConfirmedTip)
+						mlog.Log.FileOnlyf("%s", stallMsg)
+					}
+				}
+			}()
+		}
+
 		waitStart := time.Now()
 		block := blockStream.NextBlock()
 		waitTime := time.Since(waitStart)
+
+		// Stop stall monitor
+		if stallDone != nil {
+			close(stallDone)
+		}
+
 		if block == nil {
 			break
 		}
@@ -1067,30 +1102,11 @@ func ReplayBlocks(
 				leaderStr = leader.String()
 			}
 			// Log skipped slot in same format as regular blocks (with N/A for missing values)
-			mlog.Log.InfofPrecise("slot %-10d | leader: %-44s | cu: N/A        | txns: N/A           | exec: N/A   | total: %.3fs (skipped)",
+			// Padding matches normal format: cu=10 chars, txns=16 chars (v:%-5d nv:%-5d), exec=no padding
+			mlog.Log.InfofPrecise("slot %-10d | leader: %-44s | cu: N/A       | txns: N/A             | exec: N/A | total: %.3fs (skipped)",
 				block.Slot, leaderStr, waitTime.Seconds())
 			skippedSlotsCount++
 			continue // Skip all execution - no state changes for skipped slots
-		}
-
-		// Stall detection: log if waited too long for a block
-		// 2-5s: log to file only (FileOnlyf) for diagnostics without terminal noise
-		// >5s: log to terminal too (Warnf) because something is definitely wrong
-		// Don't log for first block - startup has TLS/connection overhead that causes false positives
-		if waitTime > 2*time.Second && len(execTimes) > 0 {
-			stats := blockStream.GetFetchStats()
-			modeStr := "catchup"
-			if stats.IsNearTip {
-				modeStr = "near-tip"
-			}
-			stallMsg := fmt.Sprintf("STALL: waited %.1fs for slot %d | mode: %s | tip_stale: %ds | state: %s | retries: %d | inflight: %d | retry_q: %d | tip: %d",
-				waitTime.Seconds(), stats.NextSlot, modeStr, stats.TipStaleSecs, stats.WaitingSlotState,
-				stats.WaitingSlotRetries, stats.InflightCount, stats.RetryQueueLen, stats.ConfirmedTip)
-			if waitTime > 5*time.Second {
-				mlog.Log.Warnf("%s", stallMsg) // Terminal + log file
-			} else {
-				mlog.Log.FileOnlyf("%s", stallMsg) // Log file only
-			}
 		}
 
 		if ctx.Err() != nil {

--- a/pkg/replay/block.go
+++ b/pkg/replay/block.go
@@ -862,7 +862,7 @@ func configureInitialBlockFromResume(acctsDb *accountsdb.AccountsDb,
 		// Restore SysvarCache.SlotHashes from state file (vote program needs accurate slot→hash mappings)
 		if resumeState.SlotHashes != nil {
 			sealevel.SysvarCache.SlotHashes.Sysvar = resumeState.SlotHashes
-			mlog.Log.Infof("restored SlotHashes sysvar cache with %d entries from state file", len(*resumeState.SlotHashes))
+			mlog.Log.Infof("restored SlotHashes sysvar cache with %d entries from state file\n", len(*resumeState.SlotHashes))
 		}
 	} else {
 		// No blockhash context in state file - this should not happen with new state files,

--- a/pkg/replay/block.go
+++ b/pkg/replay/block.go
@@ -71,8 +71,8 @@ var commitSlot atomic.Uint64 // The slot currently being committed (for error me
 // CurrentRunID is a unique identifier for this replay session, used to correlate logs
 var CurrentRunID string
 
-// generateRunID creates a short random hex string for log correlation
-func generateRunID() string {
+// GenerateRunID creates a short random hex string for log correlation
+func GenerateRunID() string {
 	b := make([]byte, 4) // 8 hex chars
 	if _, err := rand.Read(b); err != nil {
 		// Fallback to timestamp-based ID if crypto/rand fails
@@ -933,7 +933,7 @@ func ReplayBlocks(
 
 	// Generate unique run ID for log correlation (only if not already set by startup)
 	if CurrentRunID == "" {
-		CurrentRunID = generateRunID()
+		CurrentRunID = GenerateRunID()
 	}
 	// Create bankhash log file
 	bankhashLogPath := fmt.Sprintf("%s/bankhash.log", acctsDbPath)

--- a/pkg/replay/block.go
+++ b/pkg/replay/block.go
@@ -1049,12 +1049,28 @@ func ReplayBlocks(
 	}
 	go blockStream.Start()
 
+	var skippedSlotsCount int // Track skipped slots for 100-slot summary
+
 	for {
 		waitStart := time.Now()
 		block := blockStream.NextBlock()
 		waitTime := time.Since(waitStart)
 		if block == nil {
 			break
+		}
+
+		// Handle skipped slots - log and continue without execution
+		if block.IsSkipped {
+			// Look up leader for informational logging
+			leaderStr := "unknown"
+			if leader, exists := global.LeaderForSlot(block.Slot); exists {
+				leaderStr = leader.String()
+			}
+			// Log skipped slot in same format as regular blocks (with N/A for missing values)
+			mlog.Log.InfofPrecise("slot %-10d | leader: %-44s | cu: N/A        | txns: N/A           | exec: N/A   | total: %.3fs (skipped)",
+				block.Slot, leaderStr, waitTime.Seconds())
+			skippedSlotsCount++
+			continue // Skip all execution - no state changes for skipped slots
 		}
 
 		// Stall detection: warn if waited too long for a block
@@ -1388,12 +1404,14 @@ func ReplayBlocks(
 				// Get fetch stats (includes tip snapshot - refreshed at slot 95)
 				fetchStats := blockStream.GetFetchStats()
 
-				// Calculate distance from tip
+				// Calculate distance from tip using current slot (more accurate than TipAtSlot)
+				// TipAtSlot is when we started the refresh, but block.Slot is what we just executed
 				var tipDistanceStr string
-				if fetchStats.ConfirmedTip > 0 && fetchStats.TipAtSlot > 0 && fetchStats.TipAtSlot < fetchStats.ConfirmedTip {
-					behindConfirmed := fetchStats.ConfirmedTip - fetchStats.TipAtSlot
-					if fetchStats.ProcessedTip > 0 && fetchStats.TipAtSlot < fetchStats.ProcessedTip {
-						behindProcessed := fetchStats.ProcessedTip - fetchStats.TipAtSlot
+				currentSlotForTip := block.Slot
+				if fetchStats.ConfirmedTip > 0 && currentSlotForTip < fetchStats.ConfirmedTip {
+					behindConfirmed := fetchStats.ConfirmedTip - currentSlotForTip
+					if fetchStats.ProcessedTip > 0 && currentSlotForTip < fetchStats.ProcessedTip {
+						behindProcessed := fetchStats.ProcessedTip - currentSlotForTip
 						tipDistanceStr = fmt.Sprintf("%d slots behind confirmed, %d behind processed",
 							behindConfirmed, behindProcessed)
 					} else {
@@ -1409,13 +1427,18 @@ func ReplayBlocks(
 				mlog.Log.InfofPrecise("")
 				mlog.Log.InfofPrecise("=== 100 Slot Summary ===")
 
-				// Line 1: Mode, blocks/sec, tip distance
+				// Line 1: Mode, blocks/sec, skipped slots, tip distance
 				modeStr := "catchup"
 				if fetchStats.IsNearTip {
 					modeStr = "near-tip"
 				}
-				mlog.Log.InfofPrecise("  mode: %s | %.1f blocks/sec | %s",
-					modeStr, blocksPerSec, tipDistanceStr)
+				if skippedSlotsCount > 0 {
+					mlog.Log.InfofPrecise("  mode: %s | %.1f blocks/sec | %d skipped | %s",
+						modeStr, blocksPerSec, skippedSlotsCount, tipDistanceStr)
+				} else {
+					mlog.Log.InfofPrecise("  mode: %s | %.1f blocks/sec | %s",
+						modeStr, blocksPerSec, tipDistanceStr)
+				}
 
 				// Line 2: CU and transaction stats (median/min/max)
 				mlog.Log.InfofPrecise("  cu: median %d, min %d, max %d | txns: median vote %d, median non-vote %d",
@@ -1450,6 +1473,7 @@ func ReplayBlocks(
 				voteTxCounts = voteTxCounts[:0]
 				nonVoteTxCounts = nonVoteTxCounts[:0]
 				statsCounter = 0
+				skippedSlotsCount = 0
 			}
 		} else {
 			justCrossedEpochBoundary = false

--- a/pkg/replay/block.go
+++ b/pkg/replay/block.go
@@ -922,7 +922,7 @@ func ReplayBlocks(
 	blockDir string,
 	txParallelism int,
 	isLive bool,
-	useOvercast bool,
+	useLightbringer bool,
 	dbgOpts *DebugOptions,
 	metricsWriter io.Writer,
 	rpcServer *rpcserver.RpcServer,
@@ -1007,9 +1007,9 @@ func ReplayBlocks(
 	nonVoteTxCounts = make([]uint64, 0, summaryInterval)
 
 	var opts *blockstream.BlockSourceOpts
-	if useOvercast {
+	if useLightbringer {
 		opts = &blockstream.BlockSourceOpts{
-			SourceType:         blockstream.BlockSourceOvercast,
+			SourceType:         blockstream.BlockSourceLightbringer,
 			RpcClient:          rpcc,
 			BackupRpcEndpoints: rpcBackups,
 			StartSlot:          startSlot,
@@ -1634,7 +1634,7 @@ func parallelTxLoop(slotCtx *sealevel.SlotCtx, sigverifyWg *sync.WaitGroup, bloc
 	errs := make([]error, len(block.Transactions))
 	txDurations := make([]time.Duration, txParallelism)
 
-	if rblock.FromOvercast {
+	if rblock.FromLightbringer {
 		wg := &sync.WaitGroup{}
 		workerPool, _ := ants.NewPoolWithFunc(txParallelism, func(i interface{}) {
 			defer wg.Done()
@@ -1722,7 +1722,7 @@ func ProcessBlock(acctsDb *accountsdb.AccountsDb, block *b.Block, txParallelism 
 	for i := range block.Transactions {
 		unresolvedBlock.Transactions[i] = &solana.Transaction{}
 		*(unresolvedBlock.Transactions[i]) = *block.Transactions[i]
-		if unresolvedBlock.TxMetas != nil && !block.FromOvercast {
+		if unresolvedBlock.TxMetas != nil && !block.FromLightbringer {
 			unresolvedBlock.TxMetas[i] = &rpc.TransactionMeta{}
 			*(unresolvedBlock.TxMetas[i]) = *block.TxMetas[i]
 		}

--- a/pkg/replay/block.go
+++ b/pkg/replay/block.go
@@ -1172,6 +1172,15 @@ func ReplayBlocks(
 		lastPersistedSlot = block.Slot
 		lastPersistedBankhash = lastSlotCtx.FinalBankhash
 
+		// Check for cancellation immediately after block completes.
+		// This minimizes the window between bankhash persistence and state file update,
+		// preventing false "corruption" detection on graceful shutdown.
+		if ctx.Err() != nil {
+			mlog.Log.Infof("context cancelled after slot %d, exiting replay loop", block.Slot)
+			result.WasCancelled = true
+			break
+		}
+
 		slotReplayDuration := time.Since(start)
 
 		// Calculate slot stats: vote/non-vote tx counts and total CU

--- a/pkg/replay/block.go
+++ b/pkg/replay/block.go
@@ -1433,17 +1433,12 @@ func ReplayBlocks(
 				// TipAtSlot is when we started the refresh, but block.Slot is what we just executed
 				var tipDistanceStr string
 				currentSlotForTip := block.Slot
-				if fetchStats.ConfirmedTip > 0 && currentSlotForTip < fetchStats.ConfirmedTip {
-					behindConfirmed := fetchStats.ConfirmedTip - currentSlotForTip
-					if fetchStats.ProcessedTip > 0 && currentSlotForTip < fetchStats.ProcessedTip {
-						behindProcessed := fetchStats.ProcessedTip - currentSlotForTip
-						tipDistanceStr = fmt.Sprintf("%d slots behind confirmed, %d behind processed",
-							behindConfirmed, behindProcessed)
-					} else {
-						tipDistanceStr = fmt.Sprintf("%d slots behind confirmed", behindConfirmed)
+				if fetchStats.ConfirmedTip > 0 {
+					var behindConfirmed uint64
+					if currentSlotForTip < fetchStats.ConfirmedTip {
+						behindConfirmed = fetchStats.ConfirmedTip - currentSlotForTip
 					}
-				} else if fetchStats.ConfirmedTip > 0 {
-					tipDistanceStr = "caught up"
+					tipDistanceStr = fmt.Sprintf("%d slots behind confirmed", behindConfirmed)
 				} else {
 					tipDistanceStr = "tip unknown"
 				}

--- a/pkg/snapshot/bufmonreader.go
+++ b/pkg/snapshot/bufmonreader.go
@@ -86,7 +86,7 @@ func NewBufMonReaderHTTPWithSave(ctx context.Context, url string, savePath strin
 
 	// If savePath is provided, use TeeReader to write to disk while streaming
 	if savePath != "" {
-		mlog.Log.Infof("Saving snapshot to %s while streaming...", savePath)
+		// Note: Don't log here - caller logs before progress bar starts to avoid breaking cursor positioning
 		outFile, err := os.Create(savePath)
 		if err != nil {
 			resp.Body.Close()

--- a/pkg/snapshot/build_db.go
+++ b/pkg/snapshot/build_db.go
@@ -254,7 +254,7 @@ func BuildAccountsDb(
 	mlog.Log.Infof("Stopping shard setter.")
 	ss.Stop()
 
-	mlog.Log.Infof("snapshot processed in %s.\n", fmtDuration(time.Since(start)))
+	mlog.Log.Infof("snapshot processed in %s.", fmtDuration(time.Since(start)))
 
 	var largestFileIdBytes [8]byte
 	binary.LittleEndian.PutUint64(largestFileIdBytes[:], largestFileId.Load())

--- a/pkg/snapshot/build_db_with_incr.go
+++ b/pkg/snapshot/build_db_with_incr.go
@@ -127,7 +127,20 @@ func BuildAccountsDbWithIncr(
 		dp.Stop()
 	}
 
+	// Show indexing progress for shard flush
+	indexProgress := progress.NewIndexingProgress("Flush (shard logs)")
+	indexProgress.Start(numShards)
+	err = sl.CloseWithProgress(ctx, func(completed, total int) {
+		indexProgress.Update(completed, total)
+	})
+	if err != nil {
+		indexProgress.Interrupt(err)
+		return nil, nil, fmt.Errorf("closing shard logger: %w", err)
+	}
+
 	mlog.Log.Infof("done processing full snapshot in %s.", fmtDuration(time.Since(start)))
+
+	sl = NewShardLogger(numShards, logsDir, ss)
 
 	// Get incremental snapshot URL (tries same source first, then searches if needed)
 	mlog.Log.Infof("finding incremental snapshot matching full slot %d...", fullSnapshotSlot)

--- a/pkg/snapshot/build_db_with_incr.go
+++ b/pkg/snapshot/build_db_with_incr.go
@@ -214,7 +214,7 @@ func BuildAccountsDbWithIncr(
 	mlog.Log.Infof("Stopping shard setter.")
 	ss.Stop()
 
-	mlog.Log.Infof("snapshots processed in %s.\n", fmtDuration(time.Since(start)))
+	mlog.Log.Infof("snapshots processed in %s.", fmtDuration(time.Since(start)))
 
 	var largestFileIdBytes [8]byte
 	binary.LittleEndian.PutUint64(largestFileIdBytes[:], largestFileId.Load())

--- a/pkg/snapshot/build_db_with_incr.go
+++ b/pkg/snapshot/build_db_with_incr.go
@@ -127,20 +127,14 @@ func BuildAccountsDbWithIncr(
 		dp.Stop()
 	}
 
-	// Show indexing progress for shard flush
-	indexProgress := progress.NewIndexingProgress("Flush (shard logs)")
-	indexProgress.Start(numShards)
-	err = sl.CloseWithProgress(ctx, func(completed, total int) {
-		indexProgress.Update(completed, total)
-	})
-	if err != nil {
-		indexProgress.Interrupt(err)
-		return nil, nil, fmt.Errorf("closing shard logger: %w", err)
-	}
+	// Wait for all workers to finish before continuing to incremental phase
+	wg.Wait()
 
 	mlog.Log.Infof("done processing full snapshot in %s.", fmtDuration(time.Since(start)))
 
-	sl = NewShardLogger(numShards, logsDir, ss)
+	// Note: ShardLogger is NOT closed here - we use one logger for both phases
+	// and flush once at the end. This avoids the bug where pools still reference
+	// the old ShardLogger after reinit.
 
 	// Get incremental snapshot URL (tries same source first, then searches if needed)
 	mlog.Log.Infof("finding incremental snapshot matching full slot %d...", fullSnapshotSlot)
@@ -210,8 +204,8 @@ func BuildAccountsDbWithIncr(
 		return nil, nil, err
 	}
 
-	// Show indexing progress for incremental shard flush
-	indexProgress = progress.NewIndexingProgress("Convert log shards to index shards")
+	// Show indexing progress for shard flush
+	indexProgress := progress.NewIndexingProgress("Flush (shard logs)")
 	indexProgress.Start(numShards)
 	sl.CloseWithProgress(ctx, func(completed, total int) {
 		indexProgress.Update(completed, total)

--- a/pkg/snapshot/build_db_with_incr.go
+++ b/pkg/snapshot/build_db_with_incr.go
@@ -130,7 +130,8 @@ func BuildAccountsDbWithIncr(
 	// Wait for all workers to finish before continuing to incremental phase
 	wg.Wait()
 
-	mlog.Log.Infof("done processing full snapshot in %s.", fmtDuration(time.Since(start)))
+	// Log full snapshot processing time to debug log only (noise reduction)
+	mlog.Log.Debugf("done processing full snapshot in %s.", fmtDuration(time.Since(start)))
 
 	// Note: ShardLogger is NOT closed here - we use one logger for both phases
 	// and flush once at the end. This avoids the bug where pools still reference

--- a/pkg/snapshot/build_db_with_incr.go
+++ b/pkg/snapshot/build_db_with_incr.go
@@ -211,7 +211,7 @@ func BuildAccountsDbWithIncr(
 	}
 
 	// Show indexing progress for incremental shard flush
-	indexProgress := progress.NewIndexingProgress("Convert log shards to index shards")
+	indexProgress = progress.NewIndexingProgress("Convert log shards to index shards")
 	indexProgress.Start(numShards)
 	sl.CloseWithProgress(ctx, func(completed, total int) {
 		indexProgress.Update(completed, total)

--- a/pkg/snapshot/shard.go
+++ b/pkg/snapshot/shard.go
@@ -136,6 +136,9 @@ type ShardLogger struct {
 	totalBytes atomic.Int64 // total bytes written to shard logs
 	bytesDone  atomic.Int64 // bytes flushed to cache
 	onProgress ShardProgressCallback
+
+	// closed flag to prevent sends after Close is called (defensive)
+	closed atomic.Bool
 }
 
 // shard represents a single log shard
@@ -305,6 +308,9 @@ func (s *shard) flushLogToCache(ctx context.Context) error {
 
 // EnqueueRequest adds a request to the appropriate shard
 func (sl *ShardLogger) EnqueueRequest(k solana.PublicKey, v accountsdb.AccountIndexEntry) {
+	if sl.closed.Load() {
+		return // Already closed, silently ignore
+	}
 	hash := xxhash.Sum64(k[:])
 	shardIdx := uint32(hash % uint64(len(sl.shards)))
 	sl.shards[shardIdx].requests <- shardRequest{k, v}
@@ -318,6 +324,8 @@ func (sl *ShardLogger) Close(ctx context.Context) error {
 // CloseWithProgress closes all shards with optional progress callback.
 // The callback is called after each shard flush completes with (completed, total) counts.
 func (sl *ShardLogger) CloseWithProgress(ctx context.Context, onProgress func(completed, total int)) error {
+	// Mark as closed before closing channels to prevent late sends
+	sl.closed.Store(true)
 	for _, s := range sl.shards {
 		close(s.requests)
 	}

--- a/pkg/snapshotdl/snapshotdl.go
+++ b/pkg/snapshotdl/snapshotdl.go
@@ -449,12 +449,12 @@ func GetSnapshotURLWithInfo(ctx context.Context, snapCfg SnapshotConfig) (*Snaps
 		stats.PrintFilterPipeline(filterCfg, speedStats)
 	}
 
-	// Write detailed speed test log to file
-	if speedStats != nil && snapCfg.LogDir != "" {
-		if err := speedStats.WriteSpeedTestLog(snapCfg.LogDir, filterCfg); err != nil {
-			mlog.Log.Infof("Warning: failed to write speed test log: %v", err)
-		}
-	}
+	// Speed test log writing disabled - uncomment to enable
+	// if speedStats != nil && snapCfg.LogDir != "" {
+	// 	if err := speedStats.WriteSpeedTestLog(snapCfg.LogDir, filterCfg); err != nil {
+	// 		mlog.Log.Infof("Warning: failed to write speed test log: %v", err)
+	// 	}
+	// }
 
 	// Step 5: Get snapshot URL from best nodes (with configurable fallback)
 	var snapshotURL string

--- a/pkg/snapshotdl/snapshotdl.go
+++ b/pkg/snapshotdl/snapshotdl.go
@@ -82,6 +82,9 @@ type SnapshotConfig struct {
 
 	// Incremental snapshot selection
 	MinIncrementalSpeedMBs float64 // Minimum speed for incremental sources (MB/s, 0 = no minimum)
+
+	// Logging
+	LogDir string // Directory for snapshot finder logs (default: /mnt/mithril-logs/snapshot-finder)
 }
 
 // DefaultSnapshotConfig returns production-ready defaults matching solana-snapshot-finder-go
@@ -132,6 +135,9 @@ func DefaultSnapshotConfig() SnapshotConfig {
 
 		// Incremental selection
 		MinIncrementalSpeedMBs: 2.0, // Minimum 2 MB/s for incrementals (~8min for 1GB)
+
+		// Logging
+		LogDir: "/mnt/mithril-logs/snapshot-finder",
 	}
 }
 
@@ -444,9 +450,8 @@ func GetSnapshotURLWithInfo(ctx context.Context, snapCfg SnapshotConfig) (*Snaps
 	}
 
 	// Write detailed speed test log to file
-	if speedStats != nil {
-		logDir := "/tmp/mithril-logs"
-		if err := speedStats.WriteSpeedTestLog(logDir, filterCfg); err != nil {
+	if speedStats != nil && snapCfg.LogDir != "" {
+		if err := speedStats.WriteSpeedTestLog(snapCfg.LogDir, filterCfg); err != nil {
 			mlog.Log.Infof("Warning: failed to write speed test log: %v", err)
 		}
 	}

--- a/pkg/snapshotdl/snapshotdl.go
+++ b/pkg/snapshotdl/snapshotdl.go
@@ -275,9 +275,7 @@ func GetSnapshotURL(ctx context.Context, snapCfg SnapshotConfig) (string, int, i
 
 	// Step 3: Evaluate nodes with version tracking and statistics
 	mlog.Log.Infof("Evaluating nodes for snapshot availability and speed...")
-	evaluateStart := time.Now()
 	results, stats := rpc.EvaluateNodesWithVersionsAndStats(nodes, cfg, referenceSlot)
-	mlog.Log.Infof("Node evaluation completed in %s", time.Since(evaluateStart))
 
 	// Step 3.5: Filter to only full snapshots that have matching incrementals somewhere
 	results, _ = filterByIncrementalBaseMatch(results)
@@ -562,9 +560,7 @@ func DownloadSnapshotWithConfig(ctx context.Context, path string, snapCfg Snapsh
 
 	// Step 3: Evaluate nodes with version tracking and statistics
 	mlog.Log.Infof("Evaluating nodes for snapshot availability and speed...")
-	evaluateStart := time.Now()
 	results, stats := rpc.EvaluateNodesWithVersionsAndStats(nodes, cfg, referenceSlot)
-	mlog.Log.Infof("Node evaluation completed in %s", time.Since(evaluateStart))
 
 	// Step 3.5: Filter to only full snapshots that have matching incrementals somewhere
 	results, _ = filterByIncrementalBaseMatch(results)
@@ -680,9 +676,7 @@ func DownloadIncrementalSnapshotWithConfig(path string, referenceSlot int, fullS
 	}
 
 	// Step 2: Evaluate nodes
-	evaluateStart := time.Now()
 	results, stats := rpc.EvaluateNodesWithVersionsAndStats(nodes, cfg, referenceSlot)
-	mlog.Log.Infof("Node evaluation completed in %s", time.Since(evaluateStart))
 
 	if snapCfg.Verbose && stats != nil {
 		filterCfg := rpc.FilterConfig{
@@ -889,9 +883,7 @@ func GetIncrementalSnapshotURL(fullSnapshotURL string, referenceSlot int, fullSn
 	}
 
 	// Evaluate nodes
-	evaluateStart := time.Now()
 	results, stats := rpc.EvaluateNodesWithVersionsAndStats(nodes, cfg, referenceSlot)
-	mlog.Log.Infof("Node evaluation completed in %s", time.Since(evaluateStart))
 
 	if snapCfg.Verbose && stats != nil {
 		filterCfg := rpc.FilterConfig{

--- a/pkg/snapshotdl/snapshotdl.go
+++ b/pkg/snapshotdl/snapshotdl.go
@@ -104,7 +104,7 @@ func DefaultSnapshotConfig() SnapshotConfig {
 		// Node filtering
 		MaxRTTMs:            200,     // 200ms max RTT
 		TCPTimeoutMs:        1000,    // 1 second TCP precheck
-		MinNodeVersion:      "2.2.0", // Minimum Agave 2.2.0
+		MinNodeVersion:      "3.0.0", // Minimum Agave 3.0.0
 		AllowedNodeVersions: nil,     // Accept all versions >= minimum
 
 		// Snapshot age thresholds

--- a/pkg/state/history.go
+++ b/pkg/state/history.go
@@ -1,0 +1,234 @@
+package state
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// MaxHistoryEntries is the maximum number of history entries to retain.
+const MaxHistoryEntries = 100
+
+// HistoryEvent represents the type of state change event.
+type HistoryEvent string
+
+const (
+	HistoryEventBootstrap HistoryEvent = "bootstrap"
+	HistoryEventShutdown  HistoryEvent = "shutdown"
+	HistoryEventCorrupted HistoryEvent = "corrupted"
+	HistoryEventResume    HistoryEvent = "resume"
+	HistoryEventRebuild   HistoryEvent = "rebuild" // AccountsDB being cleaned/rebuilt
+)
+
+// StateHistoryEntry represents a single entry in the state history log.
+type StateHistoryEntry struct {
+	Timestamp time.Time    `json:"ts"`
+	Event     HistoryEvent `json:"event"`
+	Slot      uint64       `json:"slot"`
+	Bankhash  string       `json:"bankhash,omitempty"`
+	RunID     string       `json:"run_id,omitempty"`
+	Version   string       `json:"version,omitempty"`
+	Commit    string       `json:"commit,omitempty"`
+	Reason    string       `json:"reason,omitempty"` // shutdown reason or corruption reason
+}
+
+// AppendHistory appends a history entry to the state history file.
+// The history file is append-only JSONL format.
+func AppendHistory(accountsDbDir string, entry StateHistoryEntry) error {
+	historyFile := filepath.Join(accountsDbDir, HistoryFileName)
+
+	// Ensure timestamp is set
+	if entry.Timestamp.IsZero() {
+		entry.Timestamp = time.Now()
+	}
+
+	// Marshal to JSON (single line)
+	data, err := json.Marshal(entry)
+	if err != nil {
+		return fmt.Errorf("failed to marshal history entry: %w", err)
+	}
+
+	// Append to file
+	f, err := os.OpenFile(historyFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return fmt.Errorf("failed to open history file: %w", err)
+	}
+	defer f.Close()
+
+	if _, err := f.Write(append(data, '\n')); err != nil {
+		return fmt.Errorf("failed to write history entry: %w", err)
+	}
+
+	return nil
+}
+
+// LoadHistory loads all history entries from the state history file.
+// Returns empty slice if file doesn't exist.
+func LoadHistory(accountsDbDir string) ([]StateHistoryEntry, error) {
+	historyFile := filepath.Join(accountsDbDir, HistoryFileName)
+
+	f, err := os.Open(historyFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to open history file: %w", err)
+	}
+	defer f.Close()
+
+	var entries []StateHistoryEntry
+	scanner := bufio.NewScanner(f)
+	lineNum := 0
+	for scanner.Scan() {
+		lineNum++
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+
+		var entry StateHistoryEntry
+		if err := json.Unmarshal(line, &entry); err != nil {
+			// Skip malformed lines but continue
+			continue
+		}
+		entries = append(entries, entry)
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("failed to read history file: %w", err)
+	}
+
+	return entries, nil
+}
+
+// PruneHistory removes old entries if history exceeds MaxHistoryEntries.
+// Should be called on startup to prevent unbounded growth.
+func PruneHistory(accountsDbDir string) error {
+	entries, err := LoadHistory(accountsDbDir)
+	if err != nil {
+		return err
+	}
+
+	// Nothing to prune
+	if len(entries) <= MaxHistoryEntries {
+		return nil
+	}
+
+	// Keep only the most recent entries
+	entries = entries[len(entries)-MaxHistoryEntries:]
+
+	// Rewrite the file
+	historyFile := filepath.Join(accountsDbDir, HistoryFileName)
+	tmpFile := historyFile + ".tmp"
+
+	f, err := os.Create(tmpFile)
+	if err != nil {
+		return fmt.Errorf("failed to create temp history file: %w", err)
+	}
+
+	for _, entry := range entries {
+		data, err := json.Marshal(entry)
+		if err != nil {
+			f.Close()
+			os.Remove(tmpFile)
+			return fmt.Errorf("failed to marshal history entry: %w", err)
+		}
+		if _, err := f.Write(append(data, '\n')); err != nil {
+			f.Close()
+			os.Remove(tmpFile)
+			return fmt.Errorf("failed to write history entry: %w", err)
+		}
+	}
+
+	if err := f.Close(); err != nil {
+		os.Remove(tmpFile)
+		return fmt.Errorf("failed to close temp history file: %w", err)
+	}
+
+	if err := os.Rename(tmpFile, historyFile); err != nil {
+		os.Remove(tmpFile)
+		return fmt.Errorf("failed to rename history file: %w", err)
+	}
+
+	return nil
+}
+
+// GetRecentHistory returns the N most recent history entries.
+func GetRecentHistory(accountsDbDir string, n int) ([]StateHistoryEntry, error) {
+	entries, err := LoadHistory(accountsDbDir)
+	if err != nil {
+		return nil, err
+	}
+
+	if n <= 0 || len(entries) <= n {
+		return entries, nil
+	}
+
+	return entries[len(entries)-n:], nil
+}
+
+// RecordBootstrap records a bootstrap event in the history.
+func RecordBootstrap(accountsDbDir string, slot uint64, bankhash, runID, version, commit string) error {
+	return AppendHistory(accountsDbDir, StateHistoryEntry{
+		Event:    HistoryEventBootstrap,
+		Slot:     slot,
+		Bankhash: bankhash,
+		RunID:    runID,
+		Version:  version,
+		Commit:   commit,
+	})
+}
+
+// RecordShutdown records a shutdown event in the history.
+func RecordShutdown(accountsDbDir string, slot uint64, bankhash, runID, version, commit, reason string) error {
+	return AppendHistory(accountsDbDir, StateHistoryEntry{
+		Event:    HistoryEventShutdown,
+		Slot:     slot,
+		Bankhash: bankhash,
+		RunID:    runID,
+		Version:  version,
+		Commit:   commit,
+		Reason:   reason,
+	})
+}
+
+// RecordCorrupted records a corruption event in the history.
+func RecordCorrupted(accountsDbDir string, slot uint64, bankhash, runID, version, commit, reason string) error {
+	return AppendHistory(accountsDbDir, StateHistoryEntry{
+		Event:    HistoryEventCorrupted,
+		Slot:     slot,
+		Bankhash: bankhash,
+		RunID:    runID,
+		Version:  version,
+		Commit:   commit,
+		Reason:   reason,
+	})
+}
+
+// RecordResume records a resume event in the history.
+func RecordResume(accountsDbDir string, slot uint64, bankhash, runID, version, commit string) error {
+	return AppendHistory(accountsDbDir, StateHistoryEntry{
+		Event:    HistoryEventResume,
+		Slot:     slot,
+		Bankhash: bankhash,
+		RunID:    runID,
+		Version:  version,
+		Commit:   commit,
+	})
+}
+
+// RecordRebuild records when AccountsDB is about to be cleaned/rebuilt.
+// This should be called BEFORE CleanAccountsDbDir to preserve the history.
+func RecordRebuild(accountsDbDir string, slot uint64, bankhash, version, commit, reason string) error {
+	return AppendHistory(accountsDbDir, StateHistoryEntry{
+		Event:    HistoryEventRebuild,
+		Slot:     slot,
+		Bankhash: bankhash,
+		Version:  version,
+		Commit:   commit,
+		Reason:   reason, // e.g., "new-snapshot", "snapshot mode", "user requested rebuild"
+	})
+}

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -12,11 +12,19 @@ import (
 )
 
 const StateFileName = "mithril_state.json"
+const HistoryFileName = "mithril_state.history.jsonl"
+
+// CurrentStateSchemaVersion is the current version of the state file format.
+// Increment this when making breaking changes to the state file structure.
+const CurrentStateSchemaVersion uint32 = 1
 
 // MithrilState tracks the current state of the mithril node.
 // The state file serves as an atomic marker of validity - AccountsDB is valid
 // if and only if this file exists with Stage == "ready".
 type MithrilState struct {
+	// Schema version for state file format migrations
+	StateSchemaVersion uint32 `json:"state_schema_version"`
+
 	Stage          string        `json:"stage"` // "ready", "downloading", "building", "corrupted"
 	SnapshotSlot   uint64        `json:"snapshot_slot"`
 	SnapshotEpoch  uint64        `json:"snapshot_epoch,omitempty"`
@@ -26,6 +34,14 @@ type MithrilState struct {
 	FullSnapshot   *SnapshotInfo `json:"full_snapshot,omitempty"`
 	IncrSnapshot   *SnapshotInfo `json:"incr_snapshot,omitempty"`
 	BuildCompleted time.Time     `json:"build_completed_at,omitempty"`
+
+	// Build metadata - tracks how and when AccountsDB was built
+	BuildStartedAt time.Time `json:"build_started_at,omitempty"` // When bootstrap started
+	BuildMode      string    `json:"build_mode,omitempty"`       // "auto", "snapshot", "new-snapshot", "accountsdb"
+
+	// Cluster safety - prevents mainnet/testnet mixups
+	Cluster     string `json:"cluster,omitempty"`      // "mainnet-beta", "testnet", "devnet"
+	GenesisHash string `json:"genesis_hash,omitempty"` // Base58 genesis hash from RPC
 
 	// Corruption tracking - set when integrity check fails
 	CorruptionReason     string    `json:"corruption_reason,omitempty"`
@@ -53,8 +69,13 @@ type MithrilState struct {
 	LastRunID string    `json:"last_run_id,omitempty"` // Run ID from last replay session
 	LastRunAt time.Time `json:"last_run_at,omitempty"` // When last replay session started
 
-	// Build info - for tracking which version created/modified the state
-	LastCommit string `json:"last_commit,omitempty"` // Git commit hash of last run
+	// Writer info - tracks which binary version last wrote to this state
+	LastWriterVersion string `json:"last_writer_version,omitempty"` // Semver tag (e.g., "v0.1.0" or "dev")
+	LastWriterCommit  string `json:"last_writer_commit,omitempty"`  // Git commit hash of writer binary
+
+	// Legacy field name - kept for backwards compatibility during migration
+	// TODO: Remove after v1.0 release
+	LastCommit string `json:"last_commit,omitempty"` // Deprecated: use last_writer_commit
 
 	// Shutdown tracking - records why the last session ended
 	LastShutdownReason string    `json:"last_shutdown_reason,omitempty"` // human-readable reason
@@ -92,6 +113,7 @@ type SnapshotInfo struct {
 
 // LoadState loads the state file from the accountsdb directory.
 // Returns nil and no error if the file doesn't exist.
+// Handles migration from older schema versions automatically.
 func LoadState(accountsDbDir string) (*MithrilState, error) {
 	stateFile := filepath.Join(accountsDbDir, StateFileName)
 
@@ -106,6 +128,17 @@ func LoadState(accountsDbDir string) (*MithrilState, error) {
 	var state MithrilState
 	if err := json.Unmarshal(data, &state); err != nil {
 		return nil, fmt.Errorf("failed to parse state file: %w", err)
+	}
+
+	// Migrate from older schema versions
+	if state.StateSchemaVersion == 0 {
+		// Version 0 → 1 migration:
+		// - Migrate LastCommit to LastWriterCommit
+		if state.LastCommit != "" && state.LastWriterCommit == "" {
+			state.LastWriterCommit = state.LastCommit
+		}
+		state.StateSchemaVersion = 1
+		// Note: We don't save here - the state will be saved on next update
 	}
 
 	return &state, nil
@@ -172,7 +205,10 @@ type ResumeContext struct {
 	// Run tracking
 	RunID        string    // Run ID for log correlation
 	RunStartedAt time.Time // When this replay session started
-	Commit       string    // Git commit hash
+
+	// Writer info
+	WriterVersion string // Semver tag (e.g., "v0.1.0" or "dev")
+	WriterCommit  string // Git commit hash
 
 	// Shutdown tracking
 	ShutdownReason string // Why the session ended (see ShutdownReason* constants)
@@ -209,7 +245,12 @@ func (s *MithrilState) UpdateLastSlotWithContext(accountsDbDir string, slot uint
 		// Run tracking - for correlating logs with state
 		s.LastRunID = ctx.RunID
 		s.LastRunAt = ctx.RunStartedAt
-		s.LastCommit = ctx.Commit
+
+		// Writer info
+		s.LastWriterVersion = ctx.WriterVersion
+		s.LastWriterCommit = ctx.WriterCommit
+		// Also set legacy field for backwards compatibility
+		s.LastCommit = ctx.WriterCommit
 
 		// Shutdown tracking
 		if ctx.ShutdownReason != "" {
@@ -217,6 +258,10 @@ func (s *MithrilState) UpdateLastSlotWithContext(accountsDbDir string, slot uint
 			s.LastShutdownAt = time.Now()
 		}
 	}
+
+	// Ensure schema version is set
+	s.StateSchemaVersion = CurrentStateSchemaVersion
+
 	return s.Save(accountsDbDir)
 }
 
@@ -249,8 +294,19 @@ func (s *MithrilState) GetResumeContext() *ResumeContext {
 		// Run tracking (from previous session)
 		RunID:        s.LastRunID,
 		RunStartedAt: s.LastRunAt,
-		Commit:       s.LastCommit,
+
+		// Writer info (from previous session)
+		WriterVersion: s.LastWriterVersion,
+		WriterCommit:  s.getWriterCommit(),
 	}
+}
+
+// getWriterCommit returns the writer commit, preferring the new field but falling back to legacy.
+func (s *MithrilState) getWriterCommit() string {
+	if s.LastWriterCommit != "" {
+		return s.LastWriterCommit
+	}
+	return s.LastCommit // Legacy field fallback
 }
 
 // GetResumeSlot returns the slot to resume from.
@@ -315,31 +371,89 @@ func (s *MithrilState) ValidateAgainstBankhashDB(bankhashDb BankhashGetter) erro
 	return nil
 }
 
+// NewReadyStateOpts contains options for creating a new ready state.
+type NewReadyStateOpts struct {
+	SnapshotSlot     uint64
+	SnapshotEpoch    uint64
+	FullSnapshotPath string
+	IncrSnapshotPath string
+	IncrBaseSlot     uint64
+	IncrSlot         uint64
+	BuildMode        string // "auto", "snapshot", "new-snapshot", "accountsdb"
+	BuildStartedAt   time.Time
+	Cluster          string // "mainnet-beta", "testnet", "devnet"
+	GenesisHash      string // Base58 genesis hash
+	WriterVersion    string // Semver tag
+	WriterCommit     string // Git commit hash
+}
+
 // NewReadyState creates a new state marking the AccountsDB as ready.
 func NewReadyState(snapshotSlot uint64, snapshotEpoch uint64, fullSnapshotPath string, incrSnapshotPath string, incrBaseSlot uint64, incrSlot uint64) *MithrilState {
+	return NewReadyStateWithOpts(NewReadyStateOpts{
+		SnapshotSlot:     snapshotSlot,
+		SnapshotEpoch:    snapshotEpoch,
+		FullSnapshotPath: fullSnapshotPath,
+		IncrSnapshotPath: incrSnapshotPath,
+		IncrBaseSlot:     incrBaseSlot,
+		IncrSlot:         incrSlot,
+	})
+}
+
+// NewReadyStateWithOpts creates a new state with full options including cluster and version info.
+func NewReadyStateWithOpts(opts NewReadyStateOpts) *MithrilState {
 	state := &MithrilState{
-		Stage:          "ready",
-		SnapshotSlot:   snapshotSlot,
-		SnapshotEpoch:  snapshotEpoch,
-		BuildCompleted: time.Now(),
+		StateSchemaVersion: CurrentStateSchemaVersion,
+		Stage:              "ready",
+		SnapshotSlot:       opts.SnapshotSlot,
+		SnapshotEpoch:      opts.SnapshotEpoch,
+		BuildCompleted:     time.Now(),
+		BuildStartedAt:     opts.BuildStartedAt,
+		BuildMode:          opts.BuildMode,
+		Cluster:            opts.Cluster,
+		GenesisHash:        opts.GenesisHash,
+		LastWriterVersion:  opts.WriterVersion,
+		LastWriterCommit:   opts.WriterCommit,
+		LastCommit:         opts.WriterCommit, // Also set legacy field
 	}
 
-	if fullSnapshotPath != "" {
+	if opts.FullSnapshotPath != "" {
 		state.FullSnapshot = &SnapshotInfo{
-			Path: fullSnapshotPath,
-			Slot: snapshotSlot,
+			Path: opts.FullSnapshotPath,
+			Slot: opts.SnapshotSlot,
 		}
 	}
 
-	if incrSnapshotPath != "" {
+	if opts.IncrSnapshotPath != "" {
 		state.IncrSnapshot = &SnapshotInfo{
-			Path:     incrSnapshotPath,
-			BaseSlot: incrBaseSlot,
-			Slot:     incrSlot,
+			Path:     opts.IncrSnapshotPath,
+			BaseSlot: opts.IncrBaseSlot,
+			Slot:     opts.IncrSlot,
 		}
 	}
 
 	return state
+}
+
+// ValidateGenesisHash checks if the stored genesis hash matches the expected value.
+// Returns an error if there's a mismatch (prevents mainnet/testnet mixups).
+// Returns nil if state has no genesis hash stored (first run after upgrade).
+func (s *MithrilState) ValidateGenesisHash(expectedGenesisHash string) error {
+	if s.GenesisHash == "" {
+		// No genesis hash stored (older state file) - allow but log warning
+		return nil
+	}
+	if s.GenesisHash != expectedGenesisHash {
+		return fmt.Errorf("genesis hash mismatch: state has %s, RPC returned %s - refusing to use AccountsDB built for a different cluster",
+			s.GenesisHash, expectedGenesisHash)
+	}
+	return nil
+}
+
+// SetClusterInfo updates the cluster and genesis hash in the state.
+// Should be called on first run after upgrade if genesis hash is missing.
+func (s *MithrilState) SetClusterInfo(cluster, genesisHash string) {
+	s.Cluster = cluster
+	s.GenesisHash = genesisHash
 }
 
 // DeleteState removes the state file from the accountsdb directory.

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,16 @@
+package version
+
+// These variables are set at build time via ldflags:
+//   go build -ldflags "-X github.com/Overclock-Validator/mithril/pkg/version.Version=v1.0.0
+//                      -X github.com/Overclock-Validator/mithril/pkg/version.GitCommit=abc123
+//                      -X github.com/Overclock-Validator/mithril/pkg/version.BuildDate=2025-01-01"
+var (
+	// Version is the semantic version (e.g., "v1.0.0" or "dev")
+	Version = "dev"
+
+	// GitCommit is the git commit hash
+	GitCommit = "unknown"
+
+	// BuildDate is the build timestamp
+	BuildDate = "unknown"
+)

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -49,9 +49,9 @@ sudo ./scripts/performance-tune.sh          # Apply performance tuning
 
 **Resetting Mithril data** (when needed):
 ```bash
-sudo ./scripts/disk-setup.sh --delete-accounts    # After bankhash mismatch / bug fix
-sudo ./scripts/disk-setup.sh --delete-ledger      # Delete snapshots + blockstore
-sudo ./scripts/disk-setup.sh --delete-all         # Complete reset
+sudo ./scripts/disk-setup.sh --clean-accounts    # After bankhash mismatch / bug fix
+sudo ./scripts/disk-setup.sh --clean-ledger      # Clear snapshots + blockstore
+sudo ./scripts/disk-setup.sh --clean-all         # Complete reset
 ```
 
 ---
@@ -513,12 +513,12 @@ Mithril stores three types of data that can be reset independently:
 
 Sometimes you need to start fresh. These commands delete this data so you can re-sync from scratch.
 
-### Delete AccountsDB Only
+### Clean AccountsDB Only
 
 Forces Mithril to rebuild from a fresh snapshot on next run:
 
 ```bash
-sudo ./scripts/disk-setup.sh --delete-accounts
+sudo ./scripts/disk-setup.sh --clean-accounts
 ```
 
 **When to use:**
@@ -528,12 +528,12 @@ sudo ./scripts/disk-setup.sh --delete-accounts
 
 After deleting, Mithril will fetch a fresh snapshot on next run and rebuild AccountsDB from scratch.
 
-### Delete Ledger Only (Snapshots + Blockstore)
+### Clean Ledger Only (Snapshots + Blockstore)
 
 Removes both snapshots and blockstore while preserving AccountsDB:
 
 ```bash
-sudo ./scripts/disk-setup.sh --delete-ledger
+sudo ./scripts/disk-setup.sh --clean-ledger
 ```
 
 **When to use:**
@@ -541,24 +541,24 @@ sudo ./scripts/disk-setup.sh --delete-ledger
 - Reclaiming space from old snapshots and blocks together
 - When you want to clear all "ledger" data (everything except account state)
 
-### Delete Snapshots Only
+### Clean Snapshots Only
 
 Removes downloaded snapshots (Mithril will re-download them):
 
 ```bash
-sudo ./scripts/disk-setup.sh --delete-snapshots
+sudo ./scripts/disk-setup.sh --clean-snapshots
 ```
 
 **When to use:** Snapshots are old or corrupted.
 
 > **Tip:** We recommend retaining snapshots when possible (current + previous) as they're helpful for debugging. If you encounter issues, having the snapshot you synced from makes it easier for the Mithril team to reproduce and fix bugs. Only delete if you need disk space.
 
-### Delete Blockstore Only
+### Clean Blockstore Only
 
 Removes stored blocks (Mithril will rebuild them):
 
 ```bash
-sudo ./scripts/disk-setup.sh --delete-blockstore
+sudo ./scripts/disk-setup.sh --clean-blockstore
 ```
 
 **When to use:**
@@ -566,12 +566,12 @@ sudo ./scripts/disk-setup.sh --delete-blockstore
 - You want to clear block history but keep AccountsDB
 - Reclaiming disk space from old block data
 
-### Delete Everything
+### Clean Everything
 
 Complete reset - removes all Mithril data:
 
 ```bash
-sudo ./scripts/disk-setup.sh --delete-all
+sudo ./scripts/disk-setup.sh --clean-all
 ```
 
 **When to use:** Starting completely fresh, or decommissioning the node.
@@ -664,9 +664,9 @@ sudo ./scripts/performance-tune.sh --status      # Show current settings
 ./scripts/performance-tune.sh --goamd64          # Configure GOAMD64 for CPU
 
 # Reset Data
-sudo ./scripts/disk-setup.sh --delete-accounts   # Delete AccountsDB
-sudo ./scripts/disk-setup.sh --delete-ledger     # Delete ledger (snapshots + blockstore)
-sudo ./scripts/disk-setup.sh --delete-snapshots  # Delete snapshots only
-sudo ./scripts/disk-setup.sh --delete-blockstore # Delete blockstore only
-sudo ./scripts/disk-setup.sh --delete-all        # Delete everything
+sudo ./scripts/disk-setup.sh --clean-accounts   # Clean AccountsDB
+sudo ./scripts/disk-setup.sh --clean-ledger     # Clean ledger (snapshots + blockstore)
+sudo ./scripts/disk-setup.sh --clean-snapshots  # Clean snapshots only
+sudo ./scripts/disk-setup.sh --clean-blockstore # Clean blockstore only
+sudo ./scripts/disk-setup.sh --clean-all        # Clean everything
 ```

--- a/scripts/disk-setup.sh
+++ b/scripts/disk-setup.sh
@@ -183,7 +183,7 @@ fix_mithril_ownership() {
 
     info "Setting ownership to $real_user for Mithril directories..."
 
-    for dir in /mnt/mithril-accounts /mnt/mithril-ledger; do
+    for dir in /mnt/mithril-accounts /mnt/mithril-ledger /mnt/mithril-logs; do
         if [[ -d "$dir" ]]; then
             chown -R "$real_user:$real_user" "$dir"
             success "Set ownership: $dir -> $real_user"
@@ -878,6 +878,7 @@ show_status() {
         "/mnt/mithril-ledger"
         "/mnt/mithril-ledger/snapshots"
         "/mnt/mithril-ledger/blockstore"
+        "/mnt/mithril-logs"
     )
 
     for dir in "${mithril_dirs[@]}"; do

--- a/scripts/disk-setup.sh
+++ b/scripts/disk-setup.sh
@@ -152,6 +152,45 @@ check_root() {
     [[ $EUID -eq 0 ]] || die "This script must be run as root. Try: sudo $0"
 }
 
+# Get the real user (the one who ran sudo, not root)
+get_real_user() {
+    # SUDO_USER is set when running with sudo
+    if [[ -n "${SUDO_USER:-}" && "$SUDO_USER" != "root" ]]; then
+        echo "$SUDO_USER"
+    else
+        # Fallback: try to find a non-root user who owns common home dirs
+        for user in ubuntu mithril; do
+            if id -u "$user" &>/dev/null; then
+                echo "$user"
+                return
+            fi
+        done
+        # Last resort: current user (might be root)
+        whoami
+    fi
+}
+
+# Fix ownership of Mithril directories so non-root user can access
+fix_mithril_ownership() {
+    local real_user
+    real_user=$(get_real_user)
+
+    if [[ "$real_user" == "root" ]]; then
+        warn "Could not determine non-root user. Directories will be owned by root."
+        warn "Run: sudo chown -R YOUR_USER:YOUR_USER /mnt/mithril-*"
+        return
+    fi
+
+    info "Setting ownership to $real_user for Mithril directories..."
+
+    for dir in /mnt/mithril-accounts /mnt/mithril-ledger; do
+        if [[ -d "$dir" ]]; then
+            chown -R "$real_user:$real_user" "$dir"
+            success "Set ownership: $dir -> $real_user"
+        fi
+    done
+}
+
 # Check and install required dependencies for disk operations
 check_disk_deps() {
     local missing=()
@@ -1370,6 +1409,9 @@ interactive_setup() {
     # Reload systemd to pick up fstab changes
     systemctl daemon-reload
 
+    # Fix ownership so non-root user can run Mithril
+    fix_mithril_ownership
+
     echo ""
     echo "  ┌─────────────────────────────────────────────────────────────────────────┐"
     echo "  │ SETUP COMPLETE                                                           │"
@@ -1575,6 +1617,9 @@ clean_subdir() {
     echo ""
     success "$description has been deleted"
 
+    # Fix ownership so non-root user can run Mithril
+    fix_mithril_ownership
+
     # Show before/after disk space summary
     show_disk_space_summary "$mount_point" "$before_used" "$before_free" "$after_used" "$after_free" "$before_total" "$fstype"
 }
@@ -1749,6 +1794,9 @@ clean_snapshots() {
     echo ""
     success "Snapshots have been cleaned"
 
+    # Fix ownership so non-root user can run Mithril
+    fix_mithril_ownership
+
     # Show before/after disk space summary
     show_disk_space_summary "$mount_point" "$before_used" "$before_free" "$after_used" "$after_free" "$before_total" "$fstype"
 
@@ -1856,6 +1904,9 @@ clean_ledger() {
 
     echo ""
     success "Ledger data has been cleaned"
+
+    # Fix ownership so non-root user can run Mithril
+    fix_mithril_ownership
 
     # Show before/after disk space summary
     show_disk_space_summary "$mount_point" "$before_used" "$before_free" "$after_used" "$after_free" "$before_total" "$fstype"
@@ -1982,6 +2033,9 @@ clean_all() {
 
     echo ""
     success "All Mithril data has been cleaned"
+
+    # Fix ownership so non-root user can run Mithril
+    fix_mithril_ownership
 
     # Show before/after disk space summary for each mount point
     for mp in "${unique_mount_points[@]}"; do

--- a/scripts/disk-setup.sh
+++ b/scripts/disk-setup.sh
@@ -204,6 +204,9 @@ check_disk_deps() {
     command -v wipefs >/dev/null 2>&1 || missing+=("util-linux")  # wipefs is in util-linux
     command -v mkfs.ext4 >/dev/null 2>&1 || missing+=("e2fsprogs")
     command -v mkfs.xfs >/dev/null 2>&1 || missing+=("xfsprogs")
+    command -v fuser >/dev/null 2>&1 || missing+=("psmisc")       # fuser, killall
+    command -v lsof >/dev/null 2>&1 || missing+=("lsof")
+    command -v pvs >/dev/null 2>&1 || missing+=("lvm2")           # LVM tools
 
     if [[ ${#missing[@]} -gt 0 ]]; then
         echo ""
@@ -2828,6 +2831,7 @@ main() {
             ;;
         --reset)
             check_root
+            check_disk_deps
             # Check for --wipe-disks flag
             if [[ "${2:-}" == "--wipe-disks" ]]; then
                 reset_all true

--- a/scripts/disk-setup.sh
+++ b/scripts/disk-setup.sh
@@ -1259,7 +1259,7 @@ interactive_setup() {
     # Summary and confirmation
     echo ""
     echo "  ┌─────────────────────────────────────────────────────────────────────────┐"
-    echo "  │ SETUP SUMMARY                                                            │"
+    echo "  │ SETUP SUMMARY                                                           │"
     echo "  ├─────────────────────────────────────────────────────────────────────────┤"
 
     if [[ -n "$accountsdb_disk" ]]; then
@@ -1269,12 +1269,12 @@ interactive_setup() {
         printf "  │              %-58s │\n" "Model: $adb_model"
         printf "  │              %-58s │\n" "Filesystem: $accountsdb_fstype"
         if [[ "$accountsdb_disk" == "$root_disk" ]]; then
-            echo -e "  │              ${YELLOW}NEW PARTITION on OS disk (free space only)${NC}             │"
+            echo -e "  │              ${YELLOW}NEW PARTITION on OS disk (free space only)${NC}            │"
         else
-            echo -e "  │              ${RED}THIS DRIVE WILL BE ERASED${NC}                                 │"
+            echo -e "  │              ${RED}THIS DRIVE WILL BE ERASED${NC}                                │"
         fi
     else
-        echo "  │ AccountsDB:  (skipped - using existing)                                │"
+        echo "  │ AccountsDB:  (skipped - using existing)                               │"
     fi
 
     if [[ -n "$data_disk" ]]; then
@@ -1284,23 +1284,23 @@ interactive_setup() {
         printf "  │              %-58s │\n" "Model: $data_model"
         printf "  │              %-58s │\n" "Filesystem: $data_fstype"
         if [[ "$data_disk" == "$root_disk" ]]; then
-            echo -e "  │              ${YELLOW}NEW PARTITION on OS disk (free space only)${NC}             │"
+            echo -e "  │              ${YELLOW}NEW PARTITION on OS disk (free space only)${NC}            │"
         else
-            echo -e "  │              ${RED}THIS DRIVE WILL BE ERASED${NC}                                 │"
+            echo -e "  │              ${RED}THIS DRIVE WILL BE ERASED${NC}                                │"
         fi
     elif [[ -n "$accountsdb_disk" ]]; then
-        echo "  │ Data:        (same drive as AccountsDB)                                │"
+        echo "  │ Data:        (same drive as AccountsDB)                               │"
     fi
 
-    echo "  │                                                                          │"
-    echo "  │ Directory structure to be created:                                       │"
-    printf "  │   %-68s │\n" "$accountsdb_mount (AccountsDB data)"
+    echo "  │                                                                         │"
+    echo "  │ Directory structure to be created:                                      │"
+    printf "  │   %-69s │\n" "$accountsdb_mount (AccountsDB data)"
     if [[ -n "$data_disk" ]]; then
-        printf "  │   %-68s │\n" "$data_mount/snapshots"
-        printf "  │   %-68s │\n" "$data_mount/blockstore"
+        printf "  │   %-69s │\n" "$data_mount/snapshots"
+        printf "  │   %-69s │\n" "$data_mount/blockstore"
     else
-        printf "  │   %-68s │\n" "$accountsdb_mount/snapshots"
-        printf "  │   %-68s │\n" "$accountsdb_mount/blockstore"
+        printf "  │   %-69s │\n" "$accountsdb_mount/snapshots"
+        printf "  │   %-69s │\n" "$accountsdb_mount/blockstore"
     fi
     echo "  └─────────────────────────────────────────────────────────────────────────┘"
     echo ""

--- a/scripts/disk-setup.sh
+++ b/scripts/disk-setup.sh
@@ -1314,9 +1314,11 @@ interactive_setup() {
         printf "  │   %-69s │\n" "$data_mount/snapshots"
         printf "  │   %-69s │\n" "$data_mount/blockstore"
     else
-        printf "  │   %-69s │\n" "$accountsdb_mount/snapshots"
-        printf "  │   %-69s │\n" "$accountsdb_mount/blockstore"
+        # When no data disk, ledger dirs always go to /mnt/mithril-ledger
+        printf "  │   %-69s │\n" "/mnt/mithril-ledger/snapshots"
+        printf "  │   %-69s │\n" "/mnt/mithril-ledger/blockstore"
     fi
+    printf "  │   %-69s │\n" "/mnt/mithril-logs (log files)"
     echo "  └─────────────────────────────────────────────────────────────────────────┘"
     echo ""
 

--- a/scripts/disk-setup.sh
+++ b/scripts/disk-setup.sh
@@ -94,6 +94,10 @@
 #   --clean-blockstore   Clear verified blocks only
 #   --clean-all          Clear everything (complete reset)
 #
+# NUCLEAR OPTIONS (full teardown):
+#   --reset              Unmount, remove fstab entries, delete all directories
+#   --reset --wipe-disks Also wipefs the Mithril partitions (requires extra confirmation)
+#
 # MAINTENANCE:
 #   --fix-noatime        Add noatime mount option to existing Mithril partitions
 #
@@ -1315,11 +1319,11 @@ interactive_setup() {
         fi
 
         mkdir -p "$accountsdb_mount"
-        mkdir -p "$accountsdb_mount/snapshots"
-        mkdir -p "$accountsdb_mount/blockstore"
+        mkdir -p /mnt/mithril-ledger/snapshots
+        mkdir -p /mnt/mithril-ledger/blockstore
         mkdir -p /mnt/mithril-logs
 
-        success "Directories created"
+        success "Directories created at $accountsdb_mount, /mnt/mithril-ledger, /mnt/mithril-logs"
         return
     fi
 
@@ -1364,10 +1368,10 @@ interactive_setup() {
         mount "$accountsdb_part" "$accountsdb_mount"
         add_fstab_entry "$accountsdb_part" "$accountsdb_mount" "$accountsdb_fstype"
 
-        # Create subdirectories for snapshots/blockstore if no separate data disk
+        # Always create ledger directories at consistent location (even with single disk)
         if [[ -z "$data_disk" ]]; then
-            mkdir -p "$accountsdb_mount/snapshots"
-            mkdir -p "$accountsdb_mount/blockstore"
+            mkdir -p /mnt/mithril-ledger/snapshots
+            mkdir -p /mnt/mithril-ledger/blockstore
         fi
 
         if [[ "$accountsdb_disk" == "$root_disk" ]]; then
@@ -1424,15 +1428,20 @@ interactive_setup() {
     echo "  │ SETUP COMPLETE                                                           │"
     echo "  ├─────────────────────────────────────────────────────────────────────────┤"
     echo "  │                                                                          │"
+    echo "  │ Directories created:                                                     │"
+    echo "  │   /mnt/mithril-accounts      - AccountsDB storage                        │"
+    echo "  │   /mnt/mithril-ledger        - Snapshots and blockstore                  │"
+    echo "  │   /mnt/mithril-logs          - Log files                                 │"
+    echo "  │                                                                          │"
     echo "  │ Update your config.toml:                                                 │"
     echo "  │                                                                          │"
-    # Determine paths based on whether there's a separate data disk
-    local ledger_base="$accountsdb_mount"
-    [[ -n "$data_disk" ]] && ledger_base="$data_mount"
-    echo "  │   [storage]                                                              │"
-    printf "  │       accounts = \"%s\"%-*s│\n" "$accountsdb_mount" $((39 - ${#accountsdb_mount})) ""
-    printf "  │       blockstore = \"%s/blockstore\"%-*s│\n" "$ledger_base" $((29 - ${#ledger_base})) ""
-    printf "  │       snapshots = \"%s/snapshots\"%-*s│\n" "$ledger_base" $((30 - ${#ledger_base})) ""
+    echo "  │   [ledger]                                                               │"
+    echo "  │       accounts_path = \"/mnt/mithril-accounts\"                            │"
+    echo "  │       snapshot_archive_path = \"/mnt/mithril-ledger/snapshots\"            │"
+    echo "  │       path = \"/mnt/mithril-ledger/blockstore\"                            │"
+    echo "  │                                                                          │"
+    echo "  │   [log]                                                                  │"
+    echo "  │       dir = \"/mnt/mithril-logs\"                                          │"
     echo "  │                                                                          │"
     echo "  │ Next: Run performance-tune.sh to optimize I/O settings                   │"
     echo "  │                                                                          │"
@@ -2056,6 +2065,149 @@ clean_all() {
 }
 
 # ------------------------------------------------------------------------------
+# Reset (Nuclear Option)
+# ------------------------------------------------------------------------------
+
+reset_all() {
+    local wipe_disks="${1:-false}"
+
+    info "MITHRIL FULL RESET"
+    echo ""
+    echo "  This will:"
+    echo "    1. Unmount all Mithril mount points"
+    echo "    2. Remove Mithril entries from /etc/fstab"
+    echo "    3. Delete all Mithril directories"
+    if [[ "$wipe_disks" == "true" ]]; then
+        echo -e "    4. ${RED}WIPE Mithril partitions (wipefs)${NC}"
+    fi
+    echo ""
+
+    # Find all mithril mount points
+    local mithril_mounts=()
+    local mithril_dirs=(
+        "/mnt/mithril-accounts"
+        "/mnt/mithril-ledger"
+        "/mnt/mithril-logs"
+    )
+
+    echo "  Checking mount points..."
+    for dir in "${mithril_dirs[@]}"; do
+        if findmnt "$dir" >/dev/null 2>&1; then
+            local device
+            device=$(findmnt -n -o SOURCE "$dir" 2>/dev/null || echo "unknown")
+            echo -e "    ${YELLOW}MOUNTED${NC}: $dir -> $device"
+            mithril_mounts+=("$dir")
+        elif [[ -d "$dir" ]]; then
+            echo -e "    ${GREEN}EXISTS${NC}:  $dir (not mounted)"
+        else
+            echo "    -       $dir (not found)"
+        fi
+    done
+
+    # Find partitions that would be wiped
+    local partitions_to_wipe=()
+    if [[ "$wipe_disks" == "true" ]]; then
+        echo ""
+        echo "  Partitions that will be wiped:"
+        for dir in "${mithril_mounts[@]}"; do
+            local device
+            device=$(findmnt -n -o SOURCE "$dir" 2>/dev/null)
+            if [[ -n "$device" && "$device" != "/" ]]; then
+                # Safety: never wipe root partition or OS disk partitions
+                local parent_disk
+                parent_disk=$(lsblk -no PKNAME "$device" 2>/dev/null | head -1)
+                local root_disk
+                root_disk=$(get_root_disk)
+                if [[ "$parent_disk" == "$root_disk" ]]; then
+                    echo -e "    ${RED}SKIPPING${NC}: $device (on OS disk - protected)"
+                else
+                    echo -e "    ${RED}WILL WIPE${NC}: $device"
+                    partitions_to_wipe+=("$device")
+                fi
+            fi
+        done
+    fi
+
+    echo ""
+
+    # Require confirmation
+    if [[ "$wipe_disks" == "true" && ${#partitions_to_wipe[@]} -gt 0 ]]; then
+        echo -e "  ${RED}!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!${NC}"
+        echo -e "  ${RED}DESTRUCTIVE ACTION - PARTITIONS WILL BE PERMANENTLY WIPED${NC}"
+        echo -e "  ${RED}!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!${NC}"
+        echo ""
+        echo "  To proceed, type exactly:"
+        echo "    RESET AND WIPE"
+        echo ""
+        read -r -p "> " confirm
+        if [[ "$confirm" != "RESET AND WIPE" ]]; then
+            echo "  Aborted."
+            exit 1
+        fi
+    else
+        confirm_destructive "RESET MITHRIL"
+    fi
+
+    # Step 1: Unmount all mithril mount points
+    info "Unmounting Mithril directories..."
+    for mount_point in "${mithril_mounts[@]}"; do
+        echo "  Unmounting $mount_point..."
+        if ! umount "$mount_point" 2>/dev/null; then
+            # Try lazy unmount if normal unmount fails
+            warn "Normal unmount failed, trying lazy unmount..."
+            if ! umount -l "$mount_point" 2>/dev/null; then
+                warn "Could not unmount $mount_point - is mithril still running?"
+                echo "  Try: sudo lsof +D $mount_point"
+                exit 1
+            fi
+        fi
+        success "Unmounted $mount_point"
+    done
+
+    # Step 2: Remove fstab entries
+    info "Removing Mithril entries from /etc/fstab..."
+    if grep -q mithril /etc/fstab 2>/dev/null; then
+        # Backup fstab
+        cp /etc/fstab /etc/fstab.bak.$(date +%Y%m%d%H%M%S)
+        # Remove mithril lines
+        sed -i '/mithril/d' /etc/fstab
+        success "Removed Mithril entries from fstab (backup created)"
+        systemctl daemon-reload
+    else
+        echo "  No Mithril entries found in fstab"
+    fi
+
+    # Step 3: Delete directories
+    info "Removing Mithril directories..."
+    for dir in "${mithril_dirs[@]}"; do
+        if [[ -d "$dir" ]]; then
+            echo "  Removing $dir..."
+            rm -rf "$dir"
+            success "Deleted $dir"
+        fi
+    done
+
+    # Step 4: Wipe partitions (if requested)
+    if [[ "$wipe_disks" == "true" && ${#partitions_to_wipe[@]} -gt 0 ]]; then
+        info "Wiping Mithril partitions..."
+        for partition in "${partitions_to_wipe[@]}"; do
+            echo "  Wiping $partition..."
+            wipefs -a "$partition" 2>/dev/null || warn "Could not wipe $partition"
+            success "Wiped $partition"
+        done
+    fi
+
+    echo ""
+    success "Mithril has been completely reset"
+    echo ""
+    echo "  Next steps:"
+    echo "    1. Run: sudo ./scripts/disk-setup.sh --setup"
+    echo "    2. Update config.toml with new paths"
+    echo "    3. Run: ./mithril run"
+    echo ""
+}
+
+# ------------------------------------------------------------------------------
 # Disk Summary
 # ------------------------------------------------------------------------------
 
@@ -2674,6 +2826,15 @@ main() {
             check_root
             clean_all
             ;;
+        --reset)
+            check_root
+            # Check for --wipe-disks flag
+            if [[ "${2:-}" == "--wipe-disks" ]]; then
+                reset_all true
+            else
+                reset_all false
+            fi
+            ;;
         --fix-noatime)
             check_root
             fix_noatime
@@ -2711,6 +2872,10 @@ main() {
             echo "  sudo ./scripts/disk-setup.sh --clean-snapshots    # Clear snapshots only"
             echo "  sudo ./scripts/disk-setup.sh --clean-blockstore   # Clear blockstore only"
             echo "  sudo ./scripts/disk-setup.sh --clean-all          # Clear everything"
+            echo ""
+            echo "Nuclear options (full teardown):"
+            echo "  sudo ./scripts/disk-setup.sh --reset              # Unmount + remove fstab + delete dirs"
+            echo "  sudo ./scripts/disk-setup.sh --reset --wipe-disks # Also wipe partitions"
             echo ""
             echo "Maintenance:"
             echo "  sudo ./scripts/disk-setup.sh --fix-noatime        # Add noatime to existing mounts"

--- a/scripts/disk-setup.sh
+++ b/scripts/disk-setup.sh
@@ -1317,6 +1317,7 @@ interactive_setup() {
         mkdir -p "$accountsdb_mount"
         mkdir -p "$accountsdb_mount/snapshots"
         mkdir -p "$accountsdb_mount/blockstore"
+        mkdir -p /mnt/mithril-logs
 
         success "Directories created"
         return
@@ -1399,7 +1400,12 @@ interactive_setup() {
 
         mkdir -p "$data_mount/snapshots"
         mkdir -p "$data_mount/blockstore"
+    fi
 
+    # Create logs directory (always on root filesystem)
+    mkdir -p /mnt/mithril-logs
+
+    if [[ -n "$data_disk" ]]; then
         if [[ "$data_disk" == "$root_disk" ]]; then
             success "Ledger partition created on OS disk: $data_part -> $data_mount ($data_fstype)"
         else

--- a/scripts/disk-setup.sh
+++ b/scripts/disk-setup.sh
@@ -925,7 +925,22 @@ format_disk() {
     echo "  This improves SSD longevity and maintains consistent performance."
 
     # Wipe and create GPT
-    wipefs -a "$disk"
+    local wipefs_output
+    if ! wipefs_output=$(wipefs -a "$disk" 2>&1); then
+        if [[ "$wipefs_output" == *"busy"* ]]; then
+            echo ""
+            die "Device $disk is busy and cannot be wiped.
+
+  This usually happens when the kernel still holds a reference to the device.
+
+  Solution: Reboot your machine and try again.
+
+  After rebooting, run:
+    sudo ./scripts/disk-setup.sh --setup"
+        else
+            die "Failed to wipe $disk: $wipefs_output"
+        fi
+    fi
     parted -s "$disk" mklabel gpt
     parted -s "$disk" mkpart primary 1MiB "${use_percent}%"
 
@@ -2193,11 +2208,28 @@ reset_all() {
     # Step 4: Wipe partitions (if requested)
     if [[ "$wipe_disks" == "true" && ${#partitions_to_wipe[@]} -gt 0 ]]; then
         info "Wiping Mithril partitions..."
+        local wipe_had_busy=false
         for partition in "${partitions_to_wipe[@]}"; do
             echo "  Wiping $partition..."
-            wipefs -a "$partition" 2>/dev/null || warn "Could not wipe $partition"
-            success "Wiped $partition"
+            local wipe_output
+            if wipe_output=$(wipefs -a "$partition" 2>&1); then
+                success "Wiped $partition"
+            elif [[ "$wipe_output" == *"busy"* ]]; then
+                warn "Could not wipe $partition - device is busy"
+                wipe_had_busy=true
+            else
+                warn "Could not wipe $partition: $wipe_output"
+            fi
         done
+        if [[ "$wipe_had_busy" == "true" ]]; then
+            echo ""
+            warn "Some partitions could not be wiped because they are busy."
+            echo "      This usually happens when the kernel still holds a reference."
+            echo ""
+            echo "      Solution: Reboot your machine and run again:"
+            echo "        sudo ./scripts/disk-setup.sh --reset --wipe-disks"
+            echo ""
+        fi
     fi
 
     echo ""

--- a/scripts/disk-setup.sh
+++ b/scripts/disk-setup.sh
@@ -1341,7 +1341,7 @@ interactive_setup() {
         mkdir -p "$accountsdb_mount"
         mkdir -p /mnt/mithril-ledger/snapshots
         mkdir -p /mnt/mithril-ledger/blockstore
-        mkdir -p /mnt/mithril-logs
+        mkdir -p /mnt/mithril-logs/snapshot-finder
 
         success "Directories created at $accountsdb_mount, /mnt/mithril-ledger, /mnt/mithril-logs"
         return
@@ -1427,7 +1427,7 @@ interactive_setup() {
     fi
 
     # Create logs directory (always on root filesystem)
-    mkdir -p /mnt/mithril-logs
+    mkdir -p /mnt/mithril-logs/snapshot-finder
 
     if [[ -n "$data_disk" ]]; then
         if [[ "$data_disk" == "$root_disk" ]]; then

--- a/scripts/server-setup.sh
+++ b/scripts/server-setup.sh
@@ -703,7 +703,7 @@ mode_install() {
     echo "  Enable UFW firewall? (Recommended)"
     echo "    - Blocks unsolicited incoming connections"
     echo "    - Allows SSH (port 22) incoming"
-    echo "    - Allows ALL outgoing connections (RPC, Overcast, etc.)"
+    echo "    - Allows ALL outgoing connections (RPC, Lightbringer, etc.)"
     echo ""
     local ENABLE_UFW="yes"
     if yesno "  Enable UFW firewall?" "y"; then

--- a/scripts/server-setup.sh
+++ b/scripts/server-setup.sh
@@ -288,7 +288,7 @@ install_security_packages() {
     export DEBIAN_FRONTEND=noninteractive
     apt-get update
     apt-get install -y openssh-server sudo fail2ban ufw unattended-upgrades \
-                       htop iotop vim nano tmux
+                       htop iotop nload vim nano tmux
 }
 
 configure_fail2ban() {
@@ -961,7 +961,7 @@ SOURCES
 apt-get update -qq
 apt-get install -y -qq linux-generic grub-efi-amd64 openssh-server sudo \
                    fail2ban ufw unattended-upgrades netplan.io xfsprogs \
-                   chrony git curl wget htop iotop vim nano tmux
+                   chrony git curl wget htop iotop nload vim nano tmux
 
 # Time synchronization (critical for blockchain nodes)
 systemctl enable chrony >/dev/null 2>&1 || true


### PR DESCRIPTION
## Summary

Operational improvements for production deployments: version tracking, state management, and reliability fixes.

---

## Versioning & Compatibility

### COMPATIBILITY.md

New compatibility matrix documenting Mithril's versioning approach:
- Mithril uses **independent semver**, not tied to Agave patch versions
- Tracks supported networks (mainnet-beta, testnet, devnet) per release
- Documents feature gate requirements for each version

### Build Infrastructure

**Makefile** with version stamping via ldflags:
```bash
make build              # Development build with version info
make release            # Production build (stripped symbols)
VERSION=v1.0.0 make release  # Tagged release
```

**pkg/version/version.go** - Shared version package:
```go
import "github.com/Overclock-Validator/mithril/pkg/version"

fmt.Println(version.Version)    // "v1.0.0" or "dev"
fmt.Println(version.GitCommit)  // "abc1234"
fmt.Println(version.BuildDate)  // "2025-01-01T10:00:00Z"
```

---

## State Management

### New State File Fields

```json
{
  "state_schema_version": 1,
  "cluster": "mainnet-beta",
  "genesis_hash": "5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d",
  "build_mode": "auto",
  "build_started_at": "2025-01-01T10:00:00Z",
  "last_writer_version": "v0.1.0",
  "last_writer_commit": "abc1234",
  "last_shutdown_reason": "graceful shutdown (Ctrl+C)",
  "last_shutdown_at": "2025-01-01T12:00:00Z"
}
```

| Field | Purpose |
|-------|---------|
| `state_schema_version` | Enables future migrations |
| `cluster` / `genesis_hash` | Prevents mainnet/testnet mixups (hard error on mismatch) |
| `build_mode` | How AccountsDB was built ("auto", "snapshot", "accountsdb") |
| `last_writer_version` | Semver of binary that last wrote state |
| `last_shutdown_*` | Forensics - why/when last session ended |

### State History Log

Append-only JSONL file at `<accountsdb>/mithril_state.history.jsonl`:

```jsonl
{"ts":"2025-01-01T10:00:00Z","event":"bootstrap","slot":390000000,"version":"v0.1.0","commit":"abc1234"}
{"ts":"2025-01-01T12:00:00Z","event":"shutdown","slot":390100000,"reason":"graceful shutdown (Ctrl+C)"}
{"ts":"2025-01-02T08:00:00Z","event":"resume","slot":390100000,"version":"v0.1.0"}
```

Events: `bootstrap`, `shutdown`, `resume`, `corrupted`, `rebuild`. Auto-pruned to last 100 entries.

### Cluster Safety

**Problem:** Running mainnet AccountsDB against testnet RPC (or vice versa) causes silent corruption.

**Solution:**
1. `cluster` field required in config.toml
2. Genesis hash fetched from RPC and stored in state on first build
3. On resume, genesis hash validated against RPC - **hard error on mismatch**

---

## New CLI: `mithril state`

```bash
mithril state                           # Show state summary
mithril state --json                    # Full JSON dump
mithril state --full                    # Include resume context details
mithril state history                   # Show last 10 events
mithril state history --all             # Show all events
mithril state validate                  # Check state + artifacts
mithril state --accounts /path/to/db    # Override config
```

---

## Graceful Shutdown Fixes

### Fix 1: Post-Block Cancellation Check

Added a second context cancellation check immediately after block completion. The loop now exits ASAP after the last completed block, ensuring the state file update runs immediately.

### Fix 2: Immediate State Write on Cancel

When context is cancelled, the state file is now written immediately via a callback from within the replay loop, before breaking out. This eliminates the timing window where a hard kill could leave the state file behind the bankhash DB.

---

## Progress Bar & Log Improvements

Progress bars now show elapsed time when complete:
```
Snapshot Read (.tar.zst) [████████████████████] 100.0%  Finished in 2m 30s
```

- "done processing full snapshot" now prints after shard flush completes
- Removed verbose "Node evaluation completed" logs from snapshot finder
- Stale AccountsDB prompt threshold changed from 100k to 2000 slots
- Fixed box alignment in stale AccountsDB prompt

---

## Setup Scripts & Permissions

### Automatic Ownership Handling

`disk-setup.sh` now auto-detects the real user via `$SUDO_USER` and fixes ownership after setup. Mithril fails fast at startup with a helpful fix command if permissions are wrong:

```
Error: AccountsDB directory not writable: /mnt/mithril-accounts

Fix: sudo chown -R $USER:$USER /mnt/mithril-accounts
```

### New Makefile Targets

```bash
sudo make disk-setup ARGS="--setup"
sudo make tune
sudo make server-setup ARGS="harden"
```

---

## Files Changed

| Category | Files |
|----------|-------|
| **Versioning** | `COMPATIBILITY.md`, `Makefile`, `pkg/version/version.go` |
| **State** | `pkg/state/state.go`, `pkg/state/history.go` |
| **CLI** | `cmd/mithril/statecmd/statecmd.go` |
| **Node** | `cmd/mithril/node/node.go` |
| **Replay** | `pkg/replay/block.go` |
| **Progress** | `pkg/progress/progress.go` |
| **Snapshot** | `pkg/snapshotdl/snapshotdl.go` |
| **Scripts** | `scripts/disk-setup.sh`, `scripts/server-setup.sh` |
| **Docs** | `README.md`, `scripts/README.md` |

---

## Testing Checklist

- [ ] `make build` stamps version info correctly
- [ ] Fresh install with `mithril config init` works
- [ ] Resume from existing AccountsDB works
- [ ] Cluster mismatch produces hard error
- [ ] `mithril state` shows correct info
- [ ] Ctrl+C graceful shutdown preserves correct state
- [ ] Hard kill after Ctrl+C doesn't corrupt state
- [ ] `sudo ./scripts/disk-setup.sh --setup` sets correct ownership

🤖 Generated with [Claude Code](https://claude.com/claude-code)