### PR TITLE
Remove appendvec if there was a parser error

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ replace github.com/gagliardetto/solana-go => github.com/palmerlao/solana-go v0.0
 replace github.com/gagliardetto/binary => github.com/palmerlao/binary v0.0.0-20250617062159-3054b4d33aed
 
 require (
-	github.com/Overclock-Validator/fastcache v0.0.0-20250516085958-ebf01de4f1f5
 	github.com/VividCortex/ewma v1.2.0
 	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/charmbracelet/bubbles v0.21.0
@@ -65,7 +64,6 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/common v0.67.4 // indirect
 	github.com/rogpeppe/go-internal v1.12.0 // indirect
-	github.com/spaolacci/murmur3 v1.1.0 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	github.com/zeebo/assert v1.3.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
@@ -79,13 +77,11 @@ require (
 	github.com/Overclock-Validator/weightedrand v0.0.0-20251113203832-5ac028321d0a
 	github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da // indirect
 	github.com/bits-and-blooms/bitset v1.22.0 // indirect
-	github.com/cespare/xxhash v1.1.0
 	github.com/consensys/bavard v0.1.31-0.20250406004941-2db259e4b582 // indirect
 	github.com/dchest/blake2b v1.0.0 // indirect
 	github.com/decred/dcrd/crypto/blake256 v1.0.1 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1 // indirect
 	github.com/dolthub/maphash v0.1.0 // indirect
-	github.com/edsrzf/mmap-go v1.1.0 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/google/uuid v1.6.0 // indirect
@@ -93,7 +89,6 @@ require (
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/holiman/uint256 v1.3.2 // indirect
 	github.com/ipfs/go-log/v2 v2.5.1 // indirect
-	github.com/leslie-fei/memcore v0.0.0-20240611074219-2f13777e1d72 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/mimoo/StrobeGo v0.0.0-20181016162300-f8f6d4d2b643 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
@@ -172,7 +167,7 @@ require (
 	go.uber.org/ratelimit v0.2.0 // indirect
 	go.uber.org/zap v1.24.0 // indirect
 	golang.org/x/crypto v0.43.0
-	golang.org/x/exp v0.0.0-20240904232852-e7e105dedf7e // indirect
+	golang.org/x/exp v0.0.0-20240904232852-e7e105dedf7e
 	golang.org/x/net v0.46.0 // indirect
 	golang.org/x/term v0.38.0
 	golang.org/x/time v0.9.0

--- a/go.sum
+++ b/go.sum
@@ -6,14 +6,10 @@ github.com/AlekSi/pointer v1.1.0/go.mod h1:y7BvfRI3wXPWKXEBhU71nbnIEEZX0QTSB2Bj4
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/DataDog/zstd v1.5.7 h1:ybO8RBeh29qrxIhCA9E8gKY6xfONU9T6G6aP9DTKfLE=
 github.com/DataDog/zstd v1.5.7/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
-github.com/OneOfOne/xxhash v1.2.2 h1:KMrpdQIwFcEqXDklaen+P1axHaj9BSKzvpUUfnHldSE=
-github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/Overclock-Validator/bgls v0.0.0-20250309141600-b7db1bfbf3fa h1:fDsvo4/6QDrO+wBdeOhlAdGz0TzDgiyw1ZdwTAl7k+4=
 github.com/Overclock-Validator/bgls v0.0.0-20250309141600-b7db1bfbf3fa/go.mod h1:oaNwxq8pzzIPDaKP3jnP+3RKw1WE/XYE/XfJ8VEUCjU=
 github.com/Overclock-Validator/crypto v0.0.0-20250307094320-aaf52fac5261 h1:Y715CmRx2hFfXguU0xSlGkZZ7/RYpKutWffZUiQSPvw=
 github.com/Overclock-Validator/crypto v0.0.0-20250307094320-aaf52fac5261/go.mod h1:ZhRHOaVg8I1gg0VK4wmqOQPnlgPgKFT9McZ+TCW/hBA=
-github.com/Overclock-Validator/fastcache v0.0.0-20250516085958-ebf01de4f1f5 h1:I1yDEdgKFwsA4BR7zfY6BGzUVxf04MhHNm/6OoD/Y44=
-github.com/Overclock-Validator/fastcache v0.0.0-20250516085958-ebf01de4f1f5/go.mod h1:3Vxi+ox/6cbjwyjmAnwdf8TSXWjPJKsIhEGb8opPIuw=
 github.com/Overclock-Validator/frand v0.0.0-20251113191226-96ce04ddc1a8 h1:Q7QbIeYib5JUtx7f1Q4GnaPdQ/XvxitgZMPQvf/7CW0=
 github.com/Overclock-Validator/frand v0.0.0-20251113191226-96ce04ddc1a8/go.mod h1:SvoqQH599ARmAzX0za/ZNvb2+2qt47ZpslDYFf4oaK0=
 github.com/Overclock-Validator/gnark-crypto v0.0.0-20250309203346-2a67ed08a105 h1:mP6FWHZ8ddcmbE8UTrVVI2Mi2c24aqX/8p12Vn6zokQ=
@@ -46,8 +42,6 @@ github.com/bits-and-blooms/bitset v1.22.0/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6
 github.com/blendle/zapdriver v1.3.1 h1:C3dydBOWYRiOk+B8X9IVZ5IOe+7cl+tGOexN4QqHfpE=
 github.com/blendle/zapdriver v1.3.1/go.mod h1:mdXfREi6u5MArG4j9fewC+FGnXaBR+T4Ox4J2u4eHCc=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
-github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/charmbracelet/bubbles v0.21.0 h1:9TdC97SdRVg/1aaXNVWfFH3nnLAwOXr8Fn6u6mfQdFs=
@@ -68,6 +62,8 @@ github.com/charmbracelet/x/term v0.2.1 h1:AQeHeLZ1OqSXhrAWpYUtZyX1T3zVxfpZuEQMIQ
 github.com/charmbracelet/x/term v0.2.1/go.mod h1:oQ4enTYFV7QN4m0i9mzHrViD7TQKvNEEkHUMCmsxdUg=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
+github.com/cockroachdb/datadriven v1.0.3-0.20230413201302-be42291fc80f h1:otljaYPt5hWxV3MUfO5dFPFiOXg9CyG5/kCfayTqsJ4=
+github.com/cockroachdb/datadriven v1.0.3-0.20230413201302-be42291fc80f/go.mod h1:a9RdTaap04u637JoCzcUoIcDmvwSUtcUFtT/C3kJlTU=
 github.com/cockroachdb/errors v1.11.3 h1:5bA+k2Y6r+oz/6Z/RFlNeVCesGARKuC6YymtcDrbC/I=
 github.com/cockroachdb/errors v1.11.3/go.mod h1:m4UIW4CDjx+R5cybPsNrRbreomiFqt8o1h1wUVazSd8=
 github.com/cockroachdb/fifo v0.0.0-20240606204812-0bbfbd93a7ce h1:giXvy4KSc/6g/esnpM7Geqxka4WSqI1SZc7sMJFd3y4=
@@ -99,8 +95,6 @@ github.com/dgryski/go-sip13 v0.0.0-20200911182023-62edffca9245 h1:9cOfvEwjQxdwKu
 github.com/dgryski/go-sip13 v0.0.0-20200911182023-62edffca9245/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/dolthub/maphash v0.1.0 h1:bsQ7JsF4FkkWyrP3oCnFJgrCUAFbFf3kOl4L/QxPDyQ=
 github.com/dolthub/maphash v0.1.0/go.mod h1:gkg4Ch4CdCDu5h6PMriVLawB7koZ+5ijb9puGMV50a4=
-github.com/edsrzf/mmap-go v1.1.0 h1:6EUwBLQ/Mcr1EYLE4Tn1VdW1A4ckqCQWZBw8Hr0kjpQ=
-github.com/edsrzf/mmap-go v1.1.0/go.mod h1:19H/e8pUPLicwkyNgOykDXkJ9F0MHE+Z52B8EIth78Q=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
@@ -125,6 +119,8 @@ github.com/gammazero/deque v1.0.0 h1:LTmimT8H7bXkkCy6gZX7zNLtkbz4NdS2z8LZuor3j34
 github.com/gammazero/deque v1.0.0/go.mod h1:iflpYvtGfM3U8S8j+sZEKIak3SAKYpA5/SQewgfXDKo=
 github.com/getsentry/sentry-go v0.27.0 h1:Pv98CIbtB3LkMWmXi4Joa5OOcwbmnX88sF5qbK3r3Ps=
 github.com/getsentry/sentry-go v0.27.0/go.mod h1:lc76E2QywIyW8WuBnwl8Lc4bkmQH4+w1gwTf25trprY=
+github.com/go-errors/errors v1.4.2 h1:J6MZopCL4uSllY1OfXM374weqZFFItUbrImctkmUxIA=
+github.com/go-errors/errors v1.4.2/go.mod h1:sIVyrIiJhuEF+Pj9Ebtd6P/rEYROXFi3BopGUQ5a5Og=
 github.com/go-logr/logr v1.2.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=
 github.com/go-logr/logr v1.4.2/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
@@ -206,8 +202,6 @@ github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/leanovate/gopter v0.2.11 h1:vRjThO1EKPb/1NsDXuDrzldR28RLkBflWYcU9CvzWu4=
 github.com/leanovate/gopter v0.2.11/go.mod h1:aK3tzZP/C+p1m3SPRE4SYZFGP7jjkuSI4f7Xvpt0S9c=
-github.com/leslie-fei/memcore v0.0.0-20240611074219-2f13777e1d72 h1:H4Bvmf4RVyiTC1t2xNgmrNPjUhRB4hfmhibi+G2r06E=
-github.com/leslie-fei/memcore v0.0.0-20240611074219-2f13777e1d72/go.mod h1:0wCsmrIf1BcPCHMtl38ocn8mpRU0DCM5/u2HACew03E=
 github.com/linxGnu/grocksdb v1.8.0 h1:H4L/LhP7GOMf1j17oQAElHgVlbEje2h14A8Tz9cM2BE=
 github.com/linxGnu/grocksdb v1.8.0/go.mod h1:09CeBborffXhXdNpEcOeZrLKEnRtrZFEpFdPNI9Zjjg=
 github.com/logrusorgru/aurora v2.0.3+incompatible h1:tOpm7WcpBTn4fjmVfgpQq0EfczGlG91VSDkswnjF5A8=
@@ -279,6 +273,8 @@ github.com/pelletier/go-toml/v2 v2.2.2 h1:aYUidT7k73Pcl9nb2gScu7NSrKCSHIDE89b3+6
 github.com/pelletier/go-toml/v2 v2.2.2/go.mod h1:1t835xjRzz80PqgE6HHgN2JOsmgYu/h4qDAS4n929Rs=
 github.com/pierrec/lz4/v4 v4.1.22 h1:cKFw6uJDK+/gfw5BcDL0JL5aBsAFdsIT18eRtLj7VIU=
 github.com/pierrec/lz4/v4 v4.1.22/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
+github.com/pingcap/errors v0.11.4 h1:lFuQV/oaUMGcD2tqt+01ROSmJs75VG1ToEOkZIZ4nE4=
+github.com/pingcap/errors v0.11.4/go.mod h1:Oi8TUi2kEtXXLMJk9l1cGmz20kV3TaQ0usTwv5KuLY8=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
@@ -318,9 +314,6 @@ github.com/smcio/go-ethereum v1.15.12-0.20250621134551-8b739407bb93 h1:SyVKMYtLv
 github.com/smcio/go-ethereum v1.15.12-0.20250621134551-8b739407bb93/go.mod h1:Yt8yVvAdi0Bzks6fBid2WM6MXbP5VRYPUJRKYCylDw4=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
-github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
-github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
-github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.11.0 h1:WJQKhtpdm3v2IzqG8VMqrr6Rf3UYpEF239Jy9wNepM8=
 github.com/spf13/afero v1.11.0/go.mod h1:GH9Y3pIexgf1MTIWtNGyogA5MwRIDXGUr+hbWNoBjkY=
 github.com/spf13/cast v1.6.0 h1:GEiTHELF+vaR5dhz3VqZfFSzZjYbgeKDpBxQVS4GYJ0=
@@ -502,6 +495,8 @@ golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roY
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.5/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
+golang.org/x/tools v0.37.0 h1:DVSRzp7FwePZW356yEAChSdNcQo6Nsp+fex1SUW09lE=
+golang.org/x/tools v0.37.0/go.mod h1:MBN5QPQtLMHVdvsbtarmTNukZDdgwdwlO5qGacAzF0w=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/pkg/accountsdb/accountsdb.go
+++ b/pkg/accountsdb/accountsdb.go
@@ -9,7 +9,6 @@ import (
 	"path/filepath"
 	"sync/atomic"
 
-	"github.com/Overclock-Validator/fastcache"
 	"github.com/Overclock-Validator/mithril/pkg/accounts"
 	"github.com/Overclock-Validator/mithril/pkg/addresses"
 	"github.com/Overclock-Validator/mithril/pkg/mlog"
@@ -21,10 +20,9 @@ import (
 
 type AccountsDb struct {
 	Index            *pebble.DB
-	BankHashStore    fastcache.Cache
+	BankHashStore    *pebble.DB
 	AcctsDir         string
 	LargestFileId    atomic.Uint64
-	BankHashBytes    [32]byte
 	VoteAcctCache    otter.Cache[solana.PublicKey, *accounts.Account]
 	CommonAcctsCache otter.Cache[solana.PublicKey, *accounts.Account]
 	ProgramCache     otter.Cache[solana.PublicKey, *ProgramCacheEntry]
@@ -63,45 +61,20 @@ func OpenDb(accountsDbDir string) (*AccountsDb, error) {
 	largestFileId := binary.LittleEndian.Uint64(largestFileIdBytes)
 	mlog.Log.Infof("accountsdb.OpenDb: largestFileId=%d", largestFileId)
 
-	bankHashFn := fmt.Sprintf("%s/bank_hash", accountsDbDir)
-	bhf, err := os.Open(bankHashFn)
-	if err != nil {
-		mlog.Log.Infof("failed to open %s\n", bankHashFn)
-		return nil, err
-	}
-
-	bankHashBytes := make([]byte, 32)
-	bytesRead, err = bhf.Read(bankHashBytes)
-	if err != nil {
-		mlog.Log.Infof("error reading %s: %s\n", bankHashFn, err)
-		return nil, err
-	} else if bytesRead != 32 {
-		mlog.Log.Infof("error reading %s: expected 8 bytes, got %d\n", bankHashFn, bytesRead)
-		return nil, fmt.Errorf("only got %d bytes", bytesRead)
-	}
-	mlog.Log.Infof("accountsdb.OpenDb: bankHashBytes=%x", bankHashBytes)
-
 	indexDir := filepath.Join(accountsDbDir, "mithril_db")
 	db, err := pebble.Open(indexDir, &pebble.Options{})
 	if err != nil {
 		return nil, fmt.Errorf("opening indexDir=%s: %w", indexDir, err)
 	}
 
-	// attempt to open the index kv store
-	bankHashDbFn := fmt.Sprintf("%s/bankhash_db", accountsDbDir)
-	bankhashDb, err := fastcache.NewCache(fastcache.MB*128, &fastcache.Config{
-		Shards: 256,
-		//MaxElementLen: 2000000000,
-		MemoryType: fastcache.MMAP,
-		MemoryKey:  bankHashDbFn,
-	})
+	bankhashDir := filepath.Join(accountsDbDir, "bankhash_db")
+	bankhashDb, err := pebble.Open(bankhashDir, &pebble.Options{})
 	if err != nil {
-		panic(err)
+		return nil, fmt.Errorf("opening bankhashDir=%s: %w", bankhashDir, err)
 	}
 
 	accountsDb := &AccountsDb{Index: db, BankHashStore: bankhashDb, AcctsDir: appendVecsDir}
 	accountsDb.LargestFileId.Store(largestFileId)
-	copy(accountsDb.BankHashBytes[:], bankHashBytes)
 
 	return accountsDb, nil
 }
@@ -349,13 +322,20 @@ func (accountsDb *AccountsDb) storeAccountsInternal(accts []*accounts.Account, s
 func (accountsDb *AccountsDb) GetBankHashForSlot(slot uint64) ([]byte, error) {
 	var slotBytes [8]byte
 	binary.LittleEndian.PutUint64(slotBytes[:], slot)
-	return accountsDb.BankHashStore.Get(slotBytes[:])
+	bh, c, err := accountsDb.BankHashStore.Get(slotBytes[:])
+	if err != nil {
+		return nil, fmt.Errorf("GetBankHashForSlot slot=%d: %w", slot, err)
+	}
+	out := make([]byte, len(bh))
+	copy(out, bh)
+	c.Close()
+	return out, nil
 }
 
 func (accountsDb *AccountsDb) StoreBankHashForSlot(slot uint64, bankHash []byte) error {
 	var slotBytes [8]byte
 	binary.LittleEndian.PutUint64(slotBytes[:], slot)
-	return accountsDb.BankHashStore.Set(slotBytes[:], bankHash)
+	return accountsDb.BankHashStore.Set(slotBytes[:], bankHash, &pebble.WriteOptions{})
 }
 
 func (accountsDb *AccountsDb) KeysBetweenPrefixes(startPrefix uint64, endPrefix uint64) []solana.PublicKey {
@@ -373,8 +353,4 @@ func (accountsDb *AccountsDb) KeysBetweenPrefixes(startPrefix uint64, endPrefix 
 
 func (accountsDb *AccountsDb) AllKeys() [][]byte {
 	return nil
-}
-
-func (accountsDb *AccountsDb) BankHash() [32]byte {
-	return accountsDb.BankHashBytes
 }

--- a/pkg/accountsdb/index.go
+++ b/pkg/accountsdb/index.go
@@ -46,6 +46,8 @@ func BuildIndexEntriesFromAppendVecs(data []byte, fileSize uint64, slot uint64, 
 		acctIdxEntries = append(acctIdxEntries, AccountIndexEntry{})
 		err = parser.ParseNextAcct(&pubkeys[len(pubkeys)-1], &acctIdxEntries[len(acctIdxEntries)-1])
 		if err != nil {
+			pubkeys = pubkeys[:len(pubkeys)-1]
+			acctIdxEntries = acctIdxEntries[:len(acctIdxEntries)-1]
 			break
 		}
 	}

--- a/pkg/snapshot/build_db.go
+++ b/pkg/snapshot/build_db.go
@@ -14,7 +14,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/Overclock-Validator/fastcache"
 	"github.com/Overclock-Validator/mithril/pkg/accountsdb"
 	"github.com/Overclock-Validator/mithril/pkg/mlog"
 	"github.com/Overclock-Validator/mithril/pkg/progress"
@@ -40,7 +39,6 @@ func CleanAccountsDbDir(accountsDbDir string) {
 		"mithril_db_log_shards",
 		"bankhash_db",
 		"largest_file_id",
-		"bank_hash",
 		"manifest",
 		"mithril_state.json", // State file for tracking valid builds and replay progress
 	}
@@ -263,18 +261,13 @@ func BuildAccountsDb(
 
 	accountsDb := &accountsdb.AccountsDb{Index: index, AcctsDir: appendVecsOutputDir}
 	accountsDb.LargestFileId.Store(largestFileId.Load())
-	copy(accountsDb.BankHashBytes[:], manifest.Bank.Hash[:])
 
-	bankHashDbFn := fmt.Sprintf("%s/bankhash_db", accountsDbDir)
-	accountsDb.BankHashStore, err = fastcache.NewCache(fastcache.MB*128, &fastcache.Config{
-		Shards: 256,
-		//MaxElementLen: 2000000000,
-		MemoryType: fastcache.MMAP,
-		MemoryKey:  bankHashDbFn,
-	})
+	bankhashDir := filepath.Join(accountsDbDir, "bankhash_db")
+	bankhashDb, err := pebble.Open(bankhashDir, &pebble.Options{})
 	if err != nil {
-		panic(err)
+		return nil, nil, fmt.Errorf("opening bankhashDir=%s: %w", bankhashDir, err)
 	}
+	accountsDb.BankHashStore = bankhashDb
 
 	if incrementalManifest != nil {
 		return accountsDb, incrementalManifest, nil

--- a/pkg/snapshot/build_db_with_incr.go
+++ b/pkg/snapshot/build_db_with_incr.go
@@ -11,12 +11,12 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/Overclock-Validator/fastcache"
 	"github.com/Overclock-Validator/mithril/pkg/accountsdb"
 	"github.com/Overclock-Validator/mithril/pkg/mlog"
 	"github.com/Overclock-Validator/mithril/pkg/progress"
 	"github.com/Overclock-Validator/mithril/pkg/rpcclient"
 	"github.com/Overclock-Validator/mithril/pkg/snapshotdl"
+	"github.com/cockroachdb/pebble"
 	"github.com/panjf2000/ants/v2"
 	"k8s.io/klog/v2"
 )
@@ -226,18 +226,13 @@ func BuildAccountsDbWithIncr(
 
 	accountsDb := &accountsdb.AccountsDb{Index: index, AcctsDir: appendVecsOutputDir}
 	accountsDb.LargestFileId.Store(largestFileId.Load())
-	copy(accountsDb.BankHashBytes[:], manifest.Bank.Hash[:])
 
-	bankHashDbFn := fmt.Sprintf("%s/bankhash_db", accountsDbDir)
-	accountsDb.BankHashStore, err = fastcache.NewCache(fastcache.MB*128, &fastcache.Config{
-		Shards: 256,
-		//MaxElementLen: 2000000000,
-		MemoryType: fastcache.MMAP,
-		MemoryKey:  bankHashDbFn,
-	})
+	bankhashDir := filepath.Join(accountsDbDir, "bankhash_db")
+	bankhashDb, err := pebble.Open(bankhashDir, &pebble.Options{})
 	if err != nil {
-		panic(err)
+		return nil, nil, fmt.Errorf("opening bankhashDir=%s: %w", bankhashDir, err)
 	}
+	accountsDb.BankHashStore = bankhashDb
 
 	rpcClient := rpcclient.NewRpcClient(rpcEndpoints[0])
 	latestSlot, err := rpcClient.GetSlot()


### PR DESCRIPTION
Without this fix, there's always a partially uninitialized appendvec on the end of the pubkeys/acctIdxEntries slices, since the parser finishes by erroring.