### PR TITLE
feat: SIMD-0321 provide instruction-data VM address in r2

### DIFF
--- a/pkg/features/gates.go
+++ b/pkg/features/gates.go
@@ -64,6 +64,7 @@ var StaticInstructionLimit = FeatureGate{Name: "StaticInstructionLimit", Address
 var PoseidonEnforcePadding = FeatureGate{Name: "PoseidonEnforcePadding", Address: base58.MustDecodeFromString("poUdAqRXXsNmfqAZ6UqpjbeYgwBygbfQLEvWSqVhSnb")}
 var FixAltBn128PairingLengthCheck = FeatureGate{Name: "FixAltBn128PairingLengthCheck", Address: base58.MustDecodeFromString("bnYzodLwmybj7e1HAe98yZrdJTd7we69eMMLgCXqKZm")}
 var DeprecateRentExemptionThreshold = FeatureGate{Name: "DeprecateRentExemptionThreshold", Address: base58.MustDecodeFromString("rent6iVy6PDoViPBeJ6k5EJQrkj62h7DPyLbWGHwjrC")}
+var ProvideInstructionDataOffsetInVmR2 = FeatureGate{Name: "ProvideInstructionDataOffsetInVmR2", Address: base58.MustDecodeFromString("5xXZc66h4UdB6Yq7FzdBxBiRAFMMScMLwHxk2QZDaNZL")}
 
 var AllFeatureGates = []FeatureGate{StopTruncatingStringsInSyscalls, EnablePartitionedEpochReward, EnablePartitionedEpochRewardsSuperfeature,
 	LastRestartSlotSysvar, Libsecp256k1FailOnBadCount, Libsecp256k1FailOnBadCount2, EnableBpfLoaderSetAuthorityCheckedIx,
@@ -79,4 +80,5 @@ var AllFeatureGates = []FeatureGate{StopTruncatingStringsInSyscalls, EnableParti
 	ReserveMinimalCUsForBuiltinInstructions, MaskOutRentEpochInVmSerialization, RemoveAccountsExecutableFlagChecks,
 	AccountsLtHash, RemoveAccountsDeltaHash, EnableLoaderV4, EnableSbpfV1DeploymentAndExecution, EnableSbpfV2DeploymentAndExecution,
 	EnableSbpfV3DeploymentAndExecution, DisableSbpfV0Execution, ReenableSbpfV0Execution, FormalizeLoadedTransactionDataSize, IncreaseCpiAccountInfoLimit,
-	StaticInstructionLimit, PoseidonEnforcePadding, FixAltBn128PairingLengthCheck, DeprecateRentExemptionThreshold}
+	StaticInstructionLimit, PoseidonEnforcePadding, FixAltBn128PairingLengthCheck, DeprecateRentExemptionThreshold,
+	ProvideInstructionDataOffsetInVmR2}

--- a/pkg/sbpf/interpreter.go
+++ b/pkg/sbpf/interpreter.go
@@ -26,7 +26,8 @@ type Interpreter struct {
 	ro     []byte
 	stack  Stack
 	heap   []byte
-	input  []byte
+	input          []byte
+	inputDataVaddr uint64
 
 	entry    uint64
 	heapSize uint64
@@ -85,6 +86,7 @@ func NewInterpreter(p *Program, opts *VMOpts) *Interpreter {
 		stack:             NewStack(p.SbpfVersion),
 		heap:              heap,
 		input:             opts.Input,
+		inputDataVaddr:    opts.InputDataVaddr,
 		entry:             p.Entrypoint,
 		syscalls:          opts.Syscalls,
 		funcs:             p.Funcs,
@@ -113,6 +115,7 @@ func (ip *Interpreter) Finish() {
 func (ip *Interpreter) Run() (ret uint64, cuConsumed uint64, err error) {
 	var r [11]uint64
 	r[1] = VaddrInput
+	r[2] = ip.inputDataVaddr
 
 	// initialise fp
 	var sz uint64

--- a/pkg/sbpf/vm.go
+++ b/pkg/sbpf/vm.go
@@ -48,7 +48,8 @@ type VMOpts struct {
 	Context      any // passed to syscalls
 	MaxCU        int
 	ComputeMeter *cu.ComputeMeter
-	Input        []byte // mapped at VaddrInput
+	Input          []byte // mapped at VaddrInput
+	InputDataVaddr uint64 // VM address of instruction data within Input (SIMD-0321)
 
 	// Debug
 	ProgramId   solana.PublicKey

--- a/pkg/sealevel/bpf_loader.go
+++ b/pkg/sealevel/bpf_loader.go
@@ -463,21 +463,21 @@ type serializedAcctMetadata struct {
 	vmOwnerAddr     uint64
 }
 
-func serializeParametersAligned(execCtx *ExecutionCtx) ([]byte, []uint64, error) {
+func serializeParametersAligned(execCtx *ExecutionCtx) ([]byte, []uint64, uint64, error) {
 	txCtx := execCtx.TransactionContext
 	instrCtx, err := txCtx.CurrentInstructionCtx()
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, 0, err
 	}
 
 	numIxAccts := instrCtx.NumberOfInstructionAccounts()
 	if numIxAccts > MaxInstructionAccounts {
-		return nil, nil, InstrErrMaxAccountsExceeded
+		return nil, nil, 0, InstrErrMaxAccountsExceeded
 	}
 
 	programAcct, err := instrCtx.BorrowLastProgramAccount(txCtx)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, 0, err
 	}
 	programId := programAcct.Key()
 	programAcct.Drop()
@@ -495,14 +495,14 @@ func serializeParametersAligned(execCtx *ExecutionCtx) ([]byte, []uint64, error)
 	for instrAcctIdx := uint64(0); instrAcctIdx < instrCtx.NumberOfInstructionAccounts(); instrAcctIdx++ {
 		isDupe, idxInCallee, err := instrCtx.IsInstructionAccountDuplicate(instrAcctIdx)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, 0, err
 		}
 		if isDupe {
 			accts[int(instrAcctIdx)] = serializeAcct{isDuplicate: true, indexOfAcct: idxInCallee}
 		} else {
 			acct, err := instrCtx.BorrowInstructionAccount(txCtx, instrAcctIdx)
 			if err != nil {
-				return nil, nil, err
+				return nil, nil, 0, err
 			}
 
 			accts[int(instrAcctIdx)] = serializeAcct{indexOfAcct: instrAcctIdx, acct: acct}
@@ -623,6 +623,7 @@ func serializeParametersAligned(execCtx *ExecutionCtx) ([]byte, []uint64, error)
 	}
 
 	l := len(serializedData)
+	instructionDataOffset := uint64(l) + 8 // offset of actual instruction data bytes (past length prefix)
 	serializedData = serializedData[:len(serializedData)+
 		8+ /*instr data len*/
 		len(instrData)+ /*instr data*/
@@ -637,7 +638,7 @@ func serializeParametersAligned(execCtx *ExecutionCtx) ([]byte, []uint64, error)
 		panic(fmt.Sprintf("mismatch between serialized data and expected length: len(serializedData) = %d, expected size = %d", uint64(len(serializedData)), size))
 	}
 
-	return serializedData, preLens, nil
+	return serializedData, preLens, instructionDataOffset, nil
 }
 
 func deserializeParametersAligned(execCtx *ExecutionCtx, parameterBytes []byte, preLens []uint64) error {
@@ -747,21 +748,21 @@ func deserializeParametersAligned(execCtx *ExecutionCtx, parameterBytes []byte, 
 	return nil
 }
 
-func serializeParametersUnaligned(execCtx *ExecutionCtx) ([]byte, []uint64, error) {
+func serializeParametersUnaligned(execCtx *ExecutionCtx) ([]byte, []uint64, uint64, error) {
 	txCtx := execCtx.TransactionContext
 	instrCtx, err := txCtx.CurrentInstructionCtx()
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, 0, err
 	}
 
 	numIxAccts := instrCtx.NumberOfInstructionAccounts()
 	if numIxAccts > MaxInstructionAccounts {
-		return nil, nil, InstrErrMaxAccountsExceeded
+		return nil, nil, 0, InstrErrMaxAccountsExceeded
 	}
 
 	programAcct, err := instrCtx.BorrowLastProgramAccount(txCtx)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, 0, err
 	}
 	programId := programAcct.Key()
 	programAcct.Drop()
@@ -773,7 +774,7 @@ func serializeParametersUnaligned(execCtx *ExecutionCtx) ([]byte, []uint64, erro
 	for instrAcctIdx := uint64(0); instrAcctIdx < instrCtx.NumberOfInstructionAccounts(); instrAcctIdx++ {
 		isDupe, idxInCallee, err := instrCtx.IsInstructionAccountDuplicate(instrAcctIdx)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, 0, err
 		}
 		if isDupe {
 			sa := serializeAcct{isDuplicate: true, indexOfAcct: idxInCallee}
@@ -781,7 +782,7 @@ func serializeParametersUnaligned(execCtx *ExecutionCtx) ([]byte, []uint64, erro
 		} else {
 			acct, err := instrCtx.BorrowInstructionAccount(txCtx, instrAcctIdx)
 			if err != nil {
-				return nil, nil, err
+				return nil, nil, 0, err
 			}
 			defer acct.Drop()
 
@@ -882,6 +883,7 @@ func serializeParametersUnaligned(execCtx *ExecutionCtx) ([]byte, []uint64, erro
 	}
 
 	// instr data len
+	instructionDataOffset := uint64(len(serializedData)) + 8 // offset of actual instruction data bytes (past length prefix)
 	serializedData = binary.LittleEndian.AppendUint64(serializedData, uint64(len(instrData)))
 
 	// instr data
@@ -896,7 +898,7 @@ func serializeParametersUnaligned(execCtx *ExecutionCtx) ([]byte, []uint64, erro
 		panic("mismatch between serialized data and expected length")
 	}
 
-	return serializedData, preLens, nil
+	return serializedData, preLens, instructionDataOffset, nil
 }
 
 func deserializeParametersUnaligned(execCtx *ExecutionCtx, parameterBytes []byte, preLens []uint64) error {
@@ -1001,28 +1003,35 @@ func executeLoadedProgram(execCtx *ExecutionCtx, program *sbpf.Program, syscallR
 
 	var parameterBytes []byte
 	var preLens []uint64
+	var instrDataOffset uint64
 
 	if isLoaderDeprecated {
-		parameterBytes, preLens, err = serializeParametersUnaligned(execCtx)
+		parameterBytes, preLens, instrDataOffset, err = serializeParametersUnaligned(execCtx)
 		if err != nil {
 			return err
 		}
 	} else {
-		parameterBytes, preLens, err = serializeParametersAligned(execCtx)
+		parameterBytes, preLens, instrDataOffset, err = serializeParametersAligned(execCtx)
 		if err != nil {
 			return err
 		}
 	}
 
+	var inputDataVaddr uint64
+	if execCtx.Features.IsActive(features.ProvideInstructionDataOffsetInVmR2) {
+		inputDataVaddr = sbpf.VaddrInput + instrDataOffset
+	}
+
 	opts := &sbpf.VMOpts{
-		HeapMax:      int(heapSize),
-		Input:        parameterBytes,
-		Syscalls:     syscallRegistry,
-		MaxCU:        int(execCtx.ComputeMeter.Remaining()),
-		ComputeMeter: &execCtx.ComputeMeter,
-		Context:      execCtx,
-		TxSignature:  execCtx.TransactionContext.Signature,
-		ProgramId:    programId,
+		HeapMax:        int(heapSize),
+		Input:          parameterBytes,
+		InputDataVaddr: inputDataVaddr,
+		Syscalls:       syscallRegistry,
+		MaxCU:          int(execCtx.ComputeMeter.Remaining()),
+		ComputeMeter:   &execCtx.ComputeMeter,
+		Context:        execCtx,
+		TxSignature:    execCtx.TransactionContext.Signature,
+		ProgramId:      programId,
 	}
 
 	start := time.Now()


### PR DESCRIPTION
## Summary

Implements [SIMD-0321](https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0321-provide-instruction-data-offset-in-vm.md), which provides the VM address of the instruction data buffer in register `r2` at program entrypoint. This allows BPF programs to locate their instruction data within the serialized input region without scanning.

## Changes

- **Feature gate:** Added `ProvideInstructionDataOffsetInVmR2` (`5xXZc66h4UdB6Yq7FzdBxBiRAFMMScMLwHxk2QZDaNZL`) to `pkg/features/gates.go`
- **Serialization:** `serializeParametersAligned` and `serializeParametersUnaligned` now return the byte offset of the instruction data within the serialized input buffer (offset past the 8-byte length prefix). Both aligned and unaligned paths compute this identically.
- **VM plumbing:** Added `InputDataVaddr` field to `VMOpts` and `Interpreter` structs. When the feature is active, `InputDataVaddr` is set to `VaddrInput + instrDataOffset`, giving the absolute VM address of the instruction data bytes.
- **Entrypoint:** `r2` is initialized to `InputDataVaddr` at interpreter startup (alongside the existing `r1 = VaddrInput`). When the feature is inactive, `r2` remains 0 (no behavioral change for existing programs).

## Agave reference

- `agave/programs/bpf_loader/src/lib.rs` — `create_vm` sets `r2` from `instruction_data_offset`
- `agave/programs/bpf_loader/src/serialization.rs` — `serialize_parameters_aligned` returns `instruction_data_offset`
- Feature gate: `provide_instruction_data_offset_in_vm_r2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)