### PR TITLE
fix: improve input validation and Lightbringer fallback cleanup

### DIFF
--- a/cmd/mithril-tui/main.go
+++ b/cmd/mithril-tui/main.go
@@ -209,7 +209,8 @@ func (m model) View() string {
 
 func fetchMetrics(url string) tea.Cmd {
 	return func() tea.Msg {
-		resp, err := http.Get(url)
+		client := &http.Client{Timeout: 5 * time.Second}
+		resp, err := client.Get(url)
 		if err != nil {
 			return metricsMsg{err: err}
 		}

--- a/cmd/mithril/configcmd/edit.go
+++ b/cmd/mithril/configcmd/edit.go
@@ -2,6 +2,7 @@ package configcmd
 
 import (
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -490,8 +491,17 @@ func (m *editModel) validateAndApplyInput() bool {
 		m.rpcEndpoint = val
 
 	case edScrGossip:
-		if val == "" || !strings.Contains(val, ":") {
-			m.inputErr = "Format: IP:port (e.g., 198.13.130.58:8001)"
+		if val == "" {
+			m.inputErr = "Format: IP:port (e.g., 1.2.3.4:8000)"
+			return false
+		}
+		host, portStr, err := net.SplitHostPort(val)
+		if err != nil || host == "" {
+			m.inputErr = "Format: IP:port (e.g., 1.2.3.4:8000)"
+			return false
+		}
+		if p, perr := strconv.Atoi(portStr); perr != nil || p < 1 || p > 65535 {
+			m.inputErr = "Port must be 1-65535"
 			return false
 		}
 		m.gossipEntry = val
@@ -518,30 +528,34 @@ func (m *editModel) validateAndApplyInput() bool {
 		m.logsPath = filepath.Clean(val)
 
 	case edScrTuning:
-		if _, err := strconv.Atoi(val); err != nil {
-			m.inputErr = "Must be a number"
+		n, err := strconv.Atoi(val)
+		if err != nil || n < 0 {
+			m.inputErr = "Must be 0 (sequential) or a positive integer"
 			return false
 		}
 		m.txpar = val
 		m.txparWasSet = true
 
 	case edScrBlockRPS:
-		if _, err := strconv.Atoi(val); err != nil {
-			m.inputErr = "Must be a number"
+		n, err := strconv.Atoi(val)
+		if err != nil || n < 1 {
+			m.inputErr = "Must be a positive integer"
 			return false
 		}
 		m.blockMaxRPS = val
 
 	case edScrBlockInflight:
-		if _, err := strconv.Atoi(val); err != nil {
-			m.inputErr = "Must be a number"
+		n, err := strconv.Atoi(val)
+		if err != nil || n < 1 {
+			m.inputErr = "Must be a positive integer"
 			return false
 		}
 		m.blockInflight = val
 
 	case edScrRPCPort:
-		if _, err := strconv.Atoi(val); err != nil {
-			m.inputErr = "Must be a number"
+		n, err := strconv.Atoi(val)
+		if err != nil || n < 0 || n > 65535 {
+			m.inputErr = "Must be 0 (disabled) or a port number (1-65535)"
 			return false
 		}
 		m.rpcPort = val
@@ -596,8 +610,12 @@ func (m *editModel) saveConfig() {
 		rpcParts = append(rpcParts, fmt.Sprintf("%q", ep))
 	}
 	content = setTomlValue(content, "network", "rpc", "["+strings.Join(rpcParts, ", ")+"]")
-	content = setTomlValue(content, "storage", "accounts", fmt.Sprintf("%q", filepath.Clean(m.accountsPath)))
-	content = setTomlValue(content, "storage", "snapshots", fmt.Sprintf("%q", filepath.Clean(m.snapshotsPath)))
+	if m.accountsPath != "" {
+		content = setTomlValue(content, "storage", "accounts", fmt.Sprintf("%q", filepath.Clean(m.accountsPath)))
+	}
+	if m.snapshotsPath != "" {
+		content = setTomlValue(content, "storage", "snapshots", fmt.Sprintf("%q", filepath.Clean(m.snapshotsPath)))
+	}
 	content = setTomlValue(content, "block", "max_rps", m.blockMaxRPS)
 	content = setTomlValue(content, "block", "max_inflight", m.blockInflight)
 	// Only write txpar if it was originally in the config or user explicitly set a value

--- a/cmd/mithril/dashboardcmd/dashboard.go
+++ b/cmd/mithril/dashboardcmd/dashboard.go
@@ -887,8 +887,13 @@ func (m *model) applyEditField() {
 		value = filepath.Clean(value)
 	case key == "lightbringer.gossip_entrypoint" || key == "lightbringer.grpc_addr" || key == "lightbringer.rpc_addr":
 		if value != "" {
-			if _, _, err := net.SplitHostPort(value); err != nil {
+			host, portStr, err := net.SplitHostPort(value)
+			if err != nil || host == "" {
 				m.editErr = "Format: host:port (e.g., 127.0.0.1:3001)"
+				return
+			}
+			if p, perr := strconv.Atoi(portStr); perr != nil || p < 1 || p > 65535 {
+				m.editErr = "Port must be 1-65535"
 				return
 			}
 		}

--- a/cmd/mithril/node/node.go
+++ b/cmd/mithril/node/node.go
@@ -16,6 +16,7 @@ import (
 	"runtime/pprof"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -763,16 +764,23 @@ func runLive(c *cobra.Command, args []string) {
 				}
 			}()
 
-			// Monitor for crashes and auto-restart in background
+			// Monitor for crashes and auto-restart in background.
+			// Use sync.Once for safe channel close from both the fallback path and the defer.
 			lbStopMonitor := make(chan struct{})
+			var lbStopOnce sync.Once
+			stopMonitor := func() { lbStopOnce.Do(func() { close(lbStopMonitor) }) }
 			go lbManager.MonitorAndRestart(lbStopMonitor, 5)
-			defer close(lbStopMonitor)
+			defer stopMonitor()
 
 			if err := lbManager.WaitReady(30 * time.Second); err != nil {
 				mlog.Log.Warnf("lightbringer: %v — falling back to RPC", err)
 				useLightbringer = false
+				// Stop the monitor and Lightbringer immediately so they don't run unused during replay.
+				stopMonitor()
+				if stopErr := lbManager.Stop(5 * time.Second); stopErr != nil {
+					mlog.Log.Warnf("lightbringer: stop on fallback: %v", stopErr)
+				}
 				if len(rpcEndpoints) == 0 {
-					lbManager.Stop(5 * time.Second) // stop before fatal exit since klog.Fatalf bypasses defers
 					klog.Fatalf("lightbringer not ready and no RPC endpoints configured for fallback (set network.rpc)")
 				}
 			}

--- a/cmd/mithril/setupcmd/setup.go
+++ b/cmd/mithril/setupcmd/setup.go
@@ -2,6 +2,7 @@ package setupcmd
 
 import (
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -527,10 +528,16 @@ func (m *setupModel) validateAndApplyInput() bool {
 		}
 
 	case scrGossip:
-		if !m.requireNonEmpty(val) || !strings.Contains(val, ":") {
-			if m.inputErr == "" {
-				m.inputErr = "must be IP:port (e.g., 1.2.3.4:8000)"
-			}
+		if !m.requireNonEmpty(val) {
+			return false
+		}
+		host, portStr, err := net.SplitHostPort(val)
+		if err != nil || host == "" {
+			m.inputErr = "must be IP:port (e.g., 1.2.3.4:8000)"
+			return false
+		}
+		if p, perr := strconv.Atoi(portStr); perr != nil || p < 1 || p > 65535 {
+			m.inputErr = "port must be 1-65535"
 			return false
 		}
 		m.gossipEntry = val

--- a/pkg/lightbringer/config.go
+++ b/pkg/lightbringer/config.go
@@ -2,8 +2,10 @@ package lightbringer
 
 import (
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 )
 
@@ -26,13 +28,43 @@ type LightbringerTOML struct {
 	BlockConfirmRpcWS   string
 }
 
-// Validate checks that required fields are non-empty.
+// Validate checks that required fields are present and well-formed.
 func (c *LightbringerTOML) Validate() error {
 	if c.GossipEntrypoint == "" {
 		return fmt.Errorf("gossip_entrypoint is required")
 	}
+	if err := validateHostPort(c.GossipEntrypoint, "gossip_entrypoint"); err != nil {
+		return err
+	}
 	if c.GrpcAddr == "" {
 		return fmt.Errorf("grpc_addr is required")
+	}
+	if err := validateHostPort(c.GrpcAddr, "grpc_addr"); err != nil {
+		return err
+	}
+	if c.RpcAddr != "" {
+		if err := validateHostPort(c.RpcAddr, "rpc_addr"); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// validateHostPort checks that addr is a valid host:port with a numeric port in range.
+func validateHostPort(addr, field string) error {
+	host, portStr, err := net.SplitHostPort(addr)
+	if err != nil {
+		return fmt.Errorf("%s %q is not valid host:port: %w", field, addr, err)
+	}
+	if host == "" {
+		return fmt.Errorf("%s has empty host", field)
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		return fmt.Errorf("%s port %q is not numeric", field, portStr)
+	}
+	if port < 1 || port > 65535 {
+		return fmt.Errorf("%s port %d is out of range 1-65535", field, port)
 	}
 	return nil
 }

--- a/pkg/mlog/mlog.go
+++ b/pkg/mlog/mlog.go
@@ -187,35 +187,31 @@ func appendRunsLogEntry(runsLogPath string, ts time.Time, runID, commit, runDir 
 	}
 }
 
-// CreateSubprocessWriter creates a lumberjack-backed log writer for a named subprocess
-// (e.g., "lightbringer") in the current run directory. Returns os.Stderr if file
-// logging is not initialized.
+// CreateSubprocessWriter returns a writer for a named subprocess (e.g. "lightbringer")
+// that routes output to a dedicated log file in the current run directory. Subprocess
+// output is not mirrored to the terminal, keeping Mithril's own output readable.
+// When file logging is not initialized, output falls back to stderr with a
+// "[name] " prefix so developers running without a log directory can still see it.
 func (l *logger) CreateSubprocessWriter(name string) io.Writer {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
 	if !l.initialized || l.runDir == "" {
-		// No file logging — at least prefix the output so it's identifiable in interleaved stderr
 		return newPrefixWriter(os.Stderr, "["+name+"] ")
 	}
 
-	logPath := filepath.Join(l.runDir, name+".log")
-	fileWriter := &lumberjack.Logger{
-		Filename:   logPath,
-		MaxSize:    100,   // 100MB default
+	return &lumberjack.Logger{
+		Filename:   filepath.Join(l.runDir, name+".log"),
+		MaxSize:    100, // MB
 		MaxAge:     7,
 		MaxBackups: 5,
 		LocalTime:  false,
 		Compress:   true,
 	}
-
-	if l.toStdout {
-		return io.MultiWriter(newPrefixWriter(os.Stderr, "["+name+"] "), fileWriter)
-	}
-	return fileWriter
 }
 
 // prefixWriter wraps an io.Writer and prepends a prefix to each line.
+// Used only as a fallback when subprocess file logging is not available.
 type prefixWriter struct {
 	w      io.Writer
 	prefix string
@@ -228,8 +224,9 @@ func newPrefixWriter(w io.Writer, prefix string) *prefixWriter {
 func (pw *prefixWriter) Write(p []byte) (int, error) {
 	lines := bytes.Split(p, []byte("\n"))
 	for i, line := range lines {
+		// Skip the trailing empty element produced by bytes.Split when input ends in '\n'.
 		if len(line) == 0 && i == len(lines)-1 {
-			continue // skip trailing empty line from split
+			continue
 		}
 		if _, err := fmt.Fprintf(pw.w, "%s%s\n", pw.prefix, line); err != nil {
 			return 0, err


### PR DESCRIPTION
## Summary

- Add port range (0-65535) and numeric validation for txpar, block RPS, and inflight in config editor
- Use proper host:port parsing for gossip entrypoint across config edit, setup wizard, and dashboard
- Add host:port format check in Lightbringer config Validate() as safety net before binary launch
- Stop Lightbringer immediately on WaitReady fallback using sync.Once instead of leaving it running during RPC replay
- Prevent empty storage paths from being saved as "." in config editor
- Add HTTP client timeout in mithril-tui metrics fetcher
- Use consistent placeholder IP in validation error messages

## Test plan

- [x] Build, vet, and unit tests pass (including race detector)
- [x] Validation correctly rejects malformed inputs (invalid ports, bad host:port formats)
- [x] Full node run with managed Lightbringer sidecar — blocks processed, clean shutdown
- [x] TUI config editor validation verified manually