### PR TITLE
Implement account prefetching

### DIFF
--- a/cmd/mithril/node/node.go
+++ b/cmd/mithril/node/node.go
@@ -186,6 +186,7 @@ func init() {
 	Run.Flags().IntVar(&snapshot.MaxConcurrentFlushers, "max-concurrent-flushers", 16, "Bound for number of log shards to flush to Accounts DB Index at once.")
 	Run.Flags().BoolVar(&sbpf.UsePool, "use-pool", true, "Disable to allocate fresh slices")
 	Run.Flags().IntVar(&accountsdb.StoreAccountsWorkers, "store-accounts-workers", 128, "Number of workers to write account updates")
+	Run.Flags().BoolVar(&replay.UseAccountPrefetcher, "use-account-prefetcher", false, "Prefetch accounts")
 
 	// [tuning.pprof] section flags
 	Run.Flags().Int64Var(&pprofPort, "pprof-port", -1, "Port to serve HTTP pprof endpoint")
@@ -545,6 +546,11 @@ func initConfigAndBindFlags(cmd *cobra.Command) error {
 		accountsdb.StoreAccountsWorkers = config.GetInt("store-accounts-workers")
 	} else if config.IsSet("tuning.store_accounts_workers") {
 		accountsdb.StoreAccountsWorkers = config.GetInt("tuning.store_accounts_workers")
+	}
+	if flagChanged("use-account-prefetcher") {
+		replay.UseAccountPrefetcher = config.GetBool("use-account-prefetcher")
+	} else if config.IsSet("tuning.use_account_prefetcher") {
+		replay.UseAccountPrefetcher = config.GetBool("tuning.use_account_prefetcher")
 	}
 
 	return nil

--- a/config.example.toml
+++ b/config.example.toml
@@ -256,6 +256,11 @@ name = "mithril"
     # Number of goroutines to store modified accounts at the end of each block
     store_accounts_workers = 128
 
+    # true to attempt to prefetch accounts for next block while
+    # current block is executing or false to load accounts, execute
+    # transactions, store accounts serially
+    use_account_prefetcher = true
+
     # [tuning.pprof] - CPU/Memory Profiling
     #
     # Usage (assuming port = 6060):

--- a/pkg/accountsdb/batch.go
+++ b/pkg/accountsdb/batch.go
@@ -2,6 +2,7 @@ package accountsdb
 
 import (
 	"context"
+	"fmt"
 	"math"
 	"runtime"
 	"sync"
@@ -64,6 +65,9 @@ func (db *AccountsDb) GetAccountsBatch(ctx context.Context, slot uint64, pks []s
 
 	if err, ok := <-errCh; ok && err != nil {
 		return nil, err
+	}
+	if ctx.Err() != nil {
+		return nil, fmt.Errorf("GetAccountsBatch: %w", ctx.Err())
 	}
 	return out, nil
 }

--- a/pkg/replay/account_loader.go
+++ b/pkg/replay/account_loader.go
@@ -1,0 +1,74 @@
+package replay
+
+import (
+	"context"
+
+	"github.com/Overclock-Validator/mithril/pkg/accounts"
+	"github.com/Overclock-Validator/mithril/pkg/accountsdb"
+	b "github.com/Overclock-Validator/mithril/pkg/block"
+	"github.com/Overclock-Validator/mithril/pkg/blockstream"
+	"github.com/gagliardetto/solana-go"
+)
+
+// accountLoader abstracts the loading and storing of accounts for block processing.
+// This enables future pipelining where account loading can happen ahead of execution.
+type accountLoader interface {
+	// NextBlock returns the next block and the accounts it needs for execution.
+	// Returns (nil, nil, nil) when there are no more blocks.
+	// For skipped blocks, returns (block, nil, nil) since no accounts are needed.
+	NextBlock() (*b.Block, map[solana.PublicKey]*accounts.Account, error)
+
+	// StoreAccounts persists the modified accounts to the accounts database.
+	StoreAccounts(modifiedAccts []*accounts.Account, slot uint64) error
+}
+
+var _ accountLoader = (*sequentialAccountLoader)(nil)
+
+// sequentialAccountLoader implements accountLoader with synchronous loading and storing.
+// This preserves the existing behavior where loading blocks execution.
+type sequentialAccountLoader struct {
+	acctsDb     *accountsdb.AccountsDb
+	blockSource *blockstream.BlockSource
+}
+
+func (l *sequentialAccountLoader) NextBlock() (*b.Block, map[solana.PublicKey]*accounts.Account, error) {
+	block := l.blockSource.NextBlock()
+	if block == nil {
+		return nil, nil, nil
+	}
+
+	if block.IsSkipped {
+		return block, nil, nil
+	}
+
+	// Resolve address table lookups before extracting account keys
+	err := resolveAddrTableLookups(l.acctsDb, block)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Extract all unique account keys needed for this block
+	dedupedKeys := extractAndDedupeBlockAccts(block)
+
+	// Load accounts from the database
+	ctx := context.Background()
+	loadedAccts, err := l.acctsDb.GetAccountsBatch(ctx, block.Slot, dedupedKeys)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Build the accounts map
+	acctsMap := make(map[solana.PublicKey]*accounts.Account, len(loadedAccts))
+	for _, acct := range loadedAccts {
+		acctsMap[acct.Key] = acct
+	}
+
+	return block, acctsMap, nil
+}
+
+func (l *sequentialAccountLoader) StoreAccounts(modifiedAccts []*accounts.Account, slot uint64) error {
+	if len(modifiedAccts) == 0 {
+		return nil
+	}
+	return l.acctsDb.StoreAccounts(modifiedAccts, slot)
+}

--- a/pkg/replay/account_loader.go
+++ b/pkg/replay/account_loader.go
@@ -3,6 +3,7 @@ package replay
 import (
 	"context"
 	"fmt"
+	"io"
 	"runtime/trace"
 
 	"github.com/Overclock-Validator/mithril/pkg/accounts"
@@ -26,8 +27,16 @@ type accountLoader interface {
 
 	// StoreAccounts persists the modified accounts to the accounts database.
 	// Must be called exactly once after each NextBlock call.
-	// modifiedAccts may be nil or empty for skipped blocks or blocks with no writes.
-	StoreAccounts(modifiedAccts []*accounts.Account, slot uint64) error
+	// modifiedAccts may be nil or empty for skipped blocks or blocks with no
+	// writes. It accepts an optional callback to run after accounts are written
+	// to disk, since that may happen after the function call returns.
+	StoreAccounts(modifiedAccts []*accounts.Account, slot uint64, afterStoreCallback func()) error
+}
+
+func callIfNonnil(f func()) {
+	if f != nil {
+		f()
+	}
 }
 
 var _ accountLoader = (*sequentialAccountLoader)(nil)
@@ -52,8 +61,13 @@ func (l *sequentialAccountLoader) NextBlock() (*b.Block, map[solana.PublicKey]*a
 	return block, acctsMap, nil
 }
 
-func (l *sequentialAccountLoader) StoreAccounts(modifiedAccts []*accounts.Account, slot uint64) error {
-	return l.acctsDb.StoreAccounts(modifiedAccts, slot)
+func (l *sequentialAccountLoader) StoreAccounts(modifiedAccts []*accounts.Account, slot uint64, afterStoreCallback func()) error {
+	err := l.acctsDb.StoreAccounts(modifiedAccts, slot)
+	if err != nil {
+		return err
+	}
+	callIfNonnil(afterStoreCallback)
+	return nil
 }
 
 var _ accountLoader = (*accountPrefetcher)(nil)
@@ -67,6 +81,7 @@ type prefetchResult struct {
 type storeRequest struct {
 	accts []*accounts.Account
 	slot  uint64
+	cb    func()
 }
 
 // Buffers one block and prefetches accounts for the buffered block.
@@ -90,6 +105,7 @@ func newAccountPrefetcher(ctx context.Context, a *accountsdb.AccountsDb, b *bloc
 }
 
 func (p *accountPrefetcher) worker(ctx context.Context) {
+	defer close(p.prefetch)
 	// Load first block
 	block, acctsMap, err := p.loadBlockAccountsFromDB(ctx)
 	if err != nil {
@@ -101,7 +117,7 @@ func (p *accountPrefetcher) worker(ctx context.Context) {
 
 	for block != nil {
 		if ctx.Err() != nil {
-			mlog.Log.Errorf("prefetcher exiting: %v", ctx.Err())
+			p.prefetch <- prefetchResult{nil, nil, fmt.Errorf("prefetcher exiting: %w", ctx.Err())}
 			return
 		}
 
@@ -111,8 +127,13 @@ func (p *accountPrefetcher) worker(ctx context.Context) {
 		// While that block is executing, try to write previous block's stores
 		if prevStore != nil {
 			trace.WithRegion(ctx, "PrefetcherStoreAccounts", func() {
-				p.acctsDb.StoreAccounts(prevStore.accts, prevStore.slot)
+				err = p.acctsDb.StoreAccounts(prevStore.accts, prevStore.slot)
 			})
+			if err != nil {
+				p.prefetch <- prefetchResult{nil, nil, fmt.Errorf("prefetcher: storing accounts: %w", err)}
+				return
+			}
+			callIfNonnil(prevStore.cb)
 			prevStore = nil
 		}
 
@@ -147,8 +168,13 @@ func (p *accountPrefetcher) worker(ctx context.Context) {
 
 			mlog.Log.Infof("slow path, prev block wrote my ALT :(")
 			trace.WithRegion(ctx, "PrefetcherStoreAccounts", func() {
-				p.acctsDb.StoreAccounts(s.accts, s.slot)
+				err = p.acctsDb.StoreAccounts(s.accts, s.slot)
 			})
+			if err != nil {
+				p.prefetch <- prefetchResult{nil, nil, fmt.Errorf("prefetcher: storing accounts: %w", err)}
+				return
+			}
+			callIfNonnil(s.cb)
 			prevStore = nil
 
 			acctsMap, err = loadBlockAccounts(ctx, p.acctsDb, nextBlock)
@@ -168,7 +194,12 @@ func (p *accountPrefetcher) worker(ctx context.Context) {
 
 	// Write final store
 	if prevStore != nil {
-		p.acctsDb.StoreAccounts(prevStore.accts, prevStore.slot)
+		err := p.acctsDb.StoreAccounts(prevStore.accts, prevStore.slot)
+		if err != nil {
+			p.prefetch <- prefetchResult{nil, nil, fmt.Errorf("prefetcher: %w", err)}
+			return
+		}
+		callIfNonnil(prevStore.cb)
 	}
 
 	// Signal end of stream
@@ -256,11 +287,14 @@ func extractALTKeys(block *b.Block) []solana.PublicKey {
 }
 
 func (p *accountPrefetcher) NextBlock() (*b.Block, map[solana.PublicKey]*accounts.Account, error) {
-	r := <-p.prefetch
+	r, ok := <-p.prefetch
+	if !ok {
+		return nil, nil, io.EOF
+	}
 	return r.blk, r.accts, r.err
 }
 
-func (p *accountPrefetcher) StoreAccounts(modifiedAccounts []*accounts.Account, slot uint64) error {
-	p.store <- storeRequest{modifiedAccounts, slot}
+func (p *accountPrefetcher) StoreAccounts(modifiedAccounts []*accounts.Account, slot uint64, afterStoreCallback func()) error {
+	p.store <- storeRequest{modifiedAccounts, slot, afterStoreCallback}
 	return nil
 }

--- a/pkg/replay/account_loader.go
+++ b/pkg/replay/account_loader.go
@@ -2,16 +2,21 @@ package replay
 
 import (
 	"context"
+	"runtime/trace"
 
 	"github.com/Overclock-Validator/mithril/pkg/accounts"
 	"github.com/Overclock-Validator/mithril/pkg/accountsdb"
 	b "github.com/Overclock-Validator/mithril/pkg/block"
 	"github.com/Overclock-Validator/mithril/pkg/blockstream"
+	"github.com/Overclock-Validator/mithril/pkg/mlog"
 	"github.com/gagliardetto/solana-go"
 )
 
 // accountLoader abstracts the loading and storing of accounts for block processing.
-// This enables future pipelining where account loading can happen ahead of execution.
+//
+// Invariant: Every call to NextBlock must be followed by exactly one call to
+// StoreAccounts, even for skipped blocks or when there are no modified accounts.
+// This enables pipelined implementations to synchronize correctly.
 type accountLoader interface {
 	// NextBlock returns the next block and the accounts it needs for execution.
 	// Returns (nil, nil, nil) when there are no more blocks.
@@ -19,6 +24,8 @@ type accountLoader interface {
 	NextBlock() (*b.Block, map[solana.PublicKey]*accounts.Account, error)
 
 	// StoreAccounts persists the modified accounts to the accounts database.
+	// Must be called exactly once after each NextBlock call.
+	// modifiedAccts may be nil or empty for skipped blocks or blocks with no writes.
 	StoreAccounts(modifiedAccts []*accounts.Account, slot uint64) error
 }
 
@@ -33,42 +40,225 @@ type sequentialAccountLoader struct {
 
 func (l *sequentialAccountLoader) NextBlock() (*b.Block, map[solana.PublicKey]*accounts.Account, error) {
 	block := l.blockSource.NextBlock()
-	if block == nil {
-		return nil, nil, nil
-	}
-
-	if block.IsSkipped {
+	if block == nil || block.IsSkipped {
 		return block, nil, nil
 	}
 
-	// Resolve address table lookups before extracting account keys
-	err := resolveAddrTableLookups(l.acctsDb, block)
+	acctsMap, err := loadBlockAccounts(context.Background(), l.acctsDb, block)
 	if err != nil {
 		return nil, nil, err
 	}
-
-	// Extract all unique account keys needed for this block
-	dedupedKeys := extractAndDedupeBlockAccts(block)
-
-	// Load accounts from the database
-	ctx := context.Background()
-	loadedAccts, err := l.acctsDb.GetAccountsBatch(ctx, block.Slot, dedupedKeys)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	// Build the accounts map
-	acctsMap := make(map[solana.PublicKey]*accounts.Account, len(loadedAccts))
-	for _, acct := range loadedAccts {
-		acctsMap[acct.Key] = acct
-	}
-
 	return block, acctsMap, nil
 }
 
 func (l *sequentialAccountLoader) StoreAccounts(modifiedAccts []*accounts.Account, slot uint64) error {
-	if len(modifiedAccts) == 0 {
-		return nil
-	}
 	return l.acctsDb.StoreAccounts(modifiedAccts, slot)
+}
+
+var _ accountLoader = (*accountPrefetcher)(nil)
+
+type prefetchResult struct {
+	blk   *b.Block
+	accts map[solana.PublicKey]*accounts.Account
+	err   error
+}
+
+type storeRequest struct {
+	accts []*accounts.Account
+	slot  uint64
+}
+
+// Buffers one block and prefetches accounts for the buffered block.
+type accountPrefetcher struct {
+	acctsDb     *accountsdb.AccountsDb
+	blockSource *blockstream.BlockSource
+
+	prefetch chan prefetchResult
+	store    chan storeRequest
+}
+
+func newAccountPrefetcher(ctx context.Context, a *accountsdb.AccountsDb, b *blockstream.BlockSource) *accountPrefetcher {
+	p := &accountPrefetcher{
+		acctsDb:     a,
+		blockSource: b,
+		prefetch:    make(chan prefetchResult),
+		store:       make(chan storeRequest, 1),
+	}
+	go p.worker(ctx)
+	return p
+}
+
+func (p *accountPrefetcher) worker(ctx context.Context) {
+	// Load first block
+	block, acctsMap, err := p.loadBlockAccountsFromDB(ctx)
+	if err != nil {
+		p.prefetch <- prefetchResult{nil, nil, err}
+		return
+	}
+
+	var prevStore *storeRequest
+
+	for block != nil {
+		if ctx.Err() != nil {
+			return
+		}
+
+		// Send block for execution
+		p.prefetch <- prefetchResult{block, acctsMap, nil}
+
+		// While that block is executing, try to write previous block's stores
+		if prevStore != nil {
+			trace.WithRegion(ctx, "PrefetcherStoreAccounts", func() {
+				p.acctsDb.StoreAccounts(prevStore.accts, prevStore.slot)
+			})
+			prevStore = nil
+		}
+
+		// then get the next block and see if we can prefetch accounts for it.
+		nextBlock := p.blockSource.NextBlock()
+		nextNeedsAccounts := nextBlock != nil && !nextBlock.IsSkipped
+
+		var nextAcctsMap map[solana.PublicKey]*accounts.Account
+		prefetch := nextNeedsAccounts && !altKeysOverlapWritable(nextBlock, block)
+		// These branches must be exhaustive and each branch must receive from
+		// p.store due to the accountLoader invariant.
+		if prefetch {
+			nextAcctsMap, err = loadBlockAccounts(ctx, p.acctsDb, nextBlock)
+			if err != nil {
+				p.prefetch <- prefetchResult{nil, nil, err}
+				return
+			}
+
+			s := <-p.store
+
+			// patch prefetched accounts with current block's modifications
+			for _, modifiedAcct := range s.accts {
+				if _, exists := nextAcctsMap[modifiedAcct.Key]; exists {
+					nextAcctsMap[modifiedAcct.Key] = modifiedAcct
+				}
+			}
+
+			prevStore = &s
+			acctsMap = nextAcctsMap
+		} else if nextNeedsAccounts {
+			s := <-p.store
+
+			mlog.Log.Infof("slow path, prev block wrote my ALT :(")
+			trace.WithRegion(ctx, "PrefetcherStoreAccounts", func() {
+				p.acctsDb.StoreAccounts(s.accts, s.slot)
+			})
+			prevStore = nil
+
+			acctsMap, err = loadBlockAccounts(ctx, p.acctsDb, nextBlock)
+			if err != nil {
+				p.prefetch <- prefetchResult{nil, nil, err}
+				return
+			}
+		} else {
+			s := <-p.store
+
+			prevStore = &s
+			acctsMap = nil
+		}
+
+		block = nextBlock
+	}
+
+	// Write final store
+	if prevStore != nil {
+		p.acctsDb.StoreAccounts(prevStore.accts, prevStore.slot)
+	}
+
+	// Signal end of stream
+	p.prefetch <- prefetchResult{nil, nil, nil}
+}
+
+// altKeysOverlapWritable returns true if any ALT used by nextBlock is writable by block.
+func altKeysOverlapWritable(nextBlock, block *b.Block) bool {
+	writableKeys := extractWritableKeys(block)
+	for _, altKey := range extractALTKeys(nextBlock) {
+		if writableKeys[altKey] {
+			return true
+		}
+	}
+	return false
+}
+
+// loadBlockAccounts resolves ALTs and loads accounts for a block.
+func loadBlockAccounts(ctx context.Context, acctsDb *accountsdb.AccountsDb, block *b.Block) (map[solana.PublicKey]*accounts.Account, error) {
+	if err := resolveAddrTableLookups(acctsDb, block); err != nil {
+		return nil, err
+	}
+
+	// Load transaction accounts
+	dedupedKeys := extractAndDedupeBlockAccts(block)
+	r := trace.StartRegion(ctx, "GetAccountsBatch")
+	loadedAccts, err := acctsDb.GetAccountsBatch(ctx, block.Slot, dedupedKeys)
+	r.End()
+	if err != nil {
+		return nil, err
+	}
+
+	acctsMap := make(map[solana.PublicKey]*accounts.Account, len(loadedAccts))
+	for _, acct := range loadedAccts {
+		acctsMap[acct.Key] = acct
+	}
+	return acctsMap, nil
+}
+
+// loadBlockAccountsFromDB fetches the next block and loads its accounts from the database.
+func (p *accountPrefetcher) loadBlockAccountsFromDB(ctx context.Context) (*b.Block, map[solana.PublicKey]*accounts.Account, error) {
+	block := p.blockSource.NextBlock()
+	if block == nil || block.IsSkipped {
+		return block, nil, nil
+	}
+
+	acctsMap, err := loadBlockAccounts(ctx, p.acctsDb, block)
+	if err != nil {
+		return nil, nil, err
+	}
+	return block, acctsMap, nil
+}
+
+// extractWritableKeys returns all unique writable account keys from a block.
+func extractWritableKeys(block *b.Block) map[solana.PublicKey]bool {
+	writable := make(map[solana.PublicKey]bool)
+	for _, tx := range block.Transactions {
+		ams := mustAccountMetaList(tx)
+		for _, am := range ams {
+			if am.IsWritable {
+				writable[am.PublicKey] = true
+			}
+		}
+	}
+	return writable
+}
+
+// extractALTKeys returns all unique ALT keys referenced by versioned transactions in the block.
+func extractALTKeys(block *b.Block) []solana.PublicKey {
+	seen := make(map[solana.PublicKey]bool)
+	var keys []solana.PublicKey
+
+	for _, tx := range block.Transactions {
+		if !tx.Message.IsVersioned() {
+			continue
+		}
+		for _, altKey := range tx.Message.GetAddressTableLookups().GetTableIDs() {
+			if !seen[altKey] {
+				seen[altKey] = true
+				keys = append(keys, altKey)
+			}
+		}
+	}
+	return keys
+}
+
+func (p *accountPrefetcher) NextBlock() (*b.Block, map[solana.PublicKey]*accounts.Account, error) {
+	r := <-p.prefetch
+	return r.blk, r.accts, r.err
+}
+
+func (p *accountPrefetcher) StoreAccounts(modifiedAccounts []*accounts.Account, slot uint64) error {
+	p.store <- storeRequest{modifiedAccounts, slot}
+	return nil
 }

--- a/pkg/replay/account_loader.go
+++ b/pkg/replay/account_loader.go
@@ -16,9 +16,10 @@ import (
 
 // accountLoader abstracts the loading and storing of accounts for block processing.
 //
-// Invariant: Every call to NextBlock must be followed by exactly one call to
-// StoreAccounts, even for skipped blocks or when there are no modified accounts.
-// This enables pipelined implementations to synchronize correctly.
+// Invariant: Every call to NextBlock must be followed by one call to
+// StoreAccounts in order for NextBlock to be called again, even for skipped
+// blocks or when there are no modified accounts. This enables pipelined
+// implementations to synchronize correctly.
 type accountLoader interface {
 	// NextBlock returns the next block and the accounts it needs for execution.
 	// Returns (nil, nil, nil) when there are no more blocks.
@@ -26,11 +27,14 @@ type accountLoader interface {
 	NextBlock() (*b.Block, map[solana.PublicKey]*accounts.Account, error)
 
 	// StoreAccounts persists the modified accounts to the accounts database.
-	// Must be called exactly once after each NextBlock call.
 	// modifiedAccts may be nil or empty for skipped blocks or blocks with no
 	// writes. It accepts an optional callback to run after accounts are written
 	// to disk, since that may happen after the function call returns.
 	StoreAccounts(modifiedAccts []*accounts.Account, slot uint64, afterStoreCallback func()) error
+
+	// Close waits for any outstanding StoreAccounts calls to finish, then
+	// returns.
+	Close()
 }
 
 func callIfNonnil(f func()) {
@@ -70,6 +74,8 @@ func (l *sequentialAccountLoader) StoreAccounts(modifiedAccts []*accounts.Accoun
 	return nil
 }
 
+func (l *sequentialAccountLoader) Close() {}
+
 var _ accountLoader = (*accountPrefetcher)(nil)
 
 type prefetchResult struct {
@@ -93,21 +99,23 @@ type accountPrefetcher struct {
 	store    chan storeRequest
 }
 
-func newAccountPrefetcher(ctx context.Context, a *accountsdb.AccountsDb, b *blockstream.BlockSource) *accountPrefetcher {
+func newAccountPrefetcher(a *accountsdb.AccountsDb, b *blockstream.BlockSource) *accountPrefetcher {
 	p := &accountPrefetcher{
 		acctsDb:     a,
 		blockSource: b,
 		prefetch:    make(chan prefetchResult),
 		store:       make(chan storeRequest, 1),
 	}
-	go p.worker(ctx)
+	go p.worker()
 	return p
 }
 
-func (p *accountPrefetcher) worker(ctx context.Context) {
+func (p *accountPrefetcher) worker() {
+	// Intentionally not cancellation context aware. Cancellation should be done in outer loops and call Close.
+	ctx := context.Background()
 	defer close(p.prefetch)
 	// Load first block
-	block, acctsMap, err := p.loadBlockAccountsFromDB(ctx)
+	block, acctsMap, err := p.loadBlockAccountsFromDB()
 	if err != nil {
 		p.prefetch <- prefetchResult{nil, nil, fmt.Errorf("prefetcher: loading initial block: %w", err)}
 		return
@@ -116,11 +124,6 @@ func (p *accountPrefetcher) worker(ctx context.Context) {
 	var prevStore *storeRequest
 
 	for block != nil {
-		if ctx.Err() != nil {
-			p.prefetch <- prefetchResult{nil, nil, fmt.Errorf("prefetcher exiting: %w", ctx.Err())}
-			return
-		}
-
 		// Send block for execution
 		p.prefetch <- prefetchResult{block, acctsMap, nil}
 
@@ -152,7 +155,10 @@ func (p *accountPrefetcher) worker(ctx context.Context) {
 				return
 			}
 
-			s := <-p.store
+			s, ok := <-p.store
+			if !ok {
+				return
+			}
 
 			// patch prefetched accounts with current block's modifications
 			for _, modifiedAcct := range s.accts {
@@ -164,7 +170,10 @@ func (p *accountPrefetcher) worker(ctx context.Context) {
 			prevStore = &s
 			acctsMap = nextAcctsMap
 		} else if nextNeedsAccounts {
-			s := <-p.store
+			s, ok := <-p.store
+			if !ok {
+				return
+			}
 
 			mlog.Log.Infof("slow path, prev block wrote my ALT :(")
 			trace.WithRegion(ctx, "PrefetcherStoreAccounts", func() {
@@ -183,7 +192,10 @@ func (p *accountPrefetcher) worker(ctx context.Context) {
 				return
 			}
 		} else {
-			s := <-p.store
+			s, ok := <-p.store
+			if !ok {
+				return
+			}
 
 			prevStore = &s
 			acctsMap = nil
@@ -240,13 +252,13 @@ func loadBlockAccounts(ctx context.Context, acctsDb *accountsdb.AccountsDb, bloc
 }
 
 // loadBlockAccountsFromDB fetches the next block and loads its accounts from the database.
-func (p *accountPrefetcher) loadBlockAccountsFromDB(ctx context.Context) (*b.Block, map[solana.PublicKey]*accounts.Account, error) {
+func (p *accountPrefetcher) loadBlockAccountsFromDB() (*b.Block, map[solana.PublicKey]*accounts.Account, error) {
 	block := p.blockSource.NextBlock()
 	if block == nil || block.IsSkipped {
 		return block, nil, nil
 	}
 
-	acctsMap, err := loadBlockAccounts(ctx, p.acctsDb, block)
+	acctsMap, err := loadBlockAccounts(context.Background(), p.acctsDb, block)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -297,4 +309,12 @@ func (p *accountPrefetcher) NextBlock() (*b.Block, map[solana.PublicKey]*account
 func (p *accountPrefetcher) StoreAccounts(modifiedAccounts []*accounts.Account, slot uint64, afterStoreCallback func()) error {
 	p.store <- storeRequest{modifiedAccounts, slot, afterStoreCallback}
 	return nil
+}
+
+func (p *accountPrefetcher) Close() {
+	close(p.store)
+	// Consume any buffered blocks and wait for worker's defer
+	// close(p.prefetch) to know it's terminated.
+	for range p.prefetch {
+	}
 }

--- a/pkg/replay/account_loader.go
+++ b/pkg/replay/account_loader.go
@@ -2,6 +2,7 @@ package replay
 
 import (
 	"context"
+	"fmt"
 	"runtime/trace"
 
 	"github.com/Overclock-Validator/mithril/pkg/accounts"
@@ -92,7 +93,7 @@ func (p *accountPrefetcher) worker(ctx context.Context) {
 	// Load first block
 	block, acctsMap, err := p.loadBlockAccountsFromDB(ctx)
 	if err != nil {
-		p.prefetch <- prefetchResult{nil, nil, err}
+		p.prefetch <- prefetchResult{nil, nil, fmt.Errorf("prefetcher: loading initial block: %w", err)}
 		return
 	}
 
@@ -100,6 +101,7 @@ func (p *accountPrefetcher) worker(ctx context.Context) {
 
 	for block != nil {
 		if ctx.Err() != nil {
+			mlog.Log.Errorf("prefetcher exiting: %v", ctx.Err())
 			return
 		}
 
@@ -125,7 +127,7 @@ func (p *accountPrefetcher) worker(ctx context.Context) {
 		if prefetch {
 			nextAcctsMap, err = loadBlockAccounts(ctx, p.acctsDb, nextBlock)
 			if err != nil {
-				p.prefetch <- prefetchResult{nil, nil, err}
+				p.prefetch <- prefetchResult{nil, nil, fmt.Errorf("prefetcher: loading accounts on prefetch path: %w", err)}
 				return
 			}
 
@@ -151,7 +153,7 @@ func (p *accountPrefetcher) worker(ctx context.Context) {
 
 			acctsMap, err = loadBlockAccounts(ctx, p.acctsDb, nextBlock)
 			if err != nil {
-				p.prefetch <- prefetchResult{nil, nil, err}
+				p.prefetch <- prefetchResult{nil, nil, fmt.Errorf("prefetcher: loading accounts on slow path: %w", err)}
 				return
 			}
 		} else {

--- a/pkg/replay/block.go
+++ b/pkg/replay/block.go
@@ -64,6 +64,8 @@ type BlockFetchOpts struct {
 
 var SerializedParameterArena *arena.Arena[byte]
 
+var UseAccountPrefetcher = false
+
 // Commit state tracking for panic recovery
 // commitInProgress is set true during the critical window between StoreAccounts and StoreBankHashForSlot.
 // If a panic occurs while this is true, AccountsDB may be corrupted (partial writes).
@@ -264,6 +266,10 @@ func extractAndDedupeBlockAccts(block *b.Block) []solana.PublicKey {
 		pubkeyMap[pk] = struct{}{}
 	}
 
+	for _, pk := range updatedSysvarAddrs {
+		pubkeyMap[pk] = struct{}{}
+	}
+
 	pubkeys := make([]solana.PublicKey, len(pubkeyMap))
 	i := 0
 	for pk := range pubkeyMap {
@@ -348,21 +354,33 @@ func cacheConstantSysvars(acctsDb *accountsdb.AccountsDb) {
 	}
 }
 
-// load sysvar accounts and assign them to the sysvar cache
-func loadAndUpdateSysvars(
-	accountsDb *accountsdb.AccountsDb,
+// The list of sysvars processed in updateAndCacheSysvars. We need to always
+// prefetch these accounts, since reading from AccountsDB could result in
+// stale data if the prefetcher hasn't stored them yet.
+var updatedSysvarAddrs = []solana.PublicKey{
+	sealevel.SysvarClockAddr,
+	sealevel.SysvarSlotHashesAddr,
+	sealevel.SysvarRecentBlockHashesAddr,
+	sealevel.SysvarSlotHistoryAddr,
+	sealevel.SysvarStakeHistoryAddr,
+	sealevel.SysvarLastRestartSlotAddr,
+}
+
+// update sysvar accounts and assign them to the sysvar cache
+func updateAndCacheSysvars(
+	loadedAccts map[solana.PublicKey]*accounts.Account,
 	block *b.Block,
 	accts accounts.Accounts,
 	parentAccts accounts.Accounts,
 ) {
 	// update and cache clock sysvar
 	{
-		clockAcct, err := accountsDb.GetAccount(block.Slot, sealevel.SysvarClockAddr)
-		if err != nil {
+		clockAcct, loaded := loadedAccts[sealevel.SysvarClockAddr]
+		if !loaded {
 			panic("unable to retrieve clock sysvar when updating clock")
 		}
 
-		err = parentAccts.SetAccountWithoutLock(sealevel.SysvarClockAddr, clockAcct.Clone())
+		err := parentAccts.SetAccountWithoutLock(sealevel.SysvarClockAddr, clockAcct.Clone())
 		if err != nil {
 			panic("unable to set clock sysvar to accts")
 		}
@@ -393,8 +411,8 @@ func loadAndUpdateSysvars(
 
 	// update and cache SlotHashes sysvar
 	{
-		slotHashesAcct, err := accountsDb.GetAccount(block.Slot, sealevel.SysvarSlotHashesAddr)
-		if err != nil {
+		slotHashesAcct, loaded := loadedAccts[sealevel.SysvarSlotHashesAddr]
+		if !loaded {
 			panic("unable to retrieve slothashes sysvar from acctsdb")
 		}
 
@@ -403,7 +421,7 @@ func loadAndUpdateSysvars(
 		if sealevel.SysvarCache.SlotHashes.Sysvar == nil {
 			// Fresh start (first slot): unmarshal from AccountsDB
 			decoder := bin.NewBinDecoder(slotHashesAcct.Data)
-			err = slotHashes.UnmarshalWithDecoder(decoder)
+			err := slotHashes.UnmarshalWithDecoder(decoder)
 			if err != nil {
 				panic("unable to unmarshal slothashes sysvar")
 			}
@@ -423,7 +441,7 @@ func loadAndUpdateSysvars(
 		}
 
 		// Set parentAccts BEFORE updating slotHashes to ensure LtHash delta is computed correctly
-		err = parentAccts.SetAccountWithoutLock(sealevel.SysvarSlotHashesAddr, slotHashesAcct.Clone())
+		err := parentAccts.SetAccountWithoutLock(sealevel.SysvarSlotHashesAddr, slotHashesAcct.Clone())
 		if err != nil {
 			panic("unable to set slothashes sysvar to accountsdb")
 		}
@@ -443,8 +461,8 @@ func loadAndUpdateSysvars(
 
 	// cache RecentBlockhashes sysvar
 	{
-		recentBlockhashesAcct, err := accountsDb.GetAccount(block.Slot, sealevel.SysvarRecentBlockHashesAddr)
-		if err != nil {
+		recentBlockhashesAcct, loaded := loadedAccts[sealevel.SysvarRecentBlockHashesAddr]
+		if !loaded {
 			panic("unable to get recentblockhashes")
 		}
 
@@ -477,7 +495,7 @@ func loadAndUpdateSysvars(
 		}
 
 		// Set parentAccts AFTER potential data correction to ensure LtHash delta is computed correctly
-		err = parentAccts.SetAccountWithoutLock(sealevel.SysvarRecentBlockHashesAddr, recentBlockhashesAcct.Clone())
+		err := parentAccts.SetAccountWithoutLock(sealevel.SysvarRecentBlockHashesAddr, recentBlockhashesAcct.Clone())
 		if err != nil {
 			panic("unable to set recentblockhashes sysvar to accts")
 		}
@@ -490,12 +508,12 @@ func loadAndUpdateSysvars(
 
 	// cache SlotHistory sysvar
 	{
-		slotHistoryAcct, err := accountsDb.GetAccount(block.Slot, sealevel.SysvarSlotHistoryAddr)
-		if err != nil {
+		slotHistoryAcct, loaded := loadedAccts[sealevel.SysvarSlotHistoryAddr]
+		if !loaded {
 			panic("unable to get slothistory")
 		}
 
-		err = parentAccts.SetAccountWithoutLock(sealevel.SysvarSlotHistoryAddr, slotHistoryAcct.Clone())
+		err := parentAccts.SetAccountWithoutLock(sealevel.SysvarSlotHistoryAddr, slotHistoryAcct.Clone())
 		if err != nil {
 			panic("unable to set slothistory sysvar to accts")
 		}
@@ -514,8 +532,8 @@ func loadAndUpdateSysvars(
 
 	// cache StakeHistory sysvar
 	{
-		stakeHistoryAcct, err := accountsDb.GetAccount(block.Slot, sealevel.SysvarStakeHistoryAddr)
-		if err != nil {
+		stakeHistoryAcct, loaded := loadedAccts[sealevel.SysvarStakeHistoryAddr]
+		if !loaded {
 			panic("unable to get stakehistory")
 		}
 
@@ -524,7 +542,7 @@ func loadAndUpdateSysvars(
 			for _, a := range block.ParentEpochUpdatedAccts {
 				if a != nil {
 					if a.Key == sealevel.SysvarStakeHistoryAddr {
-						err = parentAccts.SetAccountWithoutLock(sealevel.SysvarStakeHistoryAddr, a.Clone())
+						err := parentAccts.SetAccountWithoutLock(sealevel.SysvarStakeHistoryAddr, a.Clone())
 						if err != nil {
 							panic("unable to set stakehistory sysvar to accts")
 						}
@@ -535,7 +553,7 @@ func loadAndUpdateSysvars(
 		}
 
 		if !setStakeHistoryParent {
-			err = parentAccts.SetAccountWithoutLock(sealevel.SysvarStakeHistoryAddr, stakeHistoryAcct.Clone())
+			err := parentAccts.SetAccountWithoutLock(sealevel.SysvarStakeHistoryAddr, stakeHistoryAcct.Clone())
 			if err != nil {
 				panic("unable to set stakehistory sysvar to accts")
 			}
@@ -547,7 +565,7 @@ func loadAndUpdateSysvars(
 		sealevel.SysvarCache.StakeHistory.Sysvar = &stakeHistory
 		sealevel.SysvarCache.StakeHistory.Acct = stakeHistoryAcct
 
-		err = accts.SetAccountWithoutLock(sealevel.SysvarStakeHistoryAddr, stakeHistoryAcct)
+		err := accts.SetAccountWithoutLock(sealevel.SysvarStakeHistoryAddr, stakeHistoryAcct)
 		if err != nil {
 			panic("unable to set stakehistory sysvar to accts")
 		}
@@ -555,12 +573,12 @@ func loadAndUpdateSysvars(
 
 	// cache LastRestartSlot sysvar
 	{
-		lastRestartSlotAcct, err := accountsDb.GetAccount(block.Slot, sealevel.SysvarLastRestartSlotAddr)
-		if err != nil {
+		lastRestartSlotAcct, loaded := loadedAccts[sealevel.SysvarLastRestartSlotAddr]
+		if !loaded {
 			panic("unable to get last restart slot sysvar acct")
 		}
 
-		err = parentAccts.SetAccountWithoutLock(sealevel.SysvarLastRestartSlotAddr, lastRestartSlotAcct.Clone())
+		err := parentAccts.SetAccountWithoutLock(sealevel.SysvarLastRestartSlotAddr, lastRestartSlotAcct.Clone())
 		if err != nil {
 			panic("unable to set last restart slot sysvar to accts")
 		}
@@ -1178,7 +1196,14 @@ func ReplayBlocks(
 	}
 	go blockStream.Start()
 
-	loader := &sequentialAccountLoader{acctsDb, blockStream}
+	var loader accountLoader
+	if UseAccountPrefetcher {
+		mlog.Log.Infof("Using account prefetcher")
+		loader = newAccountPrefetcher(ctx, acctsDb, blockStream)
+	} else {
+		mlog.Log.Infof("Using sequential account loader")
+		loader = &sequentialAccountLoader{acctsDb, blockStream}
+	}
 
 	var skippedSlotsCount int // Track skipped slots for 100-slot summary
 	replayStartLogged := false
@@ -1245,6 +1270,8 @@ func ReplayBlocks(
 			mlog.Log.InfofPrecise("slot %-10d | leader: %-44s | txns: N/A              | cu: N/A        | exec:     N/A | wait:%7.3fs | total:%7.3fs (skip)",
 				block.Slot, leaderStr, waitTime.Seconds(), waitTime.Seconds())
 			skippedSlotsCount++
+			// Maintain invariant: every NextBlock is followed by exactly one StoreAccounts
+			loader.StoreAccounts(nil, block.Slot)
 			continue // Skip all execution - no state changes for skipped slots
 		}
 
@@ -1943,7 +1970,6 @@ func parallelTxLoop(slotCtx *sealevel.SlotCtx, sigverifyWg *sync.WaitGroup, bloc
 }
 
 func prepareAccountsAndSysvars(
-	accountsDb *accountsdb.AccountsDb,
 	block *b.Block,
 	loadedAccts map[solana.PublicKey]*accounts.Account,
 ) (accounts.Accounts, accounts.Accounts) {
@@ -1968,8 +1994,7 @@ func prepareAccountsAndSysvars(
 		block.FeeRateGovernor.PrevLamportsPerSignature = block.InitialPreviousLamportsPerSignature
 	}
 
-	// load sysvar accounts and assign them to the sysvar cache
-	loadAndUpdateSysvars(accountsDb, block, accts, parentAccts)
+	updateAndCacheSysvars(loadedAccts, block, accts, parentAccts)
 
 	for idx, acct := range block.EpochUpdatedAccts {
 		if acct == nil {
@@ -2026,7 +2051,7 @@ func ProcessBlock(
 
 	start = time.Now()
 	loadAcctsRegion := trace.StartRegion(ctx, "PrepareAccounts")
-	accts, parentAccts := prepareAccountsAndSysvars(acctsDb, block, loadedAccts)
+	accts, parentAccts := prepareAccountsAndSysvars(block, loadedAccts)
 	loadAcctsRegion.End()
 	metrics.GlobalBlockReplay.LoadBlockAccounts.AddTimingSince(start)
 
@@ -2088,14 +2113,12 @@ func ProcessBlock(
 	commitSlot.Store(slotCtx.Slot)
 	commitInProgress.Store(true)
 
-	if len(modifiedAccts) > 0 {
-		storeAcctsRegion := trace.StartRegion(ctx, "StoreAccounts")
-		err := loader.StoreAccounts(modifiedAccts, slotCtx.Slot)
-		if err != nil {
-			return nil, err
-		}
-		storeAcctsRegion.End()
+	storeAcctsRegion := trace.StartRegion(ctx, "StoreAccounts")
+	err := loader.StoreAccounts(modifiedAccts, slotCtx.Slot)
+	if err != nil {
+		return nil, err
 	}
+	storeAcctsRegion.End()
 	metrics.GlobalBlockReplay.BlockUpdateAccounts.AddTimingSince(start)
 
 	// EAH workaround - see comment at top of replay loop for details
@@ -2106,7 +2129,7 @@ func ProcessBlock(
 		return slotCtx, nil
 	}
 
-	err := acctsDb.StoreBankHashForSlot(slotCtx.Slot, slotCtx.FinalBankhash)
+	err = acctsDb.StoreBankHashForSlot(slotCtx.Slot, slotCtx.FinalBankhash)
 	if err != nil {
 		mlog.Log.Infof("unable to store bankhash for slot %d", slotCtx.Slot)
 	}

--- a/pkg/replay/block.go
+++ b/pkg/replay/block.go
@@ -348,283 +348,234 @@ func cacheConstantSysvars(acctsDb *accountsdb.AccountsDb) {
 	}
 }
 
-func loadBlockAccountsAndUpdateSysvars(accountsDb *accountsdb.AccountsDb, block *b.Block) (accounts.Accounts, accounts.Accounts, error) {
-	err := resolveAddrTableLookups(accountsDb, block)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	dedupedAccts := extractAndDedupeBlockAccts(block)
-	ctx := context.Background()
-	slotAccts, err := accountsDb.GetAccountsBatch(ctx, block.Slot, dedupedAccts)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	numAccts := uint64(len(slotAccts))
-	accts := accounts.NewMemAccountsWithLen(numAccts)
-	parentAccts := accounts.NewMemAccountsWithLen(numAccts)
-
-	for _, acct := range slotAccts {
-		err = accts.SetAccountWithoutLock(acct.Key, acct)
-		if err != nil {
-			return nil, nil, err
-		}
-
-		err = parentAccts.SetAccountWithoutLock(acct.Key, acct)
-		if err != nil {
-			return nil, nil, err
-		}
-	}
-
-	block.FeeRateGovernor = sealevel.NewFeeRateGovernorDerived(block.PrevFeeRateGovernor, block.PrevNumSignatures)
-	if block.FeeRateGovernor.PrevLamportsPerSignature == 0 {
-		block.FeeRateGovernor.PrevLamportsPerSignature = block.InitialPreviousLamportsPerSignature
-	}
-
-	// load sysvar accounts and assign them to the sysvar cache
+// load sysvar accounts and assign them to the sysvar cache
+func loadAndUpdateSysvars(
+	accountsDb *accountsdb.AccountsDb,
+	block *b.Block,
+	accts accounts.Accounts,
+	parentAccts accounts.Accounts,
+) {
+	// update and cache clock sysvar
 	{
-		// update and cache clock sysvar
-		{
-			clockAcct, err := accountsDb.GetAccount(block.Slot, sealevel.SysvarClockAddr)
-			if err != nil {
-				panic("unable to retrieve clock sysvar when updating clock")
-			}
-
-			err = parentAccts.SetAccountWithoutLock(sealevel.SysvarClockAddr, clockAcct.Clone())
-			if err != nil {
-				panic("unable to set clock sysvar to accts")
-			}
-
-			decoder := bin.NewBinDecoder(clockAcct.Data)
-			var clock sealevel.SysvarClock
-
-			err = clock.UnmarshalWithDecoder(decoder)
-			if err != nil {
-				panic("unable to unmarshal clock sysvar")
-			}
-
-			err = updateClockSysvar(&clock, block)
-			if err != nil {
-				panic(fmt.Sprintf("failed to update clock sysvar: %s", err))
-			}
-
-			newClockBytes := clock.MustMarshal()
-			copy(clockAcct.Data, newClockBytes)
-			sealevel.SysvarCache.Clock.Sysvar = &clock
-			sealevel.SysvarCache.Clock.Acct = clockAcct
-
-			err = accts.SetAccountWithoutLock(sealevel.SysvarClockAddr, clockAcct)
-			if err != nil {
-				panic("unable to set clock sysvar to accts")
-			}
+		clockAcct, err := accountsDb.GetAccount(block.Slot, sealevel.SysvarClockAddr)
+		if err != nil {
+			panic("unable to retrieve clock sysvar when updating clock")
 		}
 
-		// update and cache SlotHashes sysvar
-		{
-			slotHashesAcct, err := accountsDb.GetAccount(block.Slot, sealevel.SysvarSlotHashesAddr)
-			if err != nil {
-				panic("unable to retrieve slothashes sysvar from acctsdb")
-			}
-
-			var slotHashes sealevel.SysvarSlotHashes
-
-			if sealevel.SysvarCache.SlotHashes.Sysvar == nil {
-				// Fresh start (first slot): unmarshal from AccountsDB
-				decoder := bin.NewBinDecoder(slotHashesAcct.Data)
-				err = slotHashes.UnmarshalWithDecoder(decoder)
-				if err != nil {
-					panic("unable to unmarshal slothashes sysvar")
-				}
-
-			} else {
-				// SysvarCache already populated (either from resume state file or from previous slot).
-				// The account data from AccountsDB may be stale (appendvec writes are not fsynced),
-				// so overwrite it with the authoritative data from SysvarCache.
-				// This ensures BPF programs reading the account data directly see correct values.
-				slotHashes = *sealevel.SysvarCache.SlotHashes.Sysvar
-				newData := slotHashes.MustMarshal()
-				if len(newData) != len(slotHashesAcct.Data) {
-					panic(fmt.Sprintf("SlotHashes data length mismatch: marshaled=%d, account=%d",
-						len(newData), len(slotHashesAcct.Data)))
-				}
-				copy(slotHashesAcct.Data, newData)
-			}
-
-			// Set parentAccts BEFORE updating slotHashes to ensure LtHash delta is computed correctly
-			err = parentAccts.SetAccountWithoutLock(sealevel.SysvarSlotHashesAddr, slotHashesAcct.Clone())
-			if err != nil {
-				panic("unable to set slothashes sysvar to accountsdb")
-			}
-
-			// Now update with the new slot/bankhash
-			slotHashes.Update(block.Slot, block.ParentSlot, block.ParentBankhash)
-			newSlotHashesBytes := slotHashes.MustMarshal()
-			copy(slotHashesAcct.Data, newSlotHashesBytes)
-			sealevel.SysvarCache.SlotHashes.Sysvar = &slotHashes
-			sealevel.SysvarCache.SlotHashes.Acct = slotHashesAcct
-
-			err = accts.SetAccountWithoutLock(sealevel.SysvarSlotHashesAddr, slotHashesAcct)
-			if err != nil {
-				panic("unable to set slothashes sysvar to accountsdb")
-			}
+		err = parentAccts.SetAccountWithoutLock(sealevel.SysvarClockAddr, clockAcct.Clone())
+		if err != nil {
+			panic("unable to set clock sysvar to accts")
 		}
 
-		// cache RecentBlockhashes sysvar
-		{
-			recentBlockhashesAcct, err := accountsDb.GetAccount(block.Slot, sealevel.SysvarRecentBlockHashesAddr)
-			if err != nil {
-				panic("unable to get recentblockhashes")
-			}
+		decoder := bin.NewBinDecoder(clockAcct.Data)
+		var clock sealevel.SysvarClock
 
-			if sealevel.SysvarCache.RecentBlockHashes.Sysvar == nil {
-				// Fresh start (first slot): unmarshal from AccountsDB
-				decoder := bin.NewBinDecoder(recentBlockhashesAcct.Data)
-				var recentBlockhashes sealevel.SysvarRecentBlockhashes
-				recentBlockhashes.MustUnmarshalWithDecoder(decoder)
-				sealevel.SysvarCache.RecentBlockHashes.Sysvar = &recentBlockhashes
-				sealevel.SysvarCache.RecentBlockHashes.Acct = recentBlockhashesAcct
-
-				// Debug: log the blockhash range on first load
-				if len(recentBlockhashes) > 0 {
-					mlog.Log.Infof("loaded RecentBlockhashes sysvar: %d entries, newest=%x, oldest=%x",
-						len(recentBlockhashes), recentBlockhashes[0].Blockhash[:8], recentBlockhashes[len(recentBlockhashes)-1].Blockhash[:8])
-				}
-			} else {
-				// SysvarCache already populated (either from resume state file or from previous slot).
-				// The account data from AccountsDB may be stale (appendvec writes are not fsynced),
-				// so overwrite it with the authoritative data from SysvarCache.
-				// This ensures BPF programs reading the account data directly see correct values.
-				recentBlockhashes := sealevel.SysvarCache.RecentBlockHashes.Sysvar
-				newData := recentBlockhashes.MustMarshal()
-				if len(newData) != len(recentBlockhashesAcct.Data) {
-					panic(fmt.Sprintf("RecentBlockhashes data length mismatch: marshaled=%d, account=%d",
-						len(newData), len(recentBlockhashesAcct.Data)))
-				}
-				copy(recentBlockhashesAcct.Data, newData)
-				sealevel.SysvarCache.RecentBlockHashes.Acct = recentBlockhashesAcct
-			}
-
-			// Set parentAccts AFTER potential data correction to ensure LtHash delta is computed correctly
-			err = parentAccts.SetAccountWithoutLock(sealevel.SysvarRecentBlockHashesAddr, recentBlockhashesAcct.Clone())
-			if err != nil {
-				panic("unable to set recentblockhashes sysvar to accts")
-			}
-
-			err = accts.SetAccountWithoutLock(sealevel.SysvarRecentBlockHashesAddr, recentBlockhashesAcct)
-			if err != nil {
-				panic("unable to set recentblockhashes sysvar to accts")
-			}
+		err = clock.UnmarshalWithDecoder(decoder)
+		if err != nil {
+			panic("unable to unmarshal clock sysvar")
 		}
 
-		// cache SlotHistory sysvar
-		{
-			slotHistoryAcct, err := accountsDb.GetAccount(block.Slot, sealevel.SysvarSlotHistoryAddr)
-			if err != nil {
-				panic("unable to get slothistory")
-			}
-
-			err = parentAccts.SetAccountWithoutLock(sealevel.SysvarSlotHistoryAddr, slotHistoryAcct.Clone())
-			if err != nil {
-				panic("unable to set slothistory sysvar to accts")
-			}
-
-			decoder := bin.NewBinDecoder(slotHistoryAcct.Data)
-			var slotHistory sealevel.SysvarSlotHistory
-			slotHistory.MustUnmarshalWithDecoder(decoder)
-			sealevel.SysvarCache.SlotHistory.Sysvar = &slotHistory
-			sealevel.SysvarCache.SlotHistory.Acct = slotHistoryAcct
-
-			err = accts.SetAccountWithoutLock(sealevel.SysvarSlotHistoryAddr, slotHistoryAcct)
-			if err != nil {
-				panic("unable to set clock sysvar to accts")
-			}
+		err = updateClockSysvar(&clock, block)
+		if err != nil {
+			panic(fmt.Sprintf("failed to update clock sysvar: %s", err))
 		}
 
-		// cache StakeHistory sysvar
-		{
-			stakeHistoryAcct, err := accountsDb.GetAccount(block.Slot, sealevel.SysvarStakeHistoryAddr)
+		newClockBytes := clock.MustMarshal()
+		copy(clockAcct.Data, newClockBytes)
+		sealevel.SysvarCache.Clock.Sysvar = &clock
+		sealevel.SysvarCache.Clock.Acct = clockAcct
+
+		err = accts.SetAccountWithoutLock(sealevel.SysvarClockAddr, clockAcct)
+		if err != nil {
+			panic("unable to set clock sysvar to accts")
+		}
+	}
+
+	// update and cache SlotHashes sysvar
+	{
+		slotHashesAcct, err := accountsDb.GetAccount(block.Slot, sealevel.SysvarSlotHashesAddr)
+		if err != nil {
+			panic("unable to retrieve slothashes sysvar from acctsdb")
+		}
+
+		var slotHashes sealevel.SysvarSlotHashes
+
+		if sealevel.SysvarCache.SlotHashes.Sysvar == nil {
+			// Fresh start (first slot): unmarshal from AccountsDB
+			decoder := bin.NewBinDecoder(slotHashesAcct.Data)
+			err = slotHashes.UnmarshalWithDecoder(decoder)
 			if err != nil {
-				panic("unable to get stakehistory")
+				panic("unable to unmarshal slothashes sysvar")
 			}
 
-			var setStakeHistoryParent bool
-			if len(block.EpochUpdatedAccts) != 0 {
-				for _, a := range block.ParentEpochUpdatedAccts {
-					if a != nil {
-						if a.Key == sealevel.SysvarStakeHistoryAddr {
-							err = parentAccts.SetAccountWithoutLock(sealevel.SysvarStakeHistoryAddr, a.Clone())
-							if err != nil {
-								panic("unable to set stakehistory sysvar to accts")
-							}
-							setStakeHistoryParent = true
+		} else {
+			// SysvarCache already populated (either from resume state file or from previous slot).
+			// The account data from AccountsDB may be stale (appendvec writes are not fsynced),
+			// so overwrite it with the authoritative data from SysvarCache.
+			// This ensures BPF programs reading the account data directly see correct values.
+			slotHashes = *sealevel.SysvarCache.SlotHashes.Sysvar
+			newData := slotHashes.MustMarshal()
+			if len(newData) != len(slotHashesAcct.Data) {
+				panic(fmt.Sprintf("SlotHashes data length mismatch: marshaled=%d, account=%d",
+					len(newData), len(slotHashesAcct.Data)))
+			}
+			copy(slotHashesAcct.Data, newData)
+		}
+
+		// Set parentAccts BEFORE updating slotHashes to ensure LtHash delta is computed correctly
+		err = parentAccts.SetAccountWithoutLock(sealevel.SysvarSlotHashesAddr, slotHashesAcct.Clone())
+		if err != nil {
+			panic("unable to set slothashes sysvar to accountsdb")
+		}
+
+		// Now update with the new slot/bankhash
+		slotHashes.Update(block.Slot, block.ParentSlot, block.ParentBankhash)
+		newSlotHashesBytes := slotHashes.MustMarshal()
+		copy(slotHashesAcct.Data, newSlotHashesBytes)
+		sealevel.SysvarCache.SlotHashes.Sysvar = &slotHashes
+		sealevel.SysvarCache.SlotHashes.Acct = slotHashesAcct
+
+		err = accts.SetAccountWithoutLock(sealevel.SysvarSlotHashesAddr, slotHashesAcct)
+		if err != nil {
+			panic("unable to set slothashes sysvar to accountsdb")
+		}
+	}
+
+	// cache RecentBlockhashes sysvar
+	{
+		recentBlockhashesAcct, err := accountsDb.GetAccount(block.Slot, sealevel.SysvarRecentBlockHashesAddr)
+		if err != nil {
+			panic("unable to get recentblockhashes")
+		}
+
+		if sealevel.SysvarCache.RecentBlockHashes.Sysvar == nil {
+			// Fresh start (first slot): unmarshal from AccountsDB
+			decoder := bin.NewBinDecoder(recentBlockhashesAcct.Data)
+			var recentBlockhashes sealevel.SysvarRecentBlockhashes
+			recentBlockhashes.MustUnmarshalWithDecoder(decoder)
+			sealevel.SysvarCache.RecentBlockHashes.Sysvar = &recentBlockhashes
+			sealevel.SysvarCache.RecentBlockHashes.Acct = recentBlockhashesAcct
+
+			// Debug: log the blockhash range on first load
+			if len(recentBlockhashes) > 0 {
+				mlog.Log.Infof("loaded RecentBlockhashes sysvar: %d entries, newest=%x, oldest=%x",
+					len(recentBlockhashes), recentBlockhashes[0].Blockhash[:8], recentBlockhashes[len(recentBlockhashes)-1].Blockhash[:8])
+			}
+		} else {
+			// SysvarCache already populated (either from resume state file or from previous slot).
+			// The account data from AccountsDB may be stale (appendvec writes are not fsynced),
+			// so overwrite it with the authoritative data from SysvarCache.
+			// This ensures BPF programs reading the account data directly see correct values.
+			recentBlockhashes := sealevel.SysvarCache.RecentBlockHashes.Sysvar
+			newData := recentBlockhashes.MustMarshal()
+			if len(newData) != len(recentBlockhashesAcct.Data) {
+				panic(fmt.Sprintf("RecentBlockhashes data length mismatch: marshaled=%d, account=%d",
+					len(newData), len(recentBlockhashesAcct.Data)))
+			}
+			copy(recentBlockhashesAcct.Data, newData)
+			sealevel.SysvarCache.RecentBlockHashes.Acct = recentBlockhashesAcct
+		}
+
+		// Set parentAccts AFTER potential data correction to ensure LtHash delta is computed correctly
+		err = parentAccts.SetAccountWithoutLock(sealevel.SysvarRecentBlockHashesAddr, recentBlockhashesAcct.Clone())
+		if err != nil {
+			panic("unable to set recentblockhashes sysvar to accts")
+		}
+
+		err = accts.SetAccountWithoutLock(sealevel.SysvarRecentBlockHashesAddr, recentBlockhashesAcct)
+		if err != nil {
+			panic("unable to set recentblockhashes sysvar to accts")
+		}
+	}
+
+	// cache SlotHistory sysvar
+	{
+		slotHistoryAcct, err := accountsDb.GetAccount(block.Slot, sealevel.SysvarSlotHistoryAddr)
+		if err != nil {
+			panic("unable to get slothistory")
+		}
+
+		err = parentAccts.SetAccountWithoutLock(sealevel.SysvarSlotHistoryAddr, slotHistoryAcct.Clone())
+		if err != nil {
+			panic("unable to set slothistory sysvar to accts")
+		}
+
+		decoder := bin.NewBinDecoder(slotHistoryAcct.Data)
+		var slotHistory sealevel.SysvarSlotHistory
+		slotHistory.MustUnmarshalWithDecoder(decoder)
+		sealevel.SysvarCache.SlotHistory.Sysvar = &slotHistory
+		sealevel.SysvarCache.SlotHistory.Acct = slotHistoryAcct
+
+		err = accts.SetAccountWithoutLock(sealevel.SysvarSlotHistoryAddr, slotHistoryAcct)
+		if err != nil {
+			panic("unable to set clock sysvar to accts")
+		}
+	}
+
+	// cache StakeHistory sysvar
+	{
+		stakeHistoryAcct, err := accountsDb.GetAccount(block.Slot, sealevel.SysvarStakeHistoryAddr)
+		if err != nil {
+			panic("unable to get stakehistory")
+		}
+
+		var setStakeHistoryParent bool
+		if len(block.EpochUpdatedAccts) != 0 {
+			for _, a := range block.ParentEpochUpdatedAccts {
+				if a != nil {
+					if a.Key == sealevel.SysvarStakeHistoryAddr {
+						err = parentAccts.SetAccountWithoutLock(sealevel.SysvarStakeHistoryAddr, a.Clone())
+						if err != nil {
+							panic("unable to set stakehistory sysvar to accts")
 						}
+						setStakeHistoryParent = true
 					}
 				}
 			}
+		}
 
-			if !setStakeHistoryParent {
-				err = parentAccts.SetAccountWithoutLock(sealevel.SysvarStakeHistoryAddr, stakeHistoryAcct.Clone())
-				if err != nil {
-					panic("unable to set stakehistory sysvar to accts")
-				}
-			}
-
-			decoder := bin.NewBinDecoder(stakeHistoryAcct.Data)
-			var stakeHistory sealevel.SysvarStakeHistory
-			stakeHistory.MustUnmarshalWithDecoder(decoder)
-			sealevel.SysvarCache.StakeHistory.Sysvar = &stakeHistory
-			sealevel.SysvarCache.StakeHistory.Acct = stakeHistoryAcct
-
-			err = accts.SetAccountWithoutLock(sealevel.SysvarStakeHistoryAddr, stakeHistoryAcct)
+		if !setStakeHistoryParent {
+			err = parentAccts.SetAccountWithoutLock(sealevel.SysvarStakeHistoryAddr, stakeHistoryAcct.Clone())
 			if err != nil {
 				panic("unable to set stakehistory sysvar to accts")
 			}
 		}
 
-		// cache LastRestartSlot sysvar
-		{
-			lastRestartSlotAcct, err := accountsDb.GetAccount(block.Slot, sealevel.SysvarLastRestartSlotAddr)
-			if err != nil {
-				panic("unable to get last restart slot sysvar acct")
-			}
+		decoder := bin.NewBinDecoder(stakeHistoryAcct.Data)
+		var stakeHistory sealevel.SysvarStakeHistory
+		stakeHistory.MustUnmarshalWithDecoder(decoder)
+		sealevel.SysvarCache.StakeHistory.Sysvar = &stakeHistory
+		sealevel.SysvarCache.StakeHistory.Acct = stakeHistoryAcct
 
-			err = parentAccts.SetAccountWithoutLock(sealevel.SysvarLastRestartSlotAddr, lastRestartSlotAcct.Clone())
-			if err != nil {
-				panic("unable to set last restart slot sysvar to accts")
-			}
-
-			decoder := bin.NewBinDecoder(lastRestartSlotAcct.Data)
-			var lastRestartSlot sealevel.SysvarLastRestartSlot
-			lastRestartSlot.MustUnmarshalWithDecoder(decoder)
-			sealevel.SysvarCache.LastRestartSlot.Sysvar = &lastRestartSlot
-			sealevel.SysvarCache.LastRestartSlot.Acct = lastRestartSlotAcct
-
-			err = accts.SetAccountWithoutLock(sealevel.SysvarLastRestartSlotAddr, lastRestartSlotAcct)
-			if err != nil {
-				panic("unable to set last restart slot sysvar to accts")
-			}
+		err = accts.SetAccountWithoutLock(sealevel.SysvarStakeHistoryAddr, stakeHistoryAcct)
+		if err != nil {
+			panic("unable to set stakehistory sysvar to accts")
 		}
 	}
 
-	for idx, acct := range block.EpochUpdatedAccts {
-		if acct == nil {
-			continue
+	// cache LastRestartSlot sysvar
+	{
+		lastRestartSlotAcct, err := accountsDb.GetAccount(block.Slot, sealevel.SysvarLastRestartSlotAddr)
+		if err != nil {
+			panic("unable to get last restart slot sysvar acct")
 		}
 
-		err = accts.SetAccountWithoutLock(acct.Key, acct.Clone())
+		err = parentAccts.SetAccountWithoutLock(sealevel.SysvarLastRestartSlotAddr, lastRestartSlotAcct.Clone())
 		if err != nil {
-			panic("unable to setup epoch transition modified acct")
+			panic("unable to set last restart slot sysvar to accts")
 		}
 
-		parentAcct := block.ParentEpochUpdatedAccts[idx].Clone()
-		err = parentAccts.SetAccountWithoutLock(acct.Key, parentAcct)
+		decoder := bin.NewBinDecoder(lastRestartSlotAcct.Data)
+		var lastRestartSlot sealevel.SysvarLastRestartSlot
+		lastRestartSlot.MustUnmarshalWithDecoder(decoder)
+		sealevel.SysvarCache.LastRestartSlot.Sysvar = &lastRestartSlot
+		sealevel.SysvarCache.LastRestartSlot.Acct = lastRestartSlotAcct
+
+		err = accts.SetAccountWithoutLock(sealevel.SysvarLastRestartSlotAddr, lastRestartSlotAcct)
 		if err != nil {
-			panic("unable to setup epoch transition modified acct")
+			panic("unable to set last restart slot sysvar to accts")
 		}
 	}
-
-	return accts, parentAccts, nil
 }
 
 func scanAndEnableFeatures(acctsDb *accountsdb.AccountsDb, slot uint64, startOfEpoch bool) (*features.Features, []*accounts.Account, []*accounts.Account) {
@@ -1227,6 +1178,8 @@ func ReplayBlocks(
 	}
 	go blockStream.Start()
 
+	loader := &sequentialAccountLoader{acctsDb, blockStream}
+
 	var skippedSlotsCount int // Track skipped slots for 100-slot summary
 	replayStartLogged := false
 
@@ -1261,7 +1214,14 @@ func ReplayBlocks(
 		}
 
 		waitStart := time.Now()
-		block := blockStream.NextBlock()
+		var block *b.Block
+		var loadedAccts map[solana.PublicKey]*accounts.Account
+		block, loadedAccts, err = loader.NextBlock()
+		if err != nil {
+			mlog.Log.Errorf("failed to load block accounts: %v", err)
+			result.Error = err
+			break
+		}
 		waitTime := time.Since(waitStart)
 
 		// Stop stall monitor
@@ -1408,7 +1368,7 @@ func ReplayBlocks(
 		*/
 		metrics.GlobalBlockReplay.PreprocessBlock.AddTimingSince(start)
 
-		lastSlotCtx, err = ProcessBlock(acctsDb, block, txParallelism, dbgOpts)
+		lastSlotCtx, err = ProcessBlock(loader, acctsDb, block, loadedAccts, txParallelism, dbgOpts)
 		if err != nil {
 			mlog.Log.Errorf("error encountered during block replay: %s\n", err)
 			result.Error = err
@@ -1982,7 +1942,63 @@ func parallelTxLoop(slotCtx *sealevel.SlotCtx, sigverifyWg *sync.WaitGroup, bloc
 	return txFeeAccumulator
 }
 
-func ProcessBlock(acctsDb *accountsdb.AccountsDb, block *b.Block, txParallelism int, dbgOpts *DebugOptions) (*sealevel.SlotCtx, error) {
+func prepareAccountsAndSysvars(
+	accountsDb *accountsdb.AccountsDb,
+	block *b.Block,
+	loadedAccts map[solana.PublicKey]*accounts.Account,
+) (accounts.Accounts, accounts.Accounts) {
+	numAccts := uint64(len(loadedAccts))
+	accts := accounts.NewMemAccountsWithLen(numAccts)
+	parentAccts := accounts.NewMemAccountsWithLen(numAccts)
+
+	for _, acct := range loadedAccts {
+		err := accts.SetAccountWithoutLock(acct.Key, acct)
+		if err != nil {
+			panic(err)
+		}
+
+		err = parentAccts.SetAccountWithoutLock(acct.Key, acct.Clone())
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	block.FeeRateGovernor = sealevel.NewFeeRateGovernorDerived(block.PrevFeeRateGovernor, block.PrevNumSignatures)
+	if block.FeeRateGovernor.PrevLamportsPerSignature == 0 {
+		block.FeeRateGovernor.PrevLamportsPerSignature = block.InitialPreviousLamportsPerSignature
+	}
+
+	// load sysvar accounts and assign them to the sysvar cache
+	loadAndUpdateSysvars(accountsDb, block, accts, parentAccts)
+
+	for idx, acct := range block.EpochUpdatedAccts {
+		if acct == nil {
+			continue
+		}
+
+		err := accts.SetAccountWithoutLock(acct.Key, acct.Clone())
+		if err != nil {
+			panic("unable to setup epoch transition modified acct")
+		}
+
+		parentAcct := block.ParentEpochUpdatedAccts[idx].Clone()
+		err = parentAccts.SetAccountWithoutLock(acct.Key, parentAcct)
+		if err != nil {
+			panic("unable to setup epoch transition modified acct")
+		}
+	}
+
+	return accts, parentAccts
+}
+
+func ProcessBlock(
+	loader accountLoader,
+	acctsDb *accountsdb.AccountsDb,
+	block *b.Block,
+	loadedAccts map[solana.PublicKey]*accounts.Account,
+	txParallelism int,
+	dbgOpts *DebugOptions,
+) (*sealevel.SlotCtx, error) {
 	ctx, task := trace.NewTask(context.Background(), "ProcessBlock")
 	defer task.End()
 	trace.Log(ctx, "slot", fmt.Sprintf("%d", block.Slot))
@@ -2009,12 +2025,9 @@ func ProcessBlock(acctsDb *accountsdb.AccountsDb, block *b.Block, txParallelism 
 	}
 
 	start = time.Now()
-	loadAcctsRegion := trace.StartRegion(ctx, "LoadBlockAccounts")
-	accts, parentAccts, err := loadBlockAccountsAndUpdateSysvars(acctsDb, block)
+	loadAcctsRegion := trace.StartRegion(ctx, "PrepareAccounts")
+	accts, parentAccts := prepareAccountsAndSysvars(acctsDb, block, loadedAccts)
 	loadAcctsRegion.End()
-	if err != nil {
-		panic(fmt.Sprintf("unable to load slot accounts and update sysvars: %s", err))
-	}
 	metrics.GlobalBlockReplay.LoadBlockAccounts.AddTimingSince(start)
 
 	slotCtx := newSlotCtx(block, accts, parentAccts, acctsDb)
@@ -2077,7 +2090,10 @@ func ProcessBlock(acctsDb *accountsdb.AccountsDb, block *b.Block, txParallelism 
 
 	if len(modifiedAccts) > 0 {
 		storeAcctsRegion := trace.StartRegion(ctx, "StoreAccounts")
-		err = acctsDb.StoreAccounts(modifiedAccts, slotCtx.Slot)
+		err := loader.StoreAccounts(modifiedAccts, slotCtx.Slot)
+		if err != nil {
+			return nil, err
+		}
 		storeAcctsRegion.End()
 	}
 	metrics.GlobalBlockReplay.BlockUpdateAccounts.AddTimingSince(start)
@@ -2087,10 +2103,10 @@ func ProcessBlock(acctsDb *accountsdb.AccountsDb, block *b.Block, txParallelism 
 		slotCtx.FinalBankhash = slotCtx.EahWorkaroundBankhash
 		commitInProgress.Store(false)
 		commitSlot.Store(0)
-		return slotCtx, err
+		return slotCtx, nil
 	}
 
-	err = acctsDb.StoreBankHashForSlot(slotCtx.Slot, slotCtx.FinalBankhash)
+	err := acctsDb.StoreBankHashForSlot(slotCtx.Slot, slotCtx.FinalBankhash)
 	if err != nil {
 		mlog.Log.Infof("unable to store bankhash for slot %d", slotCtx.Slot)
 	}

--- a/pkg/replay/block.go
+++ b/pkg/replay/block.go
@@ -266,6 +266,10 @@ func extractAndDedupeBlockAccts(block *b.Block) []solana.PublicKey {
 		pubkeyMap[pk] = struct{}{}
 	}
 
+	// Some addresses are not explicitly specified in the block. Add them here so
+	// that the account loader gives us the correct data. We cannot rely on
+	// accountsDb.Get to give us accurate data if using an account loader that
+	// stores last block's modified accounts asynchronously.
 	for _, pk := range updatedSysvarAddrs {
 		pubkeyMap[pk] = struct{}{}
 	}

--- a/pkg/replay/block.go
+++ b/pkg/replay/block.go
@@ -1026,6 +1026,29 @@ func buildInitialEpochStakesCache(snapshotManifest *snapshot.SnapshotManifest, p
 	}
 }
 
+type persistedTracker struct {
+	mu       sync.Mutex
+	slot     uint64
+	bankhash []byte
+}
+
+func (t *persistedTracker) Set(slot uint64, hash []byte) {
+	t.mu.Lock()
+	t.slot = slot
+	t.bankhash = make([]byte, len(hash))
+	copy(t.bankhash, hash)
+	t.mu.Unlock()
+}
+
+func (t *persistedTracker) Get() (uint64, []byte) {
+	t.mu.Lock()
+	slot := t.slot
+	out := make([]byte, len(t.bankhash))
+	copy(out, t.bankhash)
+	t.mu.Unlock()
+	return slot, out
+}
+
 func ReplayBlocks(
 	ctx context.Context,
 	acctsDb *accountsdb.AccountsDb,
@@ -1063,8 +1086,7 @@ func ReplayBlocks(
 	}
 
 	// Track last successfully persisted slot for checkpoint/resume
-	var lastPersistedSlot uint64
-	var lastPersistedBankhash []byte
+	pt := &persistedTracker{}
 
 	// RPC client - for all cluster access (blocks, leader schedule, tip polling)
 	// First endpoint is primary, rest are backups for failover
@@ -1275,7 +1297,7 @@ func ReplayBlocks(
 				block.Slot, leaderStr, waitTime.Seconds(), waitTime.Seconds())
 			skippedSlotsCount++
 			// Maintain invariant: every NextBlock is followed by exactly one StoreAccounts
-			loader.StoreAccounts(nil, block.Slot)
+			loader.StoreAccounts(nil, block.Slot, func() {})
 			continue // Skip all execution - no state changes for skipped slots
 		}
 
@@ -1399,7 +1421,7 @@ func ReplayBlocks(
 		*/
 		metrics.GlobalBlockReplay.PreprocessBlock.AddTimingSince(start)
 
-		lastSlotCtx, err = ProcessBlock(loader, acctsDb, block, loadedAccts, txParallelism, dbgOpts)
+		lastSlotCtx, err = ProcessBlock(loader, acctsDb, block, loadedAccts, txParallelism, dbgOpts, pt)
 		if err != nil {
 			mlog.Log.Errorf("error encountered during block replay: %s\n", err)
 			result.Error = err
@@ -1409,10 +1431,6 @@ func ReplayBlocks(
 		}
 
 		replayCtx.Capitalization -= lastSlotCtx.LamportsBurnt
-
-		// Track last successfully persisted slot for checkpoint/resume
-		lastPersistedSlot = block.Slot
-		lastPersistedBankhash = lastSlotCtx.FinalBankhash
 
 		// Flush any new stake pubkeys discovered during this block to the index file.
 		// This must happen BEFORE we update the state file - crash recovery depends on
@@ -1435,8 +1453,7 @@ func ReplayBlocks(
 			result.WasCancelled = true
 
 			// Populate result immediately for state write
-			result.LastPersistedSlot = lastPersistedSlot
-			result.LastPersistedBankhash = lastPersistedBankhash
+			result.LastPersistedSlot, result.LastPersistedBankhash = pt.Get()
 
 			// Capture resume context from the last slot context
 			if lastSlotCtx != nil {
@@ -1732,8 +1749,7 @@ func ReplayBlocks(
 		result.Error = fmt.Errorf("block fetch stalled - no progress for %v", blockStream.StallTimeout())
 	}
 
-	result.LastPersistedSlot = lastPersistedSlot
-	result.LastPersistedBankhash = lastPersistedBankhash
+	result.LastPersistedSlot, result.LastPersistedBankhash = pt.Get()
 
 	// Capture resume context from the last slot context (if available)
 	// This enables proper resume from Ctrl+C shutdown
@@ -2027,6 +2043,9 @@ func ProcessBlock(
 	loadedAccts map[solana.PublicKey]*accounts.Account,
 	txParallelism int,
 	dbgOpts *DebugOptions,
+	// pt is updated after StoreAccounts completes through a callback.
+	// Must be non-nil.
+	pt *persistedTracker,
 ) (*sealevel.SlotCtx, error) {
 	ctx, task := trace.NewTask(context.Background(), "ProcessBlock")
 	defer task.End()
@@ -2117,30 +2136,39 @@ func ProcessBlock(
 	commitSlot.Store(slotCtx.Slot)
 	commitInProgress.Store(true)
 
+	start = time.Now()
+	afterStoreAccounts := func() {
+		metrics.GlobalBlockReplay.BlockUpdateAccounts.AddTimingSince(start)
+		err := acctsDb.StoreBankHashForSlot(slotCtx.Slot, slotCtx.FinalBankhash)
+		if err != nil {
+			mlog.Log.Infof("unable to store bankhash for slot %d", slotCtx.Slot)
+		}
+
+		// Track last successfully persisted slot for checkpoint/resume
+		pt.Set(block.Slot, slotCtx.FinalBankhash)
+
+		// Exit critical commit window - AccountsDB is now consistent
+		commitInProgress.Store(false)
+		commitSlot.Store(0)
+	}
+
 	storeAcctsRegion := trace.StartRegion(ctx, "StoreAccounts")
-	err := loader.StoreAccounts(modifiedAccts, slotCtx.Slot)
+	err := loader.StoreAccounts(modifiedAccts, slotCtx.Slot, afterStoreAccounts)
 	if err != nil {
 		return nil, err
 	}
 	storeAcctsRegion.End()
-	metrics.GlobalBlockReplay.BlockUpdateAccounts.AddTimingSince(start)
 
-	// EAH workaround - see comment at top of replay loop for details
-	if slotCtx.HasEahWorkaround {
-		slotCtx.FinalBankhash = slotCtx.EahWorkaroundBankhash
-		commitInProgress.Store(false)
-		commitSlot.Store(0)
-		return slotCtx, nil
-	}
-
-	err = acctsDb.StoreBankHashForSlot(slotCtx.Slot, slotCtx.FinalBankhash)
-	if err != nil {
-		mlog.Log.Infof("unable to store bankhash for slot %d", slotCtx.Slot)
-	}
-
-	// Exit critical commit window - AccountsDB is now consistent
-	commitInProgress.Store(false)
-	commitSlot.Store(0)
+	/*
+		// EAH workaround - see comment at top of replay loop for details.
+		// Commented since it seems to be disabled but preserved for the curious?
+		if slotCtx.HasEahWorkaround {
+			slotCtx.FinalBankhash = slotCtx.EahWorkaroundBankhash
+			commitInProgress.Store(false)
+			commitSlot.Store(0)
+			return slotCtx, nil
+		}
+	*/
 
 	global.IncrTransactionCount(uint64(len(block.Transactions)))
 	return slotCtx, err

--- a/pkg/replay/block.go
+++ b/pkg/replay/block.go
@@ -1914,7 +1914,7 @@ func parallelTxLoop(slotCtx *sealevel.SlotCtx, sigverifyWg *sync.WaitGroup, bloc
 	} else {
 		do := make(chan int, len(block.Transactions))
 		done := make(chan int, len(block.Transactions))
-		go TopsortPlannerStream(block, do, done)
+		go TopsortPlannerStream(rblock, do, done)
 
 		wg := &sync.WaitGroup{}
 		wg.Add(txParallelism)

--- a/pkg/replay/block.go
+++ b/pkg/replay/block.go
@@ -1225,11 +1225,13 @@ func ReplayBlocks(
 	var loader accountLoader
 	if UseAccountPrefetcher {
 		mlog.Log.Infof("Using account prefetcher")
-		loader = newAccountPrefetcher(ctx, acctsDb, blockStream)
+		loader = newAccountPrefetcher(acctsDb, blockStream)
 	} else {
 		mlog.Log.Infof("Using sequential account loader")
 		loader = &sequentialAccountLoader{acctsDb, blockStream}
 	}
+	closeAccountLoader := sync.OnceFunc(func() { loader.Close() })
+	defer closeAccountLoader()
 
 	var skippedSlotsCount int // Track skipped slots for 100-slot summary
 	replayStartLogged := false
@@ -1452,6 +1454,7 @@ func ReplayBlocks(
 			mlog.Log.Infof("Context cancelled after slot %d, exiting replay loop", block.Slot)
 			result.WasCancelled = true
 
+			closeAccountLoader()
 			// Populate result immediately for state write
 			result.LastPersistedSlot, result.LastPersistedBankhash = pt.Get()
 
@@ -1749,6 +1752,7 @@ func ReplayBlocks(
 		result.Error = fmt.Errorf("block fetch stalled - no progress for %v", blockStream.StallTimeout())
 	}
 
+	closeAccountLoader()
 	result.LastPersistedSlot, result.LastPersistedBankhash = pt.Get()
 
 	// Capture resume context from the last slot context (if available)

--- a/pkg/replay/topsort_planner.go
+++ b/pkg/replay/topsort_planner.go
@@ -6,59 +6,22 @@ import (
 
 	//"github.com/Overclock-Validator/mithril/pkg/mlog"
 	"github.com/Overclock-Validator/mithril/pkg/block"
-	"github.com/Overclock-Validator/mithril/pkg/util"
 	"github.com/gagliardetto/solana-go"
-	"github.com/gagliardetto/solana-go/rpc"
 )
 
 // Type wrappers around indices.
 type acct int
 type tx int
 
-func getAllAccounts(t *solana.Transaction, tm *rpc.TransactionMeta) []solana.PublicKey {
-	accounts := make([]solana.PublicKey, 0, len(t.Message.AccountKeys)+len(tm.LoadedAddresses.ReadOnly)+len(tm.LoadedAddresses.Writable))
-	accounts = append(accounts, t.Message.AccountKeys...)
-	accounts = append(accounts, tm.LoadedAddresses.ReadOnly...)
-	accounts = append(accounts, tm.LoadedAddresses.Writable...)
-	return util.DedupePubkeys(accounts)
-}
-
-func getReadonlyAccounts(t *solana.Transaction, tm *rpc.TransactionMeta) []solana.PublicKey {
-	if t.Message.IsResolved() {
-		panic("account calculations assume tx is unresolved, and use txmeta for lookup table addresses")
+func mustAccountMetaList(t *solana.Transaction) []*solana.AccountMeta {
+	if t.Message.IsVersioned() && !t.Message.IsResolved() {
+		panic(fmt.Sprintf("topsort planner: assumes versioned (IsVersioned was %t) txs are resolved (IsResolved was %t)", t.Message.IsVersioned(), t.Message.IsResolved()))
 	}
-	msg := t.Message
-	hdr := msg.Header
-	numReadonly := len(tm.LoadedAddresses.ReadOnly)
-	signedReadonly := int(hdr.NumReadonlySignedAccounts)
-	numReadonly += signedReadonly
-	unsignedReadonly := int(hdr.NumReadonlyUnsignedAccounts)
-	numReadonly += unsignedReadonly
-	accounts := make([]solana.PublicKey, 0, numReadonly)
-
-	accounts = append(accounts, msg.AccountKeys[int(hdr.NumRequiredSignatures)-signedReadonly:hdr.NumRequiredSignatures]...)
-	accounts = append(accounts, msg.AccountKeys[len(msg.AccountKeys)-unsignedReadonly:len(msg.AccountKeys)]...)
-	accounts = append(accounts, tm.LoadedAddresses.ReadOnly...)
-	return util.DedupePubkeys(accounts)
-}
-
-func getWritableAccounts(t *solana.Transaction, tm *rpc.TransactionMeta) []solana.PublicKey {
-	if t.Message.IsResolved() {
-		panic("account calculations assume tx is unresolved, and use txmeta for lookup table addresses")
+	ams, err := t.AccountMetaList()
+	if err != nil {
+		panic(fmt.Sprintf("topsort planner: AccountMetaList failed: %v", err))
 	}
-	msg := t.Message
-	hdr := msg.Header
-	numWritable := len(tm.LoadedAddresses.Writable)
-	signedWritable := int(hdr.NumRequiredSignatures) - int(hdr.NumReadonlySignedAccounts)
-	numWritable += signedWritable
-	unsignedWritable := len(msg.AccountKeys) - int(hdr.NumRequiredSignatures) - int(hdr.NumReadonlyUnsignedAccounts)
-	numWritable += unsignedWritable
-	accounts := make([]solana.PublicKey, 0, numWritable)
-
-	accounts = append(accounts, msg.AccountKeys[0:signedWritable]...)
-	accounts = append(accounts, msg.AccountKeys[int(hdr.NumRequiredSignatures):int(hdr.NumRequiredSignatures)+unsignedWritable]...)
-	accounts = append(accounts, tm.LoadedAddresses.Writable...)
-	return util.DedupePubkeys(accounts)
+	return ams
 }
 
 func blockToDependencyGraph(b *block.Block) (adjacencyList [][]tx, inDegree []int) {
@@ -67,13 +30,13 @@ func blockToDependencyGraph(b *block.Block) (adjacencyList [][]tx, inDegree []in
 	var acctToPk []solana.PublicKey
 	pkToAcct := make(map[solana.PublicKey]acct)
 
-	for i, txMeta := range b.TxMetas {
+	for i := range b.Transactions {
 		tx := b.Transactions[i]
-		accounts := getAllAccounts(tx, txMeta)
-		for _, acctPk := range accounts {
-			if _, exists := pkToAcct[acctPk]; !exists {
-				pkToAcct[acctPk] = acct(len(acctToPk))
-				acctToPk = append(acctToPk, acctPk)
+		ams := mustAccountMetaList(tx)
+		for _, am := range ams {
+			if _, exists := pkToAcct[am.PublicKey]; !exists {
+				pkToAcct[am.PublicKey] = acct(len(acctToPk))
+				acctToPk = append(acctToPk, am.PublicKey)
 			}
 		}
 	}
@@ -82,7 +45,7 @@ func blockToDependencyGraph(b *block.Block) (adjacencyList [][]tx, inDegree []in
 	acctToWriterTxs := make(map[acct][]tx, len(acctToPk))
 	adjacencyList = make([][]tx, len(b.TxMetas))
 	inDegree = make([]int, len(b.TxMetas))
-	for txIdx, txMeta := range b.TxMetas {
+	for txIdx := range b.Transactions {
 		/* Given S < T (S occurs before T) in a sequential execution, we
 		   use these restrictions on the parallel execution to reproduce
 		   the sequential execution
@@ -97,8 +60,29 @@ func blockToDependencyGraph(b *block.Block) (adjacencyList [][]tx, inDegree []in
 
 		//txSig := b.Transactions[txIdx].Signatures[0]
 		////mlog.Log.Debugf("printing input accounts for txIdx=%d txSig=%s", txIdx, txSig)
-		readonlyAccounts := getReadonlyAccounts(b.Transactions[txIdx], txMeta)
-		for _, roAcct := range readonlyAccounts {
+		txn := b.Transactions[txIdx]
+		var readonlyAccts, writableAccts []solana.PublicKey
+		{
+			ams := mustAccountMetaList(txn)
+			var rs, ws int
+			for _, am := range ams {
+				if am.IsWritable {
+					ws++
+				} else {
+					rs++
+				}
+			}
+			readonlyAccts, writableAccts = make([]solana.PublicKey, 0, rs), make([]solana.PublicKey, 0, ws)
+			for _, am := range ams {
+				if am.IsWritable {
+					writableAccts = append(writableAccts, am.PublicKey)
+				} else {
+					readonlyAccts = append(readonlyAccts, am.PublicKey)
+				}
+			}
+		}
+
+		for _, roAcct := range readonlyAccts {
 			////mlog.Log.Debugf("- roAcct=%s", roAcct.String())
 			acct, exists := pkToAcct[roAcct]
 			if !exists {
@@ -120,7 +104,6 @@ func blockToDependencyGraph(b *block.Block) (adjacencyList [][]tx, inDegree []in
 			acctToReaderTxs[acct] = append(acctToReaderTxs[acct], t)
 		}
 
-		writableAccts := getWritableAccounts(b.Transactions[txIdx], txMeta)
 		for _, writeAcct := range writableAccts {
 			////mlog.Log.Debugf("- writeAcct=%s", writeAcct.String())
 			acct, exists := pkToAcct[writeAcct]


### PR DESCRIPTION
https://github.com/Overclock-Validator/mithril/pull/191 shows how processing a block involves loading the accounts from disk for the block, processing all the transactions in the block, and storing the accounts on disk serially.

<img width="1754" height="708" alt="image" src="https://github.com/user-attachments/assets/a8f4510b-d717-42ad-8878-68145aa9ecec" />

This PR abstracts account load and storage into `accountLoader`. `accountLoader`s also pull blocks from the block stream and provide them on request to the replay loop. This allows us to implement an `accountPrefetcher` which
1. pulls block B, and loads its accounts from accounts DB like normal
2. buffers a block B+1
3. calculate all the accounts B+1 uses and prefetch their state (from before executing block B) from accounts DB.
4. when the new account states computed by processing block B are received by the `accountPrefetcher`, we combine the prefetched states with the new account states before putting the new account states on disk.
5. then B+1 may be executed while storing accounts for block B.

part 5. can be seen in the trace visualizer: PrefetcherStoreAccounts takes place at the same time as ProcessBlock. GetAccountsBatch can also take place after that if the next block arrives soon enough.

<img width="1210" height="694" alt="image" src="https://github.com/user-attachments/assets/2f92547a-371f-4787-adb8-7d75a24c96e2" />

There is a corner case where an ALT is extended with some address, A, in block B and the ALT is used in block B+1. That prevents prefetching of address A since we don't know what it is until block B is done executing. This PR handles this case by checking if the writable accounts of block B include an ALT of block B+1, and fall back to the slow path (wait for block B to execute, store changes to disk, load accounts for block B+1 serially) if so. It seems rare.

There are also some incidental changes related to ALT resolution in the topsort planner which previously assumed it would be given unresolved txs and txmeta.

Some possible future work: I don't think account caches should be necessary with this approach. We can probably also clean up some of the resolved and unresolved block copy stuff around the planner?

### analysis

I ran three variations of this command - once at `dev`/`c48e6d32`, then at `ee57b33f` with `use_account_prefetcher = false` and at `ee57b33f` with `use_account_prefetcher = true`.

```
./mithril/cmd/mithril/mithril verify-range \
--snapshot /mnt/mithril-ledger/snapshots/snapshot-394572092-GyVQG4y2z1YZmcwMW5kyaHdPomJqTbesd3jEaZPztDWX.tar.zst \
--incremental-snapshot /mnt/mithril-ledger/snapshots/incremental-snapshot-394572092-394630887-DkrkLxp6by4XagEZATASWuZS7yzYDrGSgMF4mJaReFfM.tar.zst \
--accounts-path /mnt/mithril-accounts/ \
--num-slots 1000 \
--load-from-snapshot \
--rpc=REDACTED \
--config mithril2/config.toml 2>&1 | tee mithril.log
```

### results

slot replay duration (seconds) statistics (after dropping the first replayed slot)

| statistic | `dev` | `use_account_prefetcher = false` | `use_account_prefetcher = true` |
|-----------|-------|----------------------------------|---------------------------------|
| mean      |  0.21 |                             0.21 |                            0.19 |
| p10       |  0.14 |                             0.14 |                            0.12 |
| p25       |  0.16 |                             0.16 |                            0.14 |
| p75       |  0.25 |                             0.25 |                            0.23 |
| p90       |  0.29 |                             0.29 |                            0.27 |

It seems to consistently save about 20ms per slot.