### PR TITLE
some memory optimisations

### DIFF
--- a/pkg/accountsdb/accountsdb.go
+++ b/pkg/accountsdb/accountsdb.go
@@ -154,7 +154,7 @@ func (accountsDb *AccountsDb) CloseDb() {
 
 func (accountsDb *AccountsDb) InitCaches() {
 	var err error
-	accountsDb.VoteAcctCache, err = otter.MustBuilder[solana.PublicKey, *accounts.Account](5000).
+	accountsDb.VoteAcctCache, err = otter.MustBuilder[solana.PublicKey, *accounts.Account](2500).
 		Cost(func(key solana.PublicKey, acct *accounts.Account) uint32 {
 			return 1
 		}).
@@ -163,7 +163,7 @@ func (accountsDb *AccountsDb) InitCaches() {
 		panic(err)
 	}
 
-	accountsDb.ProgramCache, err = otter.MustBuilder[solana.PublicKey, *ProgramCacheEntry](5000).
+	accountsDb.ProgramCache, err = otter.MustBuilder[solana.PublicKey, *ProgramCacheEntry](2000).
 		Cost(func(key solana.PublicKey, progEntry *ProgramCacheEntry) uint32 {
 			return 1
 		}).
@@ -172,7 +172,7 @@ func (accountsDb *AccountsDb) InitCaches() {
 		panic(err)
 	}
 
-	accountsDb.CommonAcctsCache, err = otter.MustBuilder[solana.PublicKey, *accounts.Account](10000).
+	accountsDb.CommonAcctsCache, err = otter.MustBuilder[solana.PublicKey, *accounts.Account](5000).
 		Cost(func(key solana.PublicKey, acct *accounts.Account) uint32 {
 			return 1
 		}).

--- a/pkg/replay/block.go
+++ b/pkg/replay/block.go
@@ -1076,6 +1076,14 @@ func (t *persistedTracker) Get() (uint64, []byte) {
 	return slot, out
 }
 
+func nilifySnapshotManifest(manifest *snapshot.SnapshotManifest) {
+	manifest.Bank = nil
+	manifest.AccountsDb = nil
+	manifest.BankIncrementalSnapshotPersistence = nil
+	manifest.VersionedEpochStakes = nil
+	manifest.LtHash = nil
+}
+
 func ReplayBlocks(
 	ctx context.Context,
 	acctsDb *accountsdb.AccountsDb,
@@ -1335,6 +1343,9 @@ func ReplayBlocks(
 				// FRESH START: Use snapshot manifest
 				configErr = configureInitialBlock(acctsDb, block, snapshotManifest, replayCtx, epochSchedule, rpcc, rpcBackups)
 			}
+			// We're done with the SnapshotManifest object. Since these objects are quite large, we hint to the GC to free
+			// the object's contents by nil'ing the struct's members.
+			nilifySnapshotManifest(snapshotManifest)
 		} else {
 			configErr = configureBlock(block, replayCtx, lastSlotCtx, epochSchedule, rpcc, rpcBackups)
 		}

--- a/pkg/snapshot/manifest_decoder.go
+++ b/pkg/snapshot/manifest_decoder.go
@@ -255,10 +255,10 @@ type SerializableEpochRewardStatus struct {
 }
 
 type SnapshotManifest struct {
-	Bank                               DeserializableVersionedBank
-	AccountsDb                         AccountsDbFields
+	Bank                               *DeserializableVersionedBank
+	AccountsDb                         *AccountsDbFields
 	LamportsPerSignature               uint64
-	BankIncrementalSnapshotPersistence BankIncrementalSnapshotPersistence
+	BankIncrementalSnapshotPersistence *BankIncrementalSnapshotPersistence
 	EpochAccountHash                   [32]byte
 	VersionedEpochStakes               []VersionedEpochStakesPair
 	LtHash                             *lthash.LtHash
@@ -1413,12 +1413,14 @@ func (stakeRewards *SerializableStakeRewards) UnmarshalWithDecoder(decoder *bin.
 func (snapshot *SnapshotManifest) UnmarshalWithDecoder(decoder *bin.Decoder) error {
 	var err error
 
+	snapshot.Bank = new(DeserializableVersionedBank)
 	err = snapshot.Bank.UnmarshalWithDecoder(decoder)
 	if err != nil {
 		util.VerboseHandleError(err)
 		return err
 	}
 
+	snapshot.AccountsDb = new(AccountsDbFields)
 	err = snapshot.AccountsDb.UnmarshalWithDecoder(decoder)
 	if err != nil {
 		util.VerboseHandleError(err)
@@ -1442,6 +1444,7 @@ func (snapshot *SnapshotManifest) UnmarshalWithDecoder(decoder *bin.Decoder) err
 
 	if hasIncrementalSnapshotPersistence {
 		mlog.Log.Infof("hasIncrementalSnapshotPersistence")
+		snapshot.BankIncrementalSnapshotPersistence = new(BankIncrementalSnapshotPersistence)
 		err = snapshot.BankIncrementalSnapshotPersistence.UnmarshalWithDecoder(decoder)
 		if err != nil {
 			return nil


### PR DESCRIPTION
Optimise memory usage by cutting down AccountDB's program cache and account caches. We now also nil out the SnapshotManifest object's fields after we're done using it so that the GC can free the memory. These two changes free up quite a bit of memory.