### PR TITLE
Block fetcher: safety net for lost slots + mode switching fix

### DIFF
--- a/pkg/blockstream/block_source.go
+++ b/pkg/blockstream/block_source.go
@@ -1307,6 +1307,50 @@ func (bs *BlockSource) getRetrySlots() []uint64 {
 	return slots
 }
 
+// forceScheduleWaitingSlot is a safety net that ensures the waiting slot
+// can never fall out of the pipeline. Called during retry ticks.
+// This handles edge cases where a slot might not be in slotState, retrySlots,
+// reorderBuffer, or skippedSlots - effectively "lost" from the pipeline.
+func (bs *BlockSource) forceScheduleWaitingSlot() {
+	// What slot are we waiting to emit?
+	bs.reorderMu.Lock()
+	waiting := bs.nextSlotToSend
+	alreadyHave := bs.reorderBuffer[waiting] != nil || bs.skippedSlots[waiting]
+	bs.reorderMu.Unlock()
+	if alreadyHave {
+		return
+	}
+
+	// If tracked in slotState, it's being handled
+	bs.slotStateMu.Lock()
+	_, exists := bs.slotState[waiting]
+	bs.slotStateMu.Unlock()
+	if exists {
+		return
+	}
+
+	// Check if it's in retry queue
+	bs.retryMu.Lock()
+	inRetry := false
+	for _, s := range bs.retrySlots {
+		if s == waiting {
+			inRetry = true
+			break
+		}
+	}
+	bs.retryMu.Unlock()
+	if inRetry {
+		return
+	}
+
+	// Slot is truly lost - force schedule it
+	mlog.Log.Warnf("safety net: forcing reschedule of lost waiting slot %d", waiting)
+	if !bs.scheduleSlot(waiting) {
+		// If scheduleSlot can't enqueue (slot already in slotState from race), put in retry
+		bs.scheduleRetry(waiting)
+	}
+}
+
 // canScheduleMore returns true if we can schedule the given slot.
 // In catchup mode: gate on buffer size (up to defaultMaxPending).
 // In near-tip mode: allow scheduling a small lookahead (bs.nearTipLookahead slots)
@@ -1568,6 +1612,9 @@ func (bs *BlockSource) scheduler() {
 				}
 			}
 			bs.slotStateMu.Unlock()
+
+			// Safety net: ensure waiting slot can't fall out of pipeline
+			bs.forceScheduleWaitingSlot()
 		default:
 		}
 

--- a/pkg/blockstream/block_source.go
+++ b/pkg/blockstream/block_source.go
@@ -384,19 +384,33 @@ func NewBlockSource(opts *BlockSourceOpts) *BlockSource {
 
 // updateMode checks the gap to tip and switches between catchup and near-tip mode.
 // Uses hysteresis to avoid flapping: enter near-tip at <=32 slots, exit at >=64 slots.
+//
+// IMPORTANT: Uses nextSlotToSend (not lastExecutedSlot) for gap calculation.
+// This ensures skip-heavy stretches are counted as progress toward tip.
+// lastExecutedSlot only advances on real blocks, so using it would make the gap
+// appear larger than reality during skip streaks, keeping us in catchup mode
+// longer than necessary.
 func (bs *BlockSource) updateMode() {
 	tip := bs.confirmedTip.Load()
-	lastExecuted := bs.lastExecutedSlot.Load()
 
-	// Can't determine mode without tip
-	if tip == 0 || lastExecuted == 0 {
+	// Get last processed slot (the slot before the one we're waiting to emit)
+	// This advances on both real blocks AND skipped slots.
+	bs.reorderMu.Lock()
+	nextToSend := bs.nextSlotToSend
+	bs.reorderMu.Unlock()
+
+	// Can't determine mode without tip or progress
+	if tip == 0 || nextToSend == 0 {
 		return
 	}
 
-	// Calculate gap (tip should always be >= lastExecuted, but handle wrap)
+	// lastProcessed = the slot we just emitted (either real or skipped)
+	lastProcessed := nextToSend - 1
+
+	// Calculate gap (tip should always be >= lastProcessed, but handle wrap)
 	var gap uint64
-	if tip > lastExecuted {
-		gap = tip - lastExecuted
+	if tip > lastProcessed {
+		gap = tip - lastProcessed
 	} else {
 		gap = 0
 	}
@@ -407,15 +421,15 @@ func (bs *BlockSource) updateMode() {
 		// Currently in near-tip mode - switch to catchup if gap exceeds threshold
 		if gap >= bs.catchupThreshold {
 			bs.isNearTip.Store(false)
-			mlog.Log.Infof("MODE SWITCH: near-tip → CATCHUP | gap=%d (threshold=%d) | exec_slot=%d | tip=%d",
-				gap, bs.catchupThreshold, lastExecuted, tip)
+			mlog.Log.Infof("MODE SWITCH: near-tip → CATCHUP | gap=%d (threshold=%d) | processed_slot=%d | tip=%d",
+				gap, bs.catchupThreshold, lastProcessed, tip)
 		}
 	} else {
 		// Currently in catchup mode - switch to near-tip if gap is small
 		if gap <= bs.nearTipThreshold {
 			bs.isNearTip.Store(true)
-			mlog.Log.Infof("MODE SWITCH: catchup → NEAR-TIP | gap=%d (threshold=%d) | exec_slot=%d | tip=%d",
-				gap, bs.nearTipThreshold, lastExecuted, tip)
+			mlog.Log.Infof("MODE SWITCH: catchup → NEAR-TIP | gap=%d (threshold=%d) | processed_slot=%d | tip=%d",
+				gap, bs.nearTipThreshold, lastProcessed, tip)
 		}
 	}
 }
@@ -1344,7 +1358,7 @@ func (bs *BlockSource) forceScheduleWaitingSlot() {
 	}
 
 	// Slot is truly lost - force schedule it
-	mlog.Log.Warnf("safety net: forcing reschedule of lost waiting slot %d", waiting)
+	mlog.Log.Debugf("safety net: forcing reschedule of lost waiting slot %d", waiting)
 	if !bs.scheduleSlot(waiting) {
 		// If scheduleSlot can't enqueue (slot already in slotState from race), put in retry
 		bs.scheduleRetry(waiting)


### PR DESCRIPTION
## Summary

- **Safety net for lost waiting slots**: During block fetch, the waiting slot (`nextSlotToSend`) can occasionally fall out of the pipeline entirely (not in slotState, retrySlots, reorderBuffer, or skippedSlots). The existing priority slot logic only helps if the slot is already in the retry queue. This adds a defensive check on each retry tick (200ms) to detect and force-reschedule any truly lost waiting slot.

- **Mode switching uses processed slot**: Mode switching now uses `nextSlotToSend` (slot progression including skips) instead of `lastExecutedSlot` (only real blocks) for gap calculation. This fixes skip-heavy stretches making the gap appear larger than reality, keeping us in catchup mode longer than necessary.

## Test plan

- [ ] Run replay and observe logs for "safety net: forcing reschedule" messages
- [ ] Verify mode switching transitions to near-tip mode appropriately during skip-heavy periods
- [ ] Confirm no regressions in block fetch throughput

🤖 Generated with [Claude Code](https://claude.com/claude-code)