### PR TITLE
fix: prevent slot loss in retry queue race condition

### DIFF
--- a/pkg/blockstream/block_source.go
+++ b/pkg/blockstream/block_source.go
@@ -912,22 +912,25 @@ func (bs *BlockSource) emitOrderedBlocks() {
 		} else if isRetriable {
 			// All non-skip errors are retriable - schedule retry
 			bs.stats.FetchRetries.Add(1)
+			// CRITICAL: Must delete from slotState BEFORE adding to retry queue!
+			// Otherwise race condition: scheduler picks up from retry queue while
+			// slot is still marked slotInflight, scheduleSlot fails, slot is lost.
+			bs.slotStateMu.Lock()
+			delete(bs.slotState, result.slot)
+			delete(bs.inflightStart, result.slot)
+			bs.slotStateMu.Unlock()
 			bs.scheduleRetry(result.slot)
 		}
 		// Note: if result.block == nil && result.err == nil && !result.skipped,
 		// that's a bug in the worker, but we don't skip - it will stall and be detected.
 
-		// Mark slot done (even on error), unless retriable
-		bs.slotStateMu.Lock()
+		// Mark slot done (for non-retriable cases)
 		if !isRetriable {
+			bs.slotStateMu.Lock()
 			bs.slotState[result.slot] = slotDone
 			delete(bs.inflightStart, result.slot) // Clean up timing data
-		} else {
-			// Will be retried, reset to pending
-			delete(bs.slotState, result.slot)
-			delete(bs.inflightStart, result.slot)
+			bs.slotStateMu.Unlock()
 		}
-		bs.slotStateMu.Unlock()
 
 		// Emit consecutive blocks
 		for {
@@ -1174,7 +1177,12 @@ func (bs *BlockSource) scheduler() {
 							mlog.Log.Debugf("priority retry: scheduling waiting slot %d (buffer full, buf=%d)", slot, bufLen)
 						}
 					}
-					bs.scheduleSlot(slot)
+					// Check return value - if scheduleSlot fails, put back in retry queue.
+					// This makes the retry path lossless even if scheduleSlot fails for
+					// other reasons (work queue full, stopChan closed, etc.)
+					if !bs.scheduleSlot(slot) {
+						bs.scheduleRetry(slot)
+					}
 				} else {
 					bs.scheduleRetry(slot) // Put back
 				}


### PR DESCRIPTION
## Summary

Fixes a race condition in the block fetcher's retry loop that could silently drop slots, causing stalls.

**The bug:** When a slot fails and needs retry, the code was:
1. `scheduleRetry(slot)` - add to retry queue
2. `delete(slotState, slot)` - remove from slotState

If the scheduler's retry ticker fires between steps 1 and 2:
- Scheduler gets slot from retry queue (which clears it)
- `scheduleSlot()` fails because slot is still marked `slotInflight`
- Slot is lost forever → stall

Additionally, `scheduleSlot()` can fail for other reasons (queue full, shutdown), but the return value was ignored.

**The fix:**
- Delete from `slotState` BEFORE adding to retry queue (prevents race)
- Check `scheduleSlot()` return value and re-enqueue on failure (makes retry path lossless)

## Why this manifested recently

This bug is much more likely to hit in near-tip mode due to:
- High retry rates ("slot not available" errors for unconfirmed slots)
- Each retry creates a race window
- Tight scheduling means losing one slot = immediate stall

## Test plan

- [x] Code review of the fix
- [x] Run on mainnet and verify no stalls in near-tip mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)