### PR TITLE
Update vendorHash for gnark-crypto dependency

### DIFF
--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -47,7 +47,7 @@ in {
         version = "0.0.0";
         src = self;
         subPackages = ["cmd/mithril"];
-        vendorHash = "sha256-zWKYbW9hgBV6f4nlLH2kMhR+6QVYBKf3PH9lQ8KYuhU=";
+        vendorHash = "sha256-BVgVVvRAllEfb8D6Mh6NSaeLLOx6zeXwY4QyCwP0veo=";
         nativeBuildInputs = [pkgs.pkg-config];
         buildInputs = [pkgs.zstd];
         env = {


### PR DESCRIPTION
## Summary
- BLS12-381 syscalls (SIMD-0388) added `gnark-crypto` to `go.mod` but the `vendorHash` in `nix/packages.nix` was not updated
- This causes nix builds to fail with `cannot find module providing package github.com/Overclock-Validator/gnark-crypto/ecc/bls12-381`
- Updates `vendorHash` to include the new dependency

## Test plan
- [x] `nix build .#mithril` succeeds locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)