### PR TITLE
batch ALT lookups

### DIFF
--- a/pkg/accountsdb/accountsdb.go
+++ b/pkg/accountsdb/accountsdb.go
@@ -210,16 +210,21 @@ func (accountsDb *AccountsDb) GetAccount(slot uint64, pubkey solana.PublicKey) (
 }
 
 func (accountsDb *AccountsDb) getStoredAccount(slot uint64, pubkey solana.PublicKey) (*accounts.Account, error) {
+	r := trace.StartRegion(context.Background(), "GetStoredAccountCache")
 	cachedAcct, hasAcct := accountsDb.VoteAcctCache.Get(pubkey)
 	if hasAcct {
+		r.End()
 		return cachedAcct, nil
 	}
 
 	cachedAcct, hasAcct = accountsDb.CommonAcctsCache.Get(pubkey)
 	if hasAcct {
+		r.End()
 		return cachedAcct, nil
 	}
+	r.End()
 
+	defer trace.StartRegion(context.Background(), "GetStoredAccountDisk").End()
 	acctIdxEntryBytes, c, err := accountsDb.Index.Get(pubkey[:])
 	if err != nil {
 		//mlog.Log.Debugf("no account found in accountsdb for pubkey %s: %s", pubkey, err)
@@ -276,6 +281,7 @@ func (accountsDb *AccountsDb) getStoredAccount(slot uint64, pubkey solana.Public
 // Returns a slice of the same length as the input with results matching indexes, nil if not found.
 // Returns clones to avoid data races with the store worker.
 func (accountsDb *AccountsDb) getStoreInProgressAccounts(pks []solana.PublicKey) []*accounts.Account {
+	defer trace.StartRegion(context.Background(), "getStoreInProgressAccounts").End()
 	out := make([]*accounts.Account, len(pks))
 	accountsDb.inProgressStoreRequestsMu.Lock()
 	defer accountsDb.inProgressStoreRequestsMu.Unlock()

--- a/pkg/replay/block.go
+++ b/pkg/replay/block.go
@@ -206,30 +206,42 @@ func resolveAddrTableLookups(accountsDb *accountsdb.AccountsDb, block *b.Block) 
 			continue
 		}
 
-		var skipLookup bool
 		for _, addrTableKey := range tx.Message.GetAddressTableLookups().GetTableIDs() {
-			if _, alreadyLoaded := tables[addrTableKey]; alreadyLoaded {
-				continue
-			}
-
-			acct, err := accountsDb.GetAccount(block.Slot, addrTableKey)
-			if err != nil {
-				skipLookup = true
-				break
-			}
-
-			addrLookupTable, err := sealevel.UnmarshalAddressLookupTable(acct.Data)
-			if err != nil {
-				return err
-			}
-
-			tables[addrTableKey] = addrLookupTable.Addresses
+			tables[addrTableKey] = nil
 		}
+	}
 
-		if skipLookup {
+	tablesSlice := make([]solana.PublicKey, 0, len(tables))
+	for t := range tables {
+		tablesSlice = append(tablesSlice, t)
+	}
+	accts, err := accountsDb.GetAccountsBatch(context.Background(), block.Slot, tablesSlice)
+	if err != nil {
+		return err
+	}
+
+	for i := range tablesSlice {
+		if len(accts[i].Data) == 0 {
+			delete(tables, tablesSlice[i])
 			continue
 		}
+		addrLookupTable, err := sealevel.UnmarshalAddressLookupTable(accts[i].Data)
+		if err != nil {
+			return err
+		}
+		tables[tablesSlice[i]] = addrLookupTable.Addresses
+	}
 
+txResolveLoop:
+	for _, tx := range block.Transactions {
+		if !tx.Message.IsVersioned() || tx.Message.AddressTableLookups.NumLookups() == 0 {
+			continue
+		}
+		for _, addrTableKey := range tx.Message.GetAddressTableLookups().GetTableIDs() {
+			if _, ok := tables[addrTableKey]; !ok {
+				continue txResolveLoop
+			}
+		}
 		err := tx.Message.SetAddressTables(tables)
 		if err != nil {
 			return err

--- a/pkg/replay/transaction.go
+++ b/pkg/replay/transaction.go
@@ -299,7 +299,7 @@ func verifySignatures(tx *solana.Transaction, slot uint64, sigverifyWg *sync.Wai
 }
 
 func ProcessTransaction(slotCtx *sealevel.SlotCtx, sigverifyWg *sync.WaitGroup, tx *solana.Transaction, txMeta *rpc.TransactionMeta, dbgOpts *DebugOptions, arena *arena.Arena[sealevel.BorrowedAccount]) (*fees.TxFeeInfo, error) {
-	if slotCtx.TraceCtx != nil {
+	if trace.IsEnabled() && slotCtx.TraceCtx != nil {
 		region := trace.StartRegion(slotCtx.TraceCtx, "ProcessTransaction")
 		defer region.End()
 


### PR DESCRIPTION
I profiled LoadBlockAccounts in more detail and I saw these sequential disk reads:
<img width="544" height="862" alt="image" src="https://github.com/user-attachments/assets/0e54e27f-c8ad-45e6-996d-0e7d10e4d111" />

I think it is the ALT lookups, which used to be looked up with a `for { ... GetAccount ... }`. This PR changes it to use `GetAccountsBatch`. I found it to save about 5ms per slot over 3000 slots:
```
mithril-baseline.log:
  n=2999 mean=0.2167 p10=0.1490 p25=0.1770 p50=0.2120 p75=0.2580 p90=0.2960
mithril-batchalt.log:
  n=2999 mean=0.2116 p10=0.1450 p25=0.1720 p50=0.2060 p75=0.2540 p90=0.2892
```

<img width="857" height="913" alt="image" src="https://github.com/user-attachments/assets/aaf24027-b273-4272-ba46-bb4b3122cc8e" />
