### PR TITLE
fix(replay): prevent nil panic when getting leader in verify mode

### DIFF
--- a/pkg/block/rpc.go
+++ b/pkg/block/rpc.go
@@ -43,13 +43,16 @@ func FromBlockResult(blockResult *rpc.GetBlockResult, slot uint64, rpcc *rpcclie
 	blockReward := blockRewardRewards(blockResult.Rewards)
 
 	if !global.ManageLeaderSchedule() {
+		// In verify mode, set block.Leader from block reward data (no global schedule available)
 		if blockReward != nil {
 			block.BlockReward = &BlockRewardsInfo{Leader: blockReward.Pubkey, Lamports: uint64(blockReward.Lamports), PostBalance: blockReward.PostBalance}
+			block.Leader = blockReward.Pubkey
 		} else {
 			if rpcc != nil {
 				leaderForSlot, err := rpcc.GetLeaderForSlot(slot)
 				if err == nil {
 					block.BlockReward = &BlockRewardsInfo{Leader: leaderForSlot}
+					block.Leader = leaderForSlot
 				}
 			}
 		}

--- a/pkg/global/global_ctx.go
+++ b/pkg/global/global_ctx.go
@@ -217,6 +217,9 @@ func SetLeaderSchedule(ls *leaderschedule.LeaderSchedule) {
 }
 
 func LeaderForSlot(slot uint64) (solana.PublicKey, bool) {
+	if instance.leaderSchedule == nil {
+		return solana.PublicKey{}, false
+	}
 	return instance.leaderSchedule.LeaderForSlot(slot)
 }
 

--- a/pkg/replay/block.go
+++ b/pkg/replay/block.go
@@ -1188,10 +1188,10 @@ func ReplayBlocks(
 			}
 		}
 
-		// Get leader from internal schedule (no RPC call)
+		// Get leader from block (set by configureBlock in live mode, or by block source in verify mode)
 		leaderStr := "unknown"
-		if leader, ok := global.LeaderForSlot(block.Slot); ok {
-			leaderStr = leader.String()
+		if !block.Leader.IsZero() {
+			leaderStr = block.Leader.String()
 		}
 
 		// Fixed-width format for consistent alignment (use precise timing for block replay)


### PR DESCRIPTION
## Summary

Fixes a crash in verify mode where the logging code calls `global.LeaderForSlot()` but no leader schedule is initialized.

- Make `global.LeaderForSlot` nil-safe (returns zero, false when schedule is nil)
- Set `block.Leader` in verify mode from block reward data in `rpc.go`
- Update logging to use `block.Leader` as single source of truth

## Test plan

- [ ] Run `mithril verify-range` to confirm no panic
- [ ] Run `mithril run` to confirm live mode still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)