### PR TITLE
Optimize snapshot unpack by using multiple accounts directories

### DIFF
--- a/cmd/mithril/node/node.go
+++ b/cmd/mithril/node/node.go
@@ -77,6 +77,7 @@ var (
 	snapshotArchivePath             string
 	incrementalSnapshotFilename     string
 	accountsPath                    string
+	accountsPaths                   []string
 	scratchDirectory                string
 	rpcEndpoints                    []string
 	cluster                         string // "alpenglow", "mainnet-beta", "testnet", or "devnet"
@@ -518,7 +519,7 @@ func init() {
 	Run.Flags().StringVar(&snapshotDlPath, "download-snapshot-path", "", "Directory for discovered/downloaded snapshots")
 
 	// [ledger] section flags
-	Run.Flags().StringVarP(&accountsPath, "accounts-path", "o", "", "Output path for writing AccountsDB data to")
+	Run.Flags().StringSliceVarP(&accountsPaths, "accounts-path", "o", []string{}, "Output path(s) for writing AccountsDB data to - one dir per disk shard, can specify multiple")
 	Run.Flags().StringVar(&blockstorePath, "ledger-path", "/tmp/blocks", "Path containing slot.json files")
 
 	// [network] section flags
@@ -552,6 +553,7 @@ func init() {
 	Run.Flags().Uint64Var(&borrowedAccountArenaSize, "borrowed-account-arena-size", 1024, "Number of borrowed accounts to preallocate in arena (0 to disable)")
 	Run.Flags().IntVar(&snapshot.ZstdDecoderConcurrency, "zstd-decoder-concurrency", runtime.NumCPU(), "Zstd decoder concurrency")
 	Run.Flags().IntVar(&snapshot.MaxConcurrentFlushers, "max-concurrent-flushers", snapshot.DefaultSnapshotMaxConcurrentFlushers, "Bound for number of log shards to flush to Accounts DB Index at once")
+	Run.Flags().BoolVar(&snapshot.SnapshotDirectIO, "snapshot-directio", snapshot.DefaultSnapshotDirectIO, "Write snapshot big files with O_DIRECT (bypasses the page cache; helps decode throughput on low-RAM boxes)")
 	Run.Flags().IntVar(&snapshot.SnapshotAppendVecCopyingWorkers, "snapshot-append-vec-workers", snapshot.DefaultSnapshotAppendVecCopyingWorkers, "Snapshot bootstrap appendvec write workers")
 	Run.Flags().IntVar(&snapshot.SnapshotIndexEntryBuilderWorkers, "snapshot-index-builder-workers", snapshot.DefaultSnapshotIndexEntryBuilderWorkers, "Snapshot bootstrap account-index parser workers")
 	Run.Flags().IntVar(&snapshot.SnapshotIndexEntryCommitterWorkers, "snapshot-index-committer-workers", snapshot.DefaultSnapshotIndexEntryCommitterWorkers, "Snapshot bootstrap account-index shard enqueue workers")
@@ -776,13 +778,22 @@ func initConfigAndBindFlags(cmd *cobra.Command) error {
 	if incrementalSnapshotFilename == "" {
 		incrementalSnapshotFilename = getString("incremental-snapshot", "ledger.incremental_snapshot")
 	}
-	accountsPath = getString("accounts-path", "storage.accounts")
-	if accountsPath == "" {
-		accountsPath = getString("accounts-path", "ledger.accounts_path")
+	// storage.accounts is a list of one dir per disk shard; the single-disk case
+	// is just a slice of one. A scalar string in TOML is accepted too (viper casts
+	// it to a 1-element slice), and the --accounts-path CLI flag takes 1+ dirs.
+	accountsPaths = getStringSlice("accounts-path", "storage.accounts")
+	if len(accountsPaths) == 0 {
+		accountsPaths = getStringSlice("accounts-path", "ledger.accounts_path")
 	}
+	if len(accountsPaths) == 0 {
+		return fmt.Errorf("no accounts path configured (set storage.accounts)")
+	}
+	accountsPath = accountsPaths[0]
 	// Check write permission early to fail fast with helpful error
-	if err := checkDirWritable(accountsPath, "AccountsDB"); err != nil {
-		return err
+	for _, p := range accountsPaths {
+		if err := checkDirWritable(p, "AccountsDB"); err != nil {
+			return err
+		}
 	}
 	blockstorePath = getString("ledger-path", "storage.shredstore")
 	if blockstorePath == "" && config.IsSet("storage.blockstore") {
@@ -1102,6 +1113,7 @@ func initConfigAndBindFlags(cmd *cobra.Command) error {
 
 	snapshot.ZstdDecoderConcurrency = getInt("zstd-decoder-concurrency", "tuning.zstd_decoder_concurrency")
 	snapshot.MaxConcurrentFlushers = getInt("max-concurrent-flushers", "tuning.max_concurrent_flushers")
+	snapshot.SnapshotDirectIO = getBool("snapshot-directio", "tuning.snapshot_directio")
 	snapshot.SnapshotAppendVecCopyingWorkers = getInt("snapshot-append-vec-workers", "tuning.snapshot_append_vec_workers")
 	snapshot.SnapshotIndexEntryBuilderWorkers = getInt("snapshot-index-builder-workers", "tuning.snapshot_index_builder_workers")
 	snapshot.SnapshotIndexEntryCommitterWorkers = getInt("snapshot-index-committer-workers", "tuning.snapshot_index_committer_workers")
@@ -1728,7 +1740,7 @@ func runLive(c *cobra.Command, args []string) {
 		// Build directly from the specified files (BuildAccountsDbPaths handles AccountsDB cleanup internally)
 		// NOTE: We do NOT clean snapshot files in explicit mode - user wants to keep their explicit snapshots
 		dp := progress.NewDualProgress()
-		accountsDb, manifest, err = snapshot.BuildAccountsDbPaths(ctx, snapshotArchivePath, incrementalSnapshotFilename, accountsPath, dp)
+		accountsDb, manifest, err = snapshot.BuildAccountsDbPaths(ctx, snapshotArchivePath, incrementalSnapshotFilename, accountsPaths, dp)
 		if err != nil {
 			klog.Fatalf("failed to build AccountsDB from snapshot: %v", err)
 		}
@@ -1752,7 +1764,7 @@ func runLive(c *cobra.Command, args []string) {
 			mlog.Log.Infof("WARNING: no state file found, AccountsDB may be from incomplete build")
 		}
 		mlog.Log.Infof("Resuming from existing AccountsDB at slot %d", accountsDBSlot)
-		accountsDb, err = accountsdb.OpenDb(accountsPath)
+		accountsDb, err = accountsdb.OpenDbPaths(accountsPaths)
 		if err != nil {
 			klog.Fatalf("failed to open AccountsDB at %s: %v", accountsPath, err)
 		}
@@ -1799,7 +1811,7 @@ func runLive(c *cobra.Command, args []string) {
 				state.RecordRebuild(accountsPath, 0, "", getVersion(), getCommit(), getBranch(), "new-snapshot mode (no prior state)")
 			}
 			mlog.Log.Infof("Cleaning up previous AccountsDB artifacts in %s", accountsPath)
-			snapshot.CleanAccountsDbDir(accountsPath)
+			snapshot.CleanAccountsDbDirs(accountsPaths)
 		}
 		// Clean existing snapshots (respecting retention setting)
 		if snapshotDownloadPath != "" {
@@ -1810,7 +1822,7 @@ func runLive(c *cobra.Command, args []string) {
 			mlog.Log.Infof("Cleaning up existing snapshot files in %s (keeping %d)", snapshotDownloadPath, maxSnapshots)
 			snapshot.CleanSnapshotDownloadDir(snapshotDownloadPath, maxSnapshots)
 		}
-		accountsDb, manifest, err = downloadAndBuildFromSnapshot(ctx, rpcEndpoints, snapshotDownloadPath, accountsPath, blockstorePath)
+		accountsDb, manifest, err = downloadAndBuildFromSnapshot(ctx, rpcEndpoints, snapshotDownloadPath, accountsPaths, blockstorePath)
 		if err != nil {
 			klog.Fatalf("failed to build AccountsDB from snapshot: %v", err)
 		}
@@ -1845,9 +1857,9 @@ func runLive(c *cobra.Command, args []string) {
 				state.RecordRebuild(accountsPath, 0, "", getVersion(), getCommit(), getBranch(), "new-incremental mode (no prior state)")
 			}
 			mlog.Log.Infof("Cleaning up previous AccountsDB artifacts in %s", accountsPath)
-			snapshot.CleanAccountsDbDir(accountsPath)
+			snapshot.CleanAccountsDbDirs(accountsPaths)
 		}
-		accountsDb, manifest, err = buildFromExistingSnapshot(ctx, existingSnap, snapshotDownloadPath, accountsPath, blockstorePath, rpcEndpoints)
+		accountsDb, manifest, err = buildFromExistingSnapshot(ctx, existingSnap, snapshotDownloadPath, accountsPaths, blockstorePath, rpcEndpoints)
 		if err != nil {
 			klog.Fatalf("failed to build AccountsDB from snapshot: %v", err)
 		}
@@ -1871,7 +1883,7 @@ func runLive(c *cobra.Command, args []string) {
 				state.RecordRebuild(accountsPath, 0, "", getVersion(), getCommit(), getBranch(), "snapshot mode (no prior state)")
 			}
 			mlog.Log.Infof("Cleaning up previous AccountsDB artifacts in %s", accountsPath)
-			snapshot.CleanAccountsDbDir(accountsPath)
+			snapshot.CleanAccountsDbDirs(accountsPaths)
 		}
 
 		// Check for existing fresh snapshot
@@ -1884,7 +1896,7 @@ func runLive(c *cobra.Command, args []string) {
 		if existingSnap != nil {
 			// Reuse existing snapshot
 			mlog.Log.Infof("Reusing existing snapshot file at slot %d", existingSnap.slot)
-			accountsDb, manifest, err = buildFromExistingSnapshot(ctx, existingSnap, snapshotDownloadPath, accountsPath, blockstorePath, rpcEndpoints)
+			accountsDb, manifest, err = buildFromExistingSnapshot(ctx, existingSnap, snapshotDownloadPath, accountsPaths, blockstorePath, rpcEndpoints)
 		} else {
 			// Download fresh
 			mlog.Log.Infof("no fresh snapshot file found, downloading new one")
@@ -1896,7 +1908,7 @@ func runLive(c *cobra.Command, args []string) {
 				}
 				snapshot.CleanSnapshotDownloadDir(snapshotDownloadPath, maxSnapshots)
 			}
-			accountsDb, manifest, err = downloadAndBuildFromSnapshot(ctx, rpcEndpoints, snapshotDownloadPath, accountsPath, blockstorePath)
+			accountsDb, manifest, err = downloadAndBuildFromSnapshot(ctx, rpcEndpoints, snapshotDownloadPath, accountsPaths, blockstorePath)
 		}
 		if err != nil {
 			klog.Fatalf("failed to build AccountsDB from snapshot: %v", err)
@@ -1974,7 +1986,7 @@ func runLive(c *cobra.Command, args []string) {
 						// mithrilState is guaranteed non-nil here (we prompted because it was stale)
 						state.RecordRebuild(accountsPath, mithrilState.LastSlot, mithrilState.LastBankhash, getVersion(), getCommit(), getBranch(), "user chose rebuild (stale AccountsDB)")
 						mlog.Log.Infof("Cleaning up previous AccountsDB artifacts in %s", accountsPath)
-						snapshot.CleanAccountsDbDir(accountsPath)
+						snapshot.CleanAccountsDbDirs(accountsPaths)
 					}
 					// choice 3 forces a fresh download: skip the local-reuse check.
 					if choice == 2 {
@@ -1982,7 +1994,7 @@ func runLive(c *cobra.Command, args []string) {
 					}
 					if existingSnap != nil {
 						mlog.Log.Infof("Reusing existing snapshot file at slot %d", existingSnap.slot)
-						accountsDb, manifest, err = buildFromExistingSnapshot(ctx, existingSnap, snapshotDownloadPath, accountsPath, blockstorePath, rpcEndpoints)
+						accountsDb, manifest, err = buildFromExistingSnapshot(ctx, existingSnap, snapshotDownloadPath, accountsPaths, blockstorePath, rpcEndpoints)
 					} else {
 						// Clean up old snapshot files
 						if snapshotDownloadPath != "" {
@@ -1992,7 +2004,7 @@ func runLive(c *cobra.Command, args []string) {
 							}
 							snapshot.CleanSnapshotDownloadDir(snapshotDownloadPath, maxSnapshots)
 						}
-						accountsDb, manifest, err = downloadAndBuildFromSnapshot(ctx, rpcEndpoints, snapshotDownloadPath, accountsPath, blockstorePath)
+						accountsDb, manifest, err = downloadAndBuildFromSnapshot(ctx, rpcEndpoints, snapshotDownloadPath, accountsPaths, blockstorePath)
 					}
 					if err != nil {
 						klog.Fatalf("failed to build AccountsDB from snapshot: %v", err)
@@ -2011,7 +2023,7 @@ func runLive(c *cobra.Command, args []string) {
 			mlog.Log.Infof("mode=auto: Resuming from existing AccountsDB at slot %d", accountsDBSlot)
 			// Record resume in history
 			state.RecordResume(accountsPath, mithrilState.LastSlot, mithrilState.LastBankhash, replay.CurrentRunID, getVersion(), getCommit(), getBranch())
-			accountsDb, err = accountsdb.OpenDb(accountsPath)
+			accountsDb, err = accountsdb.OpenDbPaths(accountsPaths)
 			if err != nil {
 				klog.Fatalf("failed to open AccountsDB at %s: %v", accountsPath, err)
 			}
@@ -2083,14 +2095,14 @@ func runLive(c *cobra.Command, args []string) {
 					state.RecordRebuild(accountsPath, 0, "", getVersion(), getCommit(), getBranch(), reason)
 				}
 				mlog.Log.Infof("Cleaning up previous AccountsDB artifacts in %s", accountsPath)
-				snapshot.CleanAccountsDbDir(accountsPath)
+				snapshot.CleanAccountsDbDirs(accountsPaths)
 			}
 
 			// Check for existing fresh snapshot
 			existingSnap := detectFreshSnapshot(snapshotDownloadPath, fullThreshold, rpcEndpoints, ctx)
 			if existingSnap != nil {
 				mlog.Log.Infof("Reusing existing snapshot file at slot %d", existingSnap.slot)
-				accountsDb, manifest, err = buildFromExistingSnapshot(ctx, existingSnap, snapshotDownloadPath, accountsPath, blockstorePath, rpcEndpoints)
+				accountsDb, manifest, err = buildFromExistingSnapshot(ctx, existingSnap, snapshotDownloadPath, accountsPaths, blockstorePath, rpcEndpoints)
 			} else {
 				// Clean up old snapshot files based on retention settings
 				maxSnapshots := config.GetInt("snapshot.max_full_snapshots")
@@ -2098,7 +2110,7 @@ func runLive(c *cobra.Command, args []string) {
 					maxSnapshots = 1 // default: keep 1 snapshot
 				}
 				snapshot.CleanSnapshotDownloadDir(snapshotDownloadPath, maxSnapshots)
-				accountsDb, manifest, err = downloadAndBuildFromSnapshot(ctx, rpcEndpoints, snapshotDownloadPath, accountsPath, blockstorePath)
+				accountsDb, manifest, err = downloadAndBuildFromSnapshot(ctx, rpcEndpoints, snapshotDownloadPath, accountsPaths, blockstorePath)
 			}
 			if err != nil {
 				klog.Fatalf("failed to build AccountsDB from snapshot: %v", err)
@@ -3762,7 +3774,7 @@ func queryLatestSnapshotSlot(ctx context.Context, rpcEndpoints []string) (uint64
 }
 
 // buildFromExistingSnapshot builds AccountsDB from an existing downloaded snapshot file.
-func buildFromExistingSnapshot(ctx context.Context, snap *snapshotInfo, snapshotDir, accountsPath, blockstorePath string, rpcEndpoints []string) (*accountsdb.AccountsDb, *snapshot.SnapshotManifest, error) {
+func buildFromExistingSnapshot(ctx context.Context, snap *snapshotInfo, snapshotDir string, accountsPaths []string, blockstorePath string, rpcEndpoints []string) (*accountsdb.AccountsDb, *snapshot.SnapshotManifest, error) {
 	snapCfg := buildSnapshotConfig(rpcEndpoints)
 
 	// Construct full path to snapshot file
@@ -3772,7 +3784,7 @@ func buildFromExistingSnapshot(ctx context.Context, snap *snapshotInfo, snapshot
 	// Create progress display for extract
 	dp := progress.NewDualProgress()
 
-	accountsDb, manifest, err := snapshot.BuildAccountsDbAuto(ctx, fullSnapshotPath, snapshotDir, int(snap.slot), int(snap.slot), accountsPath, rpcEndpoints, blockstorePath, snapCfg, dp)
+	accountsDb, manifest, err := snapshot.BuildAccountsDbAuto(ctx, fullSnapshotPath, snapshotDir, int(snap.slot), int(snap.slot), accountsPaths, rpcEndpoints, blockstorePath, snapCfg, dp)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to build AccountsDB from snapshot: %w", err)
 	}
@@ -3782,7 +3794,7 @@ func buildFromExistingSnapshot(ctx context.Context, snap *snapshotInfo, snapshot
 }
 
 // downloadAndBuildFromSnapshot finds, downloads, and builds AccountsDB from a snapshot
-func downloadAndBuildFromSnapshot(ctx context.Context, rpcEndpoints []string, snapshotDownloadPath, accountsPath, blockstorePath string) (*accountsdb.AccountsDb, *snapshot.SnapshotManifest, error) {
+func downloadAndBuildFromSnapshot(ctx context.Context, rpcEndpoints []string, snapshotDownloadPath string, accountsPaths []string, blockstorePath string) (*accountsdb.AccountsDb, *snapshot.SnapshotManifest, error) {
 	snapCfg := buildSnapshotConfig(rpcEndpoints)
 	fullSnapshotDlStart := time.Now()
 	fullSnapshotInfo, err := snapshotdl.GetSnapshotURLWithInfo(ctx, snapCfg)
@@ -3806,7 +3818,7 @@ func downloadAndBuildFromSnapshot(ctx context.Context, rpcEndpoints []string, sn
 	// Create progress display for snapshot download and extract
 	dp := progress.NewDualProgress()
 
-	accountsDb, manifest, err := snapshot.BuildAccountsDbAuto(ctx, fullSnapshotURL, snapshotDownloadPath, fullSnapshotSlot, fullSnapshotInfo.ReferenceSlot, accountsPath, rpcEndpoints, blockstorePath, snapCfg, dp)
+	accountsDb, manifest, err := snapshot.BuildAccountsDbAuto(ctx, fullSnapshotURL, snapshotDownloadPath, fullSnapshotSlot, fullSnapshotInfo.ReferenceSlot, accountsPaths, rpcEndpoints, blockstorePath, snapCfg, dp)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to build AccountsDB from snapshot: %w", err)
 	}

--- a/cmd/mithril/node/node.go
+++ b/cmd/mithril/node/node.go
@@ -229,6 +229,7 @@ func init() {
 	Run.Flags().Uint64Var(&borrowedAccountArenaSize, "borrowed-account-arena-size", 1024, "Number of borrowed accounts to preallocate in arena (0 to disable)")
 	Run.Flags().IntVar(&snapshot.ZstdDecoderConcurrency, "zstd-decoder-concurrency", runtime.NumCPU(), "Zstd decoder concurrency")
 	Run.Flags().IntVar(&snapshot.MaxConcurrentFlushers, "max-concurrent-flushers", snapshot.DefaultSnapshotMaxConcurrentFlushers, "Bound for number of log shards to flush to Accounts DB Index at once")
+	Run.Flags().IntVar(&snapshot.SnapshotFlushSortWorkers, "flush-sort-workers", snapshot.DefaultSnapshotFlushSortWorkers, "Snapshot index-flush concurrent sort workers (0 = one per CPU)")
 	Run.Flags().BoolVar(&snapshot.SnapshotDirectIO, "snapshot-directio", snapshot.DefaultSnapshotDirectIO, "Write snapshot big files with O_DIRECT (bypasses the page cache; helps decode throughput on low-RAM boxes)")
 	Run.Flags().IntVar(&snapshot.SnapshotAppendVecCopyingWorkers, "snapshot-append-vec-workers", snapshot.DefaultSnapshotAppendVecCopyingWorkers, "Snapshot bootstrap appendvec write workers")
 	Run.Flags().IntVar(&snapshot.SnapshotIndexEntryBuilderWorkers, "snapshot-index-builder-workers", snapshot.DefaultSnapshotIndexEntryBuilderWorkers, "Snapshot bootstrap account-index parser workers")
@@ -683,6 +684,7 @@ func initConfigAndBindFlags(cmd *cobra.Command) error {
 
 	snapshot.ZstdDecoderConcurrency = getInt("zstd-decoder-concurrency", "tuning.zstd_decoder_concurrency")
 	snapshot.MaxConcurrentFlushers = getInt("max-concurrent-flushers", "tuning.max_concurrent_flushers")
+	snapshot.SnapshotFlushSortWorkers = getInt("flush-sort-workers", "tuning.flush_sort_workers")
 	snapshot.SnapshotDirectIO = getBool("snapshot-directio", "tuning.snapshot_directio")
 	snapshot.SnapshotAppendVecCopyingWorkers = getInt("snapshot-append-vec-workers", "tuning.snapshot_append_vec_workers")
 	snapshot.SnapshotIndexEntryBuilderWorkers = getInt("snapshot-index-builder-workers", "tuning.snapshot_index_builder_workers")

--- a/cmd/mithril/node/node.go
+++ b/cmd/mithril/node/node.go
@@ -553,6 +553,7 @@ func init() {
 	Run.Flags().Uint64Var(&borrowedAccountArenaSize, "borrowed-account-arena-size", 1024, "Number of borrowed accounts to preallocate in arena (0 to disable)")
 	Run.Flags().IntVar(&snapshot.ZstdDecoderConcurrency, "zstd-decoder-concurrency", runtime.NumCPU(), "Zstd decoder concurrency")
 	Run.Flags().IntVar(&snapshot.MaxConcurrentFlushers, "max-concurrent-flushers", snapshot.DefaultSnapshotMaxConcurrentFlushers, "Bound for number of log shards to flush to Accounts DB Index at once")
+	Run.Flags().IntVar(&snapshot.SnapshotFlushSortWorkers, "flush-sort-workers", snapshot.DefaultSnapshotFlushSortWorkers, "Snapshot index-flush concurrent sort workers (0 = one per CPU)")
 	Run.Flags().BoolVar(&snapshot.SnapshotDirectIO, "snapshot-directio", snapshot.DefaultSnapshotDirectIO, "Write snapshot big files with O_DIRECT (bypasses the page cache; helps decode throughput on low-RAM boxes)")
 	Run.Flags().IntVar(&snapshot.SnapshotAppendVecCopyingWorkers, "snapshot-append-vec-workers", snapshot.DefaultSnapshotAppendVecCopyingWorkers, "Snapshot bootstrap appendvec write workers")
 	Run.Flags().IntVar(&snapshot.SnapshotIndexEntryBuilderWorkers, "snapshot-index-builder-workers", snapshot.DefaultSnapshotIndexEntryBuilderWorkers, "Snapshot bootstrap account-index parser workers")
@@ -1113,6 +1114,7 @@ func initConfigAndBindFlags(cmd *cobra.Command) error {
 
 	snapshot.ZstdDecoderConcurrency = getInt("zstd-decoder-concurrency", "tuning.zstd_decoder_concurrency")
 	snapshot.MaxConcurrentFlushers = getInt("max-concurrent-flushers", "tuning.max_concurrent_flushers")
+	snapshot.SnapshotFlushSortWorkers = getInt("flush-sort-workers", "tuning.flush_sort_workers")
 	snapshot.SnapshotDirectIO = getBool("snapshot-directio", "tuning.snapshot_directio")
 	snapshot.SnapshotAppendVecCopyingWorkers = getInt("snapshot-append-vec-workers", "tuning.snapshot_append_vec_workers")
 	snapshot.SnapshotIndexEntryBuilderWorkers = getInt("snapshot-index-builder-workers", "tuning.snapshot_index_builder_workers")

--- a/cmd/mithril/node/node.go
+++ b/cmd/mithril/node/node.go
@@ -59,7 +59,8 @@ var (
 	bootstrapMode               string // "auto", "snapshot", or "accountsdb"
 	snapshotArchivePath         string
 	incrementalSnapshotFilename string
-	accountsPath                string
+	accountsPath                string   // primary accounts/metadata dir (accountsPaths[0])
+	accountsPaths               []string // one dir per disk shard
 	scratchDirectory            string
 	rpcEndpoints                []string
 	cluster                     string // "mainnet-beta", "testnet", "devnet"
@@ -208,7 +209,7 @@ func init() {
 	Run.Flags().StringVar(&incrementalSnapshotFilename, "incremental-snapshot", "", "Path to specific incremental snapshot file (bypasses auto-discovery)")
 
 	// [ledger] section flags
-	Run.Flags().StringVarP(&accountsPath, "accounts-path", "o", "", "Output path for writing AccountsDB data to")
+	Run.Flags().StringSliceVarP(&accountsPaths, "accounts-path", "o", []string{}, "Output path(s) for writing AccountsDB data to - one dir per disk shard, can specify multiple")
 	Run.Flags().StringVar(&blockstorePath, "ledger-path", "/tmp/blocks", "Path containing slot.json files")
 
 	// [network] section flags
@@ -228,6 +229,7 @@ func init() {
 	Run.Flags().Uint64Var(&borrowedAccountArenaSize, "borrowed-account-arena-size", 1024, "Number of borrowed accounts to preallocate in arena (0 to disable)")
 	Run.Flags().IntVar(&snapshot.ZstdDecoderConcurrency, "zstd-decoder-concurrency", runtime.NumCPU(), "Zstd decoder concurrency")
 	Run.Flags().IntVar(&snapshot.MaxConcurrentFlushers, "max-concurrent-flushers", snapshot.DefaultSnapshotMaxConcurrentFlushers, "Bound for number of log shards to flush to Accounts DB Index at once")
+	Run.Flags().BoolVar(&snapshot.SnapshotDirectIO, "snapshot-directio", snapshot.DefaultSnapshotDirectIO, "Write snapshot big files with O_DIRECT (bypasses the page cache; helps decode throughput on low-RAM boxes)")
 	Run.Flags().IntVar(&snapshot.SnapshotAppendVecCopyingWorkers, "snapshot-append-vec-workers", snapshot.DefaultSnapshotAppendVecCopyingWorkers, "Snapshot bootstrap appendvec write workers")
 	Run.Flags().IntVar(&snapshot.SnapshotIndexEntryBuilderWorkers, "snapshot-index-builder-workers", snapshot.DefaultSnapshotIndexEntryBuilderWorkers, "Snapshot bootstrap account-index parser workers")
 	Run.Flags().IntVar(&snapshot.SnapshotIndexEntryCommitterWorkers, "snapshot-index-committer-workers", snapshot.DefaultSnapshotIndexEntryCommitterWorkers, "Snapshot bootstrap account-index shard enqueue workers")
@@ -445,13 +447,22 @@ func initConfigAndBindFlags(cmd *cobra.Command) error {
 	if incrementalSnapshotFilename == "" {
 		incrementalSnapshotFilename = getString("incremental-snapshot", "ledger.incremental_snapshot")
 	}
-	accountsPath = getString("accounts-path", "storage.accounts")
-	if accountsPath == "" {
-		accountsPath = getString("accounts-path", "ledger.accounts_path")
+	// storage.accounts is a list of one dir per disk shard; the single-disk case
+	// is just a slice of one. A scalar string in TOML is accepted too (viper casts
+	// it to a 1-element slice), and the --accounts-path CLI flag takes 1+ dirs.
+	accountsPaths = getStringSlice("accounts-path", "storage.accounts")
+	if len(accountsPaths) == 0 {
+		accountsPaths = getStringSlice("accounts-path", "ledger.accounts_path")
 	}
+	if len(accountsPaths) == 0 {
+		return fmt.Errorf("no accounts path configured (set storage.accounts)")
+	}
+	accountsPath = accountsPaths[0]
 	// Check write permission early to fail fast with helpful error
-	if err := checkDirWritable(accountsPath, "AccountsDB"); err != nil {
-		return err
+	for _, p := range accountsPaths {
+		if err := checkDirWritable(p, "AccountsDB"); err != nil {
+			return err
+		}
 	}
 	blockstorePath = getString("ledger-path", "storage.shredstore")
 	if blockstorePath == "" && config.IsSet("storage.blockstore") {
@@ -672,6 +683,7 @@ func initConfigAndBindFlags(cmd *cobra.Command) error {
 
 	snapshot.ZstdDecoderConcurrency = getInt("zstd-decoder-concurrency", "tuning.zstd_decoder_concurrency")
 	snapshot.MaxConcurrentFlushers = getInt("max-concurrent-flushers", "tuning.max_concurrent_flushers")
+	snapshot.SnapshotDirectIO = getBool("snapshot-directio", "tuning.snapshot_directio")
 	snapshot.SnapshotAppendVecCopyingWorkers = getInt("snapshot-append-vec-workers", "tuning.snapshot_append_vec_workers")
 	snapshot.SnapshotIndexEntryBuilderWorkers = getInt("snapshot-index-builder-workers", "tuning.snapshot_index_builder_workers")
 	snapshot.SnapshotIndexEntryCommitterWorkers = getInt("snapshot-index-committer-workers", "tuning.snapshot_index_committer_workers")
@@ -1040,7 +1052,7 @@ func runLive(c *cobra.Command, args []string) {
 		// Build directly from the specified files (BuildAccountsDbPaths handles AccountsDB cleanup internally)
 		// NOTE: We do NOT clean snapshot files in explicit mode - user wants to keep their explicit snapshots
 		dp := progress.NewDualProgress()
-		accountsDb, manifest, err = snapshot.BuildAccountsDbPaths(ctx, snapshotArchivePath, incrementalSnapshotFilename, accountsPath, dp)
+		accountsDb, manifest, err = snapshot.BuildAccountsDbPaths(ctx, snapshotArchivePath, incrementalSnapshotFilename, accountsPaths, dp)
 		if err != nil {
 			klog.Fatalf("failed to build AccountsDB from snapshot: %v", err)
 		}
@@ -1067,7 +1079,7 @@ func runLive(c *cobra.Command, args []string) {
 			mlog.Log.Infof("WARNING: no state file found, AccountsDB may be from incomplete build")
 		}
 		mlog.Log.Infof("Resuming from existing AccountsDB at slot %d", accountsDBSlot)
-		accountsDb, err = accountsdb.OpenDb(accountsPath)
+		accountsDb, err = accountsdb.OpenDb(accountsPaths)
 		if err != nil {
 			klog.Fatalf("failed to open AccountsDB at %s: %v", accountsPath, err)
 		}
@@ -1098,7 +1110,7 @@ func runLive(c *cobra.Command, args []string) {
 				state.RecordRebuild(accountsPath, 0, "", getVersion(), getCommit(), getBranch(), "new-snapshot mode (no prior state)")
 			}
 			mlog.Log.Infof("Cleaning up previous AccountsDB artifacts in %s", accountsPath)
-			snapshot.CleanAccountsDbDir(accountsPath)
+			snapshot.CleanAccountsDbDir(accountsPaths)
 		}
 		// Clean existing snapshots (respecting retention setting)
 		if snapshotDownloadPath != "" {
@@ -1109,7 +1121,7 @@ func runLive(c *cobra.Command, args []string) {
 			mlog.Log.Infof("Cleaning up existing snapshot files in %s (keeping %d)", snapshotDownloadPath, maxSnapshots)
 			snapshot.CleanSnapshotDownloadDir(snapshotDownloadPath, maxSnapshots)
 		}
-		accountsDb, manifest, err = downloadAndBuildFromSnapshot(ctx, rpcEndpoints, snapshotDownloadPath, accountsPath, blockstorePath)
+		accountsDb, manifest, err = downloadAndBuildFromSnapshot(ctx, rpcEndpoints, snapshotDownloadPath, accountsPaths, blockstorePath)
 		if err != nil {
 			klog.Fatalf("failed to build AccountsDB from snapshot: %v", err)
 		}
@@ -1138,7 +1150,7 @@ func runLive(c *cobra.Command, args []string) {
 				state.RecordRebuild(accountsPath, 0, "", getVersion(), getCommit(), getBranch(), "snapshot mode (no prior state)")
 			}
 			mlog.Log.Infof("Cleaning up previous AccountsDB artifacts in %s", accountsPath)
-			snapshot.CleanAccountsDbDir(accountsPath)
+			snapshot.CleanAccountsDbDir(accountsPaths)
 		}
 
 		// Check for existing fresh snapshot
@@ -1151,7 +1163,7 @@ func runLive(c *cobra.Command, args []string) {
 		if existingSnap != nil {
 			// Reuse existing snapshot
 			mlog.Log.Infof("Reusing existing snapshot file at slot %d", existingSnap.slot)
-			accountsDb, manifest, err = buildFromExistingSnapshot(ctx, existingSnap, snapshotDownloadPath, accountsPath, blockstorePath, rpcEndpoints)
+			accountsDb, manifest, err = buildFromExistingSnapshot(ctx, existingSnap, snapshotDownloadPath, accountsPaths, blockstorePath, rpcEndpoints)
 		} else {
 			// Download fresh
 			mlog.Log.Infof("no fresh snapshot file found, downloading new one")
@@ -1163,7 +1175,7 @@ func runLive(c *cobra.Command, args []string) {
 				}
 				snapshot.CleanSnapshotDownloadDir(snapshotDownloadPath, maxSnapshots)
 			}
-			accountsDb, manifest, err = downloadAndBuildFromSnapshot(ctx, rpcEndpoints, snapshotDownloadPath, accountsPath, blockstorePath)
+			accountsDb, manifest, err = downloadAndBuildFromSnapshot(ctx, rpcEndpoints, snapshotDownloadPath, accountsPaths, blockstorePath)
 		}
 		if err != nil {
 			klog.Fatalf("failed to build AccountsDB from snapshot: %v", err)
@@ -1217,13 +1229,13 @@ func runLive(c *cobra.Command, args []string) {
 						// mithrilState is guaranteed non-nil here (we prompted because it was stale)
 						state.RecordRebuild(accountsPath, mithrilState.LastSlot, mithrilState.LastBankhash, getVersion(), getCommit(), getBranch(), "user chose rebuild (stale AccountsDB)")
 						mlog.Log.Infof("Cleaning up previous AccountsDB artifacts in %s", accountsPath)
-						snapshot.CleanAccountsDbDir(accountsPath)
+						snapshot.CleanAccountsDbDir(accountsPaths)
 					}
 					// Check for existing fresh snapshot
 					existingSnap := detectFreshSnapshot(snapshotDownloadPath, fullThreshold, rpcEndpoints, ctx)
 					if existingSnap != nil {
 						mlog.Log.Infof("Reusing existing snapshot file at slot %d", existingSnap.slot)
-						accountsDb, manifest, err = buildFromExistingSnapshot(ctx, existingSnap, snapshotDownloadPath, accountsPath, blockstorePath, rpcEndpoints)
+						accountsDb, manifest, err = buildFromExistingSnapshot(ctx, existingSnap, snapshotDownloadPath, accountsPaths, blockstorePath, rpcEndpoints)
 					} else {
 						// Clean up old snapshot files
 						if snapshotDownloadPath != "" {
@@ -1233,7 +1245,7 @@ func runLive(c *cobra.Command, args []string) {
 							}
 							snapshot.CleanSnapshotDownloadDir(snapshotDownloadPath, maxSnapshots)
 						}
-						accountsDb, manifest, err = downloadAndBuildFromSnapshot(ctx, rpcEndpoints, snapshotDownloadPath, accountsPath, blockstorePath)
+						accountsDb, manifest, err = downloadAndBuildFromSnapshot(ctx, rpcEndpoints, snapshotDownloadPath, accountsPaths, blockstorePath)
 					}
 					if err != nil {
 						klog.Fatalf("failed to build AccountsDB from snapshot: %v", err)
@@ -1255,7 +1267,7 @@ func runLive(c *cobra.Command, args []string) {
 			mlog.Log.Infof("mode=auto: Resuming from existing AccountsDB at slot %d", accountsDBSlot)
 			// Record resume in history
 			state.RecordResume(accountsPath, mithrilState.LastSlot, mithrilState.LastBankhash, replay.CurrentRunID, getVersion(), getCommit(), getBranch())
-			accountsDb, err = accountsdb.OpenDb(accountsPath)
+			accountsDb, err = accountsdb.OpenDb(accountsPaths)
 			if err != nil {
 				klog.Fatalf("failed to open AccountsDB at %s: %v", accountsPath, err)
 			}
@@ -1311,14 +1323,14 @@ func runLive(c *cobra.Command, args []string) {
 					state.RecordRebuild(accountsPath, 0, "", getVersion(), getCommit(), getBranch(), reason)
 				}
 				mlog.Log.Infof("Cleaning up previous AccountsDB artifacts in %s", accountsPath)
-				snapshot.CleanAccountsDbDir(accountsPath)
+				snapshot.CleanAccountsDbDir(accountsPaths)
 			}
 
 			// Check for existing fresh snapshot
 			existingSnap := detectFreshSnapshot(snapshotDownloadPath, fullThreshold, rpcEndpoints, ctx)
 			if existingSnap != nil {
 				mlog.Log.Infof("Reusing existing snapshot file at slot %d", existingSnap.slot)
-				accountsDb, manifest, err = buildFromExistingSnapshot(ctx, existingSnap, snapshotDownloadPath, accountsPath, blockstorePath, rpcEndpoints)
+				accountsDb, manifest, err = buildFromExistingSnapshot(ctx, existingSnap, snapshotDownloadPath, accountsPaths, blockstorePath, rpcEndpoints)
 			} else {
 				// Clean up old snapshot files based on retention settings
 				maxSnapshots := config.GetInt("snapshot.max_full_snapshots")
@@ -1326,7 +1338,7 @@ func runLive(c *cobra.Command, args []string) {
 					maxSnapshots = 1 // default: keep 1 snapshot
 				}
 				snapshot.CleanSnapshotDownloadDir(snapshotDownloadPath, maxSnapshots)
-				accountsDb, manifest, err = downloadAndBuildFromSnapshot(ctx, rpcEndpoints, snapshotDownloadPath, accountsPath, blockstorePath)
+				accountsDb, manifest, err = downloadAndBuildFromSnapshot(ctx, rpcEndpoints, snapshotDownloadPath, accountsPaths, blockstorePath)
 			}
 			if err != nil {
 				klog.Fatalf("failed to build AccountsDB from snapshot: %v", err)
@@ -2222,7 +2234,7 @@ func queryLatestSnapshotSlot(ctx context.Context, rpcEndpoints []string) (uint64
 }
 
 // buildFromExistingSnapshot builds AccountsDB from an existing downloaded snapshot file.
-func buildFromExistingSnapshot(ctx context.Context, snap *snapshotInfo, snapshotDir, accountsPath, blockstorePath string, rpcEndpoints []string) (*accountsdb.AccountsDb, *snapshot.SnapshotManifest, error) {
+func buildFromExistingSnapshot(ctx context.Context, snap *snapshotInfo, snapshotDir string, accountsPaths []string, blockstorePath string, rpcEndpoints []string) (*accountsdb.AccountsDb, *snapshot.SnapshotManifest, error) {
 	snapCfg := buildSnapshotConfig(rpcEndpoints)
 
 	// Construct full path to snapshot file
@@ -2232,7 +2244,7 @@ func buildFromExistingSnapshot(ctx context.Context, snap *snapshotInfo, snapshot
 	// Create progress display for extract
 	dp := progress.NewDualProgress()
 
-	accountsDb, manifest, err := snapshot.BuildAccountsDbAuto(ctx, fullSnapshotPath, snapshotDir, int(snap.slot), int(snap.slot), accountsPath, rpcEndpoints, blockstorePath, snapCfg, dp)
+	accountsDb, manifest, err := snapshot.BuildAccountsDbAuto(ctx, fullSnapshotPath, snapshotDir, int(snap.slot), int(snap.slot), accountsPaths, rpcEndpoints, blockstorePath, snapCfg, dp)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to build AccountsDB from snapshot: %w", err)
 	}
@@ -2242,7 +2254,7 @@ func buildFromExistingSnapshot(ctx context.Context, snap *snapshotInfo, snapshot
 }
 
 // downloadAndBuildFromSnapshot finds, downloads, and builds AccountsDB from a snapshot
-func downloadAndBuildFromSnapshot(ctx context.Context, rpcEndpoints []string, snapshotDownloadPath, accountsPath, blockstorePath string) (*accountsdb.AccountsDb, *snapshot.SnapshotManifest, error) {
+func downloadAndBuildFromSnapshot(ctx context.Context, rpcEndpoints []string, snapshotDownloadPath string, accountsPaths []string, blockstorePath string) (*accountsdb.AccountsDb, *snapshot.SnapshotManifest, error) {
 	snapCfg := buildSnapshotConfig(rpcEndpoints)
 	fullSnapshotDlStart := time.Now()
 	fullSnapshotInfo, err := snapshotdl.GetSnapshotURLWithInfo(ctx, snapCfg)
@@ -2266,7 +2278,7 @@ func downloadAndBuildFromSnapshot(ctx context.Context, rpcEndpoints []string, sn
 	// Create progress display for snapshot download and extract
 	dp := progress.NewDualProgress()
 
-	accountsDb, manifest, err := snapshot.BuildAccountsDbAuto(ctx, fullSnapshotURL, snapshotDownloadPath, fullSnapshotSlot, fullSnapshotSlot, accountsPath, rpcEndpoints, blockstorePath, snapCfg, dp)
+	accountsDb, manifest, err := snapshot.BuildAccountsDbAuto(ctx, fullSnapshotURL, snapshotDownloadPath, fullSnapshotSlot, fullSnapshotSlot, accountsPaths, rpcEndpoints, blockstorePath, snapCfg, dp)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to build AccountsDB from snapshot: %w", err)
 	}

--- a/cmd/mithril/node/node.go
+++ b/cmd/mithril/node/node.go
@@ -789,6 +789,9 @@ func initConfigAndBindFlags(cmd *cobra.Command) error {
 	if len(accountsPaths) == 0 {
 		return fmt.Errorf("no accounts path configured (set storage.accounts)")
 	}
+	if err := accountsdb.ValidateAccountsPaths(accountsPaths); err != nil {
+		return err
+	}
 	accountsPath = accountsPaths[0]
 	// Check write permission early to fail fast with helpful error
 	for _, p := range accountsPaths {

--- a/config.example.toml
+++ b/config.example.toml
@@ -94,6 +94,18 @@ name = "mithril"
     # Put this on your fastest NVMe due to heavy random I/O.
     accounts = "/mnt/mithril-accounts"
 
+    # For multi-disk setups, accounts may instead be a list of directories, one
+    # per physical disk. The snapshot unpack shards append-vecs across them so
+    # aggregate write throughput approaches the sum of the disks. The first entry
+    # also holds the shared metadata (account index, manifest, state); the others
+    # hold only their disk's shard of the account data. The number of directories
+    # is fixed at build time - changing it requires rebuilding the AccountsDB.
+    #   accounts = [
+    #       "/mnt/nvme0/mithril-accounts",  # primary: metadata + shard 0
+    #       "/mnt/nvme1/mithril-accounts",  # shard 1
+    #       "/mnt/nvme2/mithril-accounts",  # shard 2
+    #   ]
+
     # Fold batch size K: rooted (finalized+verified) slots fold to disk K at a
     # time as ONE union-deduped sequential segment with ONE fsync. Larger K =
     # fewer, larger writes (less NVMe wear: hot accounts written once per K
@@ -517,6 +529,14 @@ name = "mithril"
 
     # Bound for number of index shards to convert to SSTs at once.
     max_concurrent_flushers = 8
+
+    # Write the snapshot append-vec big files with O_DIRECT, bypassing the OS page
+    # cache. On a ~460GB unpack the buffered path churns hundreds of GB of dirty
+    # pages, which evicts the zstd-decode working set; O_DIRECT avoids that and
+    # gives a modest (~6%) unpack speedup that grows on low-RAM boxes. Off by
+    # default (buffered is the safe choice). Requires a filesystem that supports
+    # O_DIRECT (ext4/xfs; not tmpfs).
+    # snapshot_directio = false
 
     # Size in MB for serialized parameter arena (0 to disable)
     param_arena_size_mb = 512

--- a/config.example.toml
+++ b/config.example.toml
@@ -530,6 +530,10 @@ name = "mithril"
     # Bound for number of index shards to convert to SSTs at once.
     max_concurrent_flushers = 8
 
+    # Concurrent sort workers used during the index flush.
+    # 0 (default) = one per CPU.
+    # flush_sort_workers = 0
+
     # Write the snapshot append-vec big files with O_DIRECT, bypassing the OS page
     # cache. On a ~460GB unpack the buffered path churns hundreds of GB of dirty
     # pages, which evicts the zstd-decode working set; O_DIRECT avoids that and

--- a/config.example.toml
+++ b/config.example.toml
@@ -374,6 +374,10 @@ name = "mithril"
     # Bound for number of index shards to convert to SSTs at once.
     max_concurrent_flushers = 8
 
+    # Concurrent sort workers used during the index flush.
+    # 0 (default) = one per CPU.
+    # flush_sort_workers = 0
+
     # Write the snapshot append-vec big files with O_DIRECT, bypassing the OS page
     # cache. On a ~460GB unpack the buffered path churns hundreds of GB of dirty
     # pages, which evicts the zstd-decode working set; O_DIRECT avoids that and

--- a/config.example.toml
+++ b/config.example.toml
@@ -519,7 +519,8 @@ name = "mithril"
     snapshot_index_committer_workers = 64
 
     # Number of temporary account-index shard logs/SSTs.
-    snapshot_index_shards = 64
+    # More shards reduce per-flusher sort memory when entries are evenly spread.
+    snapshot_index_shards = 256
 
     # Optional temp directory for snapshot index shard logs/SST staging.
     # This can move tens of GB of temporary write/read churn off the AccountsDB
@@ -528,6 +529,7 @@ name = "mithril"
     snapshot_index_temp_dir = ""
 
     # Bound for number of index shards to convert to SSTs at once.
+    # Lower this to reduce concurrent sort memory at the cost of throughput.
     max_concurrent_flushers = 8
 
     # Concurrent sort workers used during the index flush.

--- a/config.example.toml
+++ b/config.example.toml
@@ -71,6 +71,18 @@ name = "mithril"
     # Put this on your fastest NVMe due to heavy random I/O.
     accounts = "/mnt/mithril-accounts"
 
+    # For multi-disk setups, accounts may instead be a list of directories, one
+    # per physical disk. The snapshot unpack shards append-vecs across them so
+    # aggregate write throughput approaches the sum of the disks. The first entry
+    # also holds the shared metadata (account index, manifest, state); the others
+    # hold only their disk's shard of the account data. The number of directories
+    # is fixed at build time - changing it requires rebuilding the AccountsDB.
+    #   accounts = [
+    #       "/mnt/nvme0/mithril-accounts",  # primary: metadata + shard 0
+    #       "/mnt/nvme1/mithril-accounts",  # shard 1
+    #       "/mnt/nvme2/mithril-accounts",  # shard 2
+    #   ]
+
     # Shredstore - Lightbringer stores received shreds here
     # Used for block streaming and potential repair serving.
     shredstore = "/mnt/mithril-ledger/shredstore"
@@ -361,6 +373,14 @@ name = "mithril"
 
     # Bound for number of index shards to convert to SSTs at once.
     max_concurrent_flushers = 8
+
+    # Write the snapshot append-vec big files with O_DIRECT, bypassing the OS page
+    # cache. On a ~460GB unpack the buffered path churns hundreds of GB of dirty
+    # pages, which evicts the zstd-decode working set; O_DIRECT avoids that and
+    # gives a modest (~6%) unpack speedup that grows on low-RAM boxes. Off by
+    # default (buffered is the safe choice). Requires a filesystem that supports
+    # O_DIRECT (ext4/xfs; not tmpfs).
+    # snapshot_directio = false
 
     # Size in MB for serialized parameter arena (0 to disable)
     param_arena_size_mb = 512

--- a/docs/reviews/pr245-alpenglow.md
+++ b/docs/reviews/pr245-alpenglow.md
@@ -1,0 +1,152 @@
+# PR #245 review on Alpenglow
+
+Reviewed 2026-09-07 on `allnodes-ryzen9700x-fra` (Ryzen 7 9700X).
+Original PR: https://github.com/Overclock-Validator/mithril/pull/245
+Original head: `46157e132edc37b580c279e75b7cbc42e9027548`.
+Base fetched for this review: `origin/alpenglow-dev`, `7e4e8af1`.
+Local review branch: `7layer/pr245-alpenglow-review`.
+
+The PR was rebased in an isolated worktree. Its four commits are retained;
+conflict resolution also ports the layout to Alpenglow's newer AccountsDB.
+The existing checkouts and the upstream PR branch were not changed.
+
+## Findings
+
+1. **P1 — Reject duplicate or aliased shard directories before opening writers.**
+   `openShardBigFiles` opens an independent truncating writer for every supplied
+   path. When two paths name the same directory, both writers begin at offset
+   zero in the same `accounts/data` file. A deterministic reproduction wrote
+   `first-account` to shard 0 and `other-account` to shard 1: both writes and
+   close succeeded, but reading shard 0 returned `other-account`. Validate
+   directory identity before cleanup/opening, including symlink aliases.
+   This is in the original PR, whose writer implementation is unchanged by
+   the rebase. Reproduction: `duplicate_shards_test.go` in the review artifacts.
+
+2. **P2 — Teach Alpenglow compaction about coalesced snapshot storage.**
+   The new `accounts/data` files are invisible to `CompactOnce`, which scans
+   only primary-directory names matching `<slot>.<fileId>`. A completely dead
+   snapshot file remained on disk and `FilesDeleted` was zero. This loses
+   Alpenglow's existing bootstrap-data reclamation and leaves the original
+   snapshot allocation permanently retained. A solution must preserve extent
+   boundaries, account slots, rewind pins and crash safety; simply renaming
+   `data` is insufficient because it contains appendvecs from different slots.
+   This is an integration issue with `alpenglow-dev`, not a claim about the
+   original `dev` branch. Reproduction: `compaction_shards_test.go`.
+
+3. **P1 — Keep Linux-only O_DIRECT behind platform-specific code.**
+   `pkg/snapshot/shard_writer.go:76` refers to `syscall.O_DIRECT` in an
+   unconditional Go file, so even buffered mode cannot compile on macOS.
+   The baseline snapshot package cross-build succeeds. Cross-building the PR
+   snapshot package on Zen 5 with
+   `GOOS=darwin GOARCH=arm64 CGO_ENABLED=0` fails with
+   `undefined: syscall.O_DIRECT`. Put the flag/open implementation behind
+   platform build constraints, with an explicit unsupported-direct-mode error
+   on other systems while retaining buffered writes.
+
+The reproductions intentionally fail on this review branch and are kept outside
+its ordinary test suite. This review does not implement the outstanding fixes.
+
+## Rebase integration
+
+- Retain Alpenglow worker-error propagation, rejected-task accounting and
+  status-cache retention; return pooled tar buffers on worker exits.
+- Route batch account reads through the same file resolver as individual reads.
+- Share the durable file-ID high-water mark across runtime writes, folds and
+  compaction. Keep fold/compaction segments on the primary directory alongside
+  their recovery manifests, using primary-shard IDs.
+- Write bootstrap/high-water metadata for the coalesced namespace.
+- Preserve legacy single-directory opening and ready-state validation.
+- Preserve the corrected snapshot freshness reference and newer node settings.
+- Replace hard-coded writer-test mount paths with `t.TempDir`; add a sharded
+  snapshot → fold → reopen → recover → fold → rewind regression test.
+
+## Validation and limits
+
+All builds, tests, node runs and timings were executed on Zen 5 with Go 1.26.4
+and `GOEXPERIMENT=arenas`. The Mac was used only for source editing and analysis.
+Linux exposes one Samsung PM9A3 NVMe (960 GB decimal); PCI, sysfs and block-device
+inventories all show one NVMe controller/device. Multiple directories here test
+layout correctness, not multiple physical disks' aggregate bandwidth.
+
+Both baseline and candidate pass the targeted AccountsDB, snapshot, config,
+state and node suites. Candidate race checks and vet pass for those packages.
+Both buffered and O_DIRECT writer readback/placement tests actually ran on ext4
+with `TMPDIR=/var/tmp`, including oversized buffers. Sharded fold/restart/rewind
+passes. The intentionally failing reproductions and macOS cross-build are reported
+separately above.
+
+Pinned corpus:
+
+- Full slot 952183: `snapshot-952183-39vtNcVskxhNNHpmSFhQiUZfBvePGuWLLoZSNK2ZrSco.tar.zst`
+- Incremental through 1021126:
+  `incremental-snapshot-952183-1021126-8WPCAjnCZDUcCqYRYf3ThbBqZ6Qfsu3uKAmDUv7LMiWZ.tar.zst`
+- Archives fetched from `https://rpc.ag.validator1.net`; checksums saved in
+  `snapshot-sha256.txt` in the review artifacts.
+
+After unpacking full + incremental snapshots and reopening, the baseline and
+candidate (including two-directory buffered and one-directory O_DIRECT modes)
+both read **5,593,721 indexed accounts** successfully and produced
+identical canonical account digests:
+`82fecea1d07acf1cbdefe89f8ae4e222a7e416b0eb2bca24f7eb4289f8253f6a`.
+Every key was checked through both individual and batch APIs. The probe accounts
+for the batch API's existing canonical zero-lamport tombstones and treats nil
+and empty data equally. The reported manifest bank hash also matched; this is
+not a separate recomputation of the bank hash.
+
+## Full-node smoke test
+
+The baseline and candidate were each launched for up to three minutes in
+verifying mode, with their own
+storage/log/ledger directories and no validator keys, to replay a bounded range
+starting at 1021127 from RPC. The restored testnet returns RPC error -32015:
+`Transaction version (1) is not supported by the requesting client`.
+The shared `pkg/rpcclient/blockfetch.go` requests maximum version 0. This is
+outside PR #245. Snapshot bootstrap and node initialization succeed, but the
+requested replay range cannot be claimed as validated. RPC-only runs also do
+not validate Alpenglow certificate-backed durable promotion. The running
+Lightbringer instance was left untouched.
+
+## Measurements
+
+Buffered unpack of the same full + incremental corpus, eight alternating
+pairs on CPUs `2-7,10-15` (Go's automatic parallelism; no host tuning or global
+cache drops). Archives were warm, each output database was rebuilt, and the
+full production bootstrap API—including manifest parsing, cleanup, unpack,
+indexing and opening the DB—was timed. Full account readback ran separately.
+No test nodes, builds or race checks ran during these samples; the existing
+Lightbringer service remained active.
+
+| Metric | Alpenglow baseline | Rebased PR |
+| --- | ---: | ---: |
+| Median bootstrap elapsed | 1.1533 s | 1.0446 s |
+| Median process peak RSS | 257.0 MiB | 488.7 MiB |
+
+The candidate used **9.4% less elapsed time**, winning all eight paired samples
+(two-sided exact sign test p=0.0078125). **Peak RSS increased about 90%**. RSS is
+measured for the probe process, including its close/reopen/cache initialization;
+it is not a count of allocations or total memory including OS page cache.
+Buffer retention is a possible contributor and needs profiling before making
+claims about its cause or mainnet-scale memory requirements.
+
+Two-directory buffered and one-directory O_DIRECT builds also reopened and
+validated every account against the same digest. These were correctness runs,
+not repeated comparisons of those options. In particular, this does not prove
+O_DIRECT is faster or measure scaling across physical drives. The corpus is
+small (420 MiB compressed), and buffered completion is not a measurement of
+fully fsynced disk throughput. No replay-throughput improvement is established.
+
+## Reproduction artifacts
+
+Local evidence is in
+`/Users/nikolashayes/Desktop/programming/Codex/review-results/pr245-zen5-2026-09-07`:
+`probe.go`, `build.sh`, `run-node.sh`, `measure.sh`, the two failing reproductions,
+`analyze.py`, `summary.json`, and raw `results/` logs. `python3 analyze.py`
+regenerates the summary without executing benchmarks.
+
+The isolated remote test root is
+`/var/tmp/mithril-pr245-20260907-01a07786` and retains sources, binaries, pinned
+archives and databases for follow-up. Both bounded node processes have exited;
+the pre-existing Lightbringer PID remains running. No validator keys were read,
+no stake/vote operation was attempted, and no GitHub review, comment or push
+was made.
+

--- a/docs/reviews/pr245-alpenglow.md
+++ b/docs/reviews/pr245-alpenglow.md
@@ -10,7 +10,7 @@ The PR was rebased in an isolated worktree. Its four commits are retained;
 conflict resolution also ports the layout to Alpenglow's newer AccountsDB.
 The existing checkouts and the upstream PR branch were not changed.
 
-## Findings
+## Findings at the review checkpoint (`18631a3a`)
 
 1. **P1 — Reject duplicate or aliased shard directories before opening writers.**
    `openShardBigFiles` opens an independent truncating writer for every supplied
@@ -43,8 +43,10 @@ The existing checkouts and the upstream PR branch were not changed.
    platform build constraints, with an explicit unsupported-direct-mode error
    on other systems while retaining buffered writes.
 
-The reproductions intentionally fail on this review branch and are kept outside
-its ordinary test suite. This review does not implement the outstanding fixes.
+The reproductions intentionally fail at the review checkpoint and remain in
+the original artifacts. The follow-up fixes are now on this branch; see
+[PR #245 fixes and memory investigation](pr245-fixes.md) for implementation,
+new passing regressions, durability checks, and updated measurements.
 
 ## Rebase integration
 
@@ -125,8 +127,9 @@ The candidate used **9.4% less elapsed time**, winning all eight paired samples
 (two-sided exact sign test p=0.0078125). **Peak RSS increased about 90%**. RSS is
 measured for the probe process, including its close/reopen/cache initialization;
 it is not a count of allocations or total memory including OS page cache.
-Buffer retention is a possible contributor and needs profiling before making
-claims about its cause or mainnet-scale memory requirements.
+Subsequent heap profiles confirmed retained tar and writer buffers as
+contributors. See the follow-up report for measurements after earlier buffer
+release; mainnet-scale memory requirements remain unmeasured.
 
 Two-directory buffered and one-directory O_DIRECT builds also reopened and
 validated every account against the same digest. These were correctness runs,

--- a/docs/reviews/pr245-fixes.md
+++ b/docs/reviews/pr245-fixes.md
@@ -1,0 +1,161 @@
+# PR #245 fixes and memory investigation
+
+Follow-up to [the review](pr245-alpenglow.md), 2026-09-07.
+The comparison checkpoint is `18631a3a` on `7layer/pr245-alpenglow-review`;
+the upstream Alpenglow baseline is `7e4e8af1`. The PR remains rebased in the
+isolated worktree. No upstream branch has been pushed or changed.
+
+## Fixed behavior
+
+- Reject duplicate, symlink-aliased, and overlapping accounts roots and data
+  directories before cleanup, database opening, or truncating shard writers.
+  Resolve nonexistent suffixes through existing parents. Invalid configurations
+  now produce an error and leave existing data intact.
+- Move the O_DIRECT flag into Linux-only code. Buffered snapshot code now
+  cross-builds for Darwin/arm64. Other platforms reject explicit direct I/O
+  before opening a shard writer.
+- Include every shard's coalesced snapshot `accounts/data` in Alpenglow
+  compaction. Find live accounts through the canonical index, retaining their
+  original Slot and values, including unaligned packed appendvec starts,
+  missing final padding and direct-I/O gaps.
+- Release closed disk-writer buffers and drained worker-pool references before
+  shard sorting. Make writer close idempotent and reject writes after close;
+  deferred cleanup also closes writers on bootstrap errors. This drops the
+  writer's references to 32 MiB per disk without forcing a production GC.
+
+## Compaction design and limits
+
+An incremental assessment pass sums live record bytes. Once the dead fraction
+passes the existing threshold, another incremental pass streams live records
+into durable replacement segments. The source remains until all index moves
+are durable. Writes use a 64 KiB copy buffer; each output contains at most
+8,192 records, bounding manifest and index-batch memory independently of the
+size of the source file. Scan and move budgets stop between records; one
+indivisible account can exceed an otherwise empty cycle's budget.
+
+Outputs use manifest kind 3 and `0.<fileId>` physical names, with each account's
+original index Slot preserved. Opening the DB rebuilds the file-ID-to-path map
+from CRC-validated manifests. Later compaction scans only each output's recorded
+key range. The initial snapshot file still requires a walk over the whole
+account index, spread across cycles. This avoids an allocation proportional to
+a snapshot file's size and avoids sequential parsing across packed boundaries.
+
+Ordering is data sync → directory sync → atomic durable manifest → index commit
+(WAL sync, or explicit index flush with WAL disabled). Source removal also
+flushes the index, including after an earlier ambiguous commit error. Reader
+pins protect the switch and unlink. Existing fold/rewind pins apply on every
+cycle and invalidate saved scan progress. Restart or error repeats assessment
+of the remaining references; recovery removes undecided outputs, and decided
+but unreferenced outputs are themselves reclaimable.
+
+Partial evacuation temporarily needs space for both source and copied live
+records. Net bytes reclaimed can therefore be negative before final unlink.
+An in-horizon undo pointer pins the entire source file and can defer reclamation.
+No mainnet-scale compaction throughput or wear claim is made here.
+
+Legacy databases remain readable. Once these new replacement segments have
+been created, an older binary without manifest-kind-3 addressing cannot read
+them; downgrade requires a compatible binary or rebuilding from a snapshot.
+The snapshot coalesced format itself is unchanged.
+
+## Validation
+
+All compilation, tests, profiles and timings ran on `allnodes-ryzen9700x-fra`,
+Go 1.26.4, `GOEXPERIMENT=arenas`. The Mac was used for source edits and analysis.
+Tests used `TMPDIR=/var/tmp` so direct-I/O checks exercised the NVMe filesystem.
+
+Passed:
+
+- AccountsDB, snapshot, config, state and node package suites, race checks, vet,
+  Linux node/probe builds, and Darwin/arm64 snapshot cross-build.
+- Alias rejection without truncation; writer cleanup/readback and repeated close.
+- Two-shard mixed-slot compaction, bounded progress across reopen, cold individual
+  and batch reads, threshold handling, fully dead deletion, and re-compaction
+  of replacement outputs.
+- Invalid index locations and truncated source records fail without unlinking.
+- A new undo pin invalidates partial work; rewind restores original values.
+  Concurrent reads remain correct while sources are evacuated and removed.
+- Error injection and abrupt subprocess exit after data sync, manifest sync,
+  index commit, and immediately before unlink, with the actual index WAL both
+  enabled and disabled. The subprocess tests exit without CloseDb, so shutdown
+  cannot hide a missing durability step. Recovery and readback pass afterward.
+
+The same pinned full snapshot at slot 952183 and incremental through 1021126
+from the review were rebuilt and reopened in single-directory buffered,
+two-directory buffered, and single-directory O_DIRECT modes. All three read
+**5,593,721 accounts** through individual and batch APIs and matched the
+baseline digest:
+`82fecea1d07acf1cbdefe89f8ae4e222a7e416b0eb2bca24f7eb4289f8253f6a`.
+The supplied manifest bank hash also matched; it was not independently recomputed.
+
+The host exposes one NVMe, so two directories test the layout rather than
+physical multi-drive scaling. The earlier bounded node replay attempt remains
+limited by the shared client's lack of version-1 transaction support; these
+fixes do not establish replay-throughput or consensus validation.
+
+## Memory explanation
+
+The new snapshot pipeline reduced cumulative allocation but kept more memory
+live at once. Separate diagnostic builds sampled allocations at 64 KiB and
+forced GC at the unpack/index boundary and after index construction. They were
+not used as elapsed-time evidence.
+
+In the reviewed PR diagnostic run, the pre-index live heap was 133.8 MiB versus
+58.6 MiB for the baseline: roughly **43.3 MiB of retained tar buffers plus
+32 MiB of writer staging buffers** accounted for the difference. After indexing,
+the writer still retained its 32 MiB. Cumulative sampled allocation through
+indexing fell from approximately 5,816 to 4,624 MiB (about 20%). Fewer allocated
+bytes over time does not imply a smaller peak live heap.
+
+The fix removes writer buffers from both phase-boundary profiles. After-index
+retained heap was 56.9 MiB, versus 90.6 MiB in the reviewed PR run. However,
+`sync.Pool` retention is GC-dependent: the fixed diagnostic run retained about
+101.6 MiB of tar buffers before indexing. Releasing worker references does not
+immediately empty the runtime's pool caches. The existing 45.8 MiB stake collector
+is present in both versions. Overlapping read/sort/write work and GC headroom
+also contribute to peak RSS; these profiles do not uniquely attribute every
+byte of the process peak.
+
+## Repeated measurements
+
+Eight interleaved samples per version, reversing the order every pair, with
+CPUs `2-7,10-15`, default Go parallelism, warm pinned archives and fresh output
+DB rebuilds. The timer covers the production bootstrap API. Peak RSS covers
+the probe process including close/reopen and cache initialization; full account
+readback ran separately. No profiling, forced GC, build, race check, or test
+node overlapped these samples. The pre-existing Lightbringer service remained
+running, as in the original review.
+
+| Metric (median) | Alpenglow baseline | Reviewed PR | With fixes |
+| --- | ---: | ---: | ---: |
+| Bootstrap elapsed | 1.1698 s | 1.0689 s | 1.0653 s |
+| Process peak RSS | 248.5 MiB | 503.4 MiB | 469.0 MiB |
+
+The fixed branch is **8.9% faster than the Alpenglow baseline**, winning all
+eight paired samples (two-sided exact sign test p=0.0078125). Its elapsed time
+is indistinguishable from the reviewed PR in this small experiment (four wins,
+p=1). The observed RSS median is 6.8% lower than the reviewed PR, but RSS is noisy
+(six of eight paired wins; sign-test p≈0.289), so this is not an established
+process-peak reduction. The deterministic removal of writer references is
+confirmed by tests and heap profiles. Peak RSS remains substantially higher
+than baseline; the overall memory tradeoff has not been eliminated.
+
+A useful next focused improvement is a byte-bounded tar buffer pool, evaluated
+against throughput and peak memory across multiple corpus sizes. A phase-specific
+peak metric would distinguish unpack pressure from index-pipeline pressure.
+Neither broader optimization nor mainnet sizing is included in these fixes.
+
+## Artifacts
+
+Local task evidence:
+`/Users/nikolashayes/Desktop/programming/Codex/review-results/pr245-fixes-zen5-2026-09-07`.
+`measure.sh` contains the exact repeated-run command, `analyze.py` regenerates
+`summary.json`, and `results/` plus `profiles/` retain raw logs and heap profiles.
+The original diagnostic source generator is retained as `profile-original.py`;
+`profile-fixed.py` applies identical checkpoints to the fixed source.
+
+Remote task root:
+`/var/tmp/mithril-pr245-fixes-20260907`.
+The original reviewed sources/binaries and pinned archives remain in the prior
+review root. The uninstrumented fixed binary and separate diagnostic binary are
+retained. No node service, validator identity or stake configuration was changed.

--- a/nix/modules/shared/lib.nix
+++ b/nix/modules/shared/lib.nix
@@ -66,6 +66,7 @@
       };
       tuning = {
         zstd_decoder_concurrency = cfg.configSchema.tuningZstdDecoderConcurrency;
+        snapshot_index_shards = cfg.configSchema.tuningSnapshotIndexShards;
         max_concurrent_flushers = cfg.configSchema.tuningMaxConcurrentFlushers;
         param_arena_size_mb = cfg.configSchema.tuningParamArenaSizeMb;
         borrowed_account_arena_size = cfg.configSchema.tuningBorrowedAccountArenaSize;

--- a/nix/modules/shared/options.nix
+++ b/nix/modules/shared/options.nix
@@ -344,9 +344,15 @@
         description = "Zstd decoder concurrency.";
       };
 
+      tuningSnapshotIndexShards = lib.mkOption {
+        type = lib.types.ints.between 1 1000;
+        default = 256;
+        description = "Snapshot account-index shard count; more shards reduce per-flusher sort memory when entries are evenly spread.";
+      };
+
       tuningMaxConcurrentFlushers = lib.mkOption {
         type = lib.types.int;
-        default = 16;
+        default = 8;
         description = "Max concurrent flushers.";
       };
 

--- a/pkg/accountsdb/accountsdb.go
+++ b/pkg/accountsdb/accountsdb.go
@@ -29,7 +29,8 @@ import (
 type AccountsDb struct {
 	Index            *pebble.DB
 	BankHashStore    *pebble.DB
-	AcctsDir         string
+	AcctsDir         string // primary shard's accounts dir; its parent is the metadata dir
+	Shards           *Shards
 	LargestFileId    atomic.Uint64
 	VoteAcctCache    otter.Cache[solana.PublicKey, *accounts.Account]
 	CommonAcctsCache otter.Cache[solana.PublicKey, *accounts.Account]
@@ -137,32 +138,46 @@ func NewAccountsIndexPebbleOptions(logger pebble.Logger) *pebble.Options {
 }
 
 func OpenDb(accountsDbDir string) (*AccountsDb, error) {
-	// check for existence of the 'accounts' directory, which holds the appendvecs
-	appendVecsDir := fmt.Sprintf("%s/accounts", accountsDbDir)
-	_, err := os.Stat(appendVecsDir)
+	return OpenDbPaths([]string{accountsDbDir})
+}
+
+func OpenDbPaths(accountsPaths []string) (*AccountsDb, error) {
+	if len(accountsPaths) == 0 {
+		return nil, fmt.Errorf("OpenDb: no accounts paths configured")
+	}
+	// The first path holds all metadata (index, manifest, state); every path
+	// holds an "accounts" dir with that disk's shard data.
+	accountsDbDir := accountsPaths[0]
+
+	// num_shards records the shard count the DB was built with.
+	b, err := os.ReadFile(filepath.Join(accountsDbDir, "num_shards"))
+	legacy := os.IsNotExist(err) && len(accountsPaths) == 1
+	if legacy {
+		b = make([]byte, 8)
+		binary.LittleEndian.PutUint64(b, 1)
+		err = nil
+	}
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("reading num_shards: %w", err)
+	}
+	if len(b) != 8 {
+		return nil, fmt.Errorf("num_shards: expected 8 bytes, got %d", len(b))
+	}
+	numShards := int(binary.LittleEndian.Uint64(b))
+	if numShards != len(accountsPaths) {
+		return nil, fmt.Errorf("configured %d accounts dir(s) but AccountsDB was built with %d shard(s); rebuild required", len(accountsPaths), numShards)
 	}
 
-	// attempt to open largest_file_id file
-	largestFileIdFn := fmt.Sprintf("%s/largest_file_id", accountsDbDir)
-	lfi, err := os.Open(largestFileIdFn)
-	if err != nil {
-		mlog.Log.Infof("failed to open %s\n", largestFileIdFn)
-		return nil, err
+	shardDirs := make([]string, len(accountsPaths))
+	for i, p := range accountsPaths {
+		shardDirs[i] = filepath.Join(p, "accounts")
 	}
 
-	largestFileIdBytes := make([]byte, 8)
-	bytesRead, err := lfi.Read(largestFileIdBytes)
-	if err != nil {
-		mlog.Log.Infof("error reading %s: %s\n", largestFileIdFn, err)
+	// check for existence of the primary 'accounts' directory, which holds the appendvecs
+	appendVecsDir := shardDirs[0]
+	if _, err := os.Stat(appendVecsDir); err != nil {
 		return nil, err
-	} else if bytesRead != 8 {
-		mlog.Log.Infof("error reading %s: expected 8 bytes, got %d\n", largestFileIdFn, bytesRead)
-		return nil, fmt.Errorf("only got %d bytes", bytesRead)
 	}
-
-	largestFileId := binary.LittleEndian.Uint64(largestFileIdBytes)
 
 	indexDir := filepath.Join(accountsDbDir, "mithril_db")
 	db, err := pebble.Open(indexDir, NewAccountsIndexPebbleOptions(silentLogger{}))
@@ -178,7 +193,16 @@ func OpenDb(accountsDbDir string) (*AccountsDb, error) {
 
 	accountsDb := &AccountsDb{
 		IndexWALDisabled: DisableIndexWAL, Index: db, BankHashStore: bankhashDb, AcctsDir: appendVecsDir}
-	accountsDb.LargestFileId.Store(largestFileId)
+	if !legacy {
+		accountsDb.Shards = newShards(shardDirs)
+	}
+	largestBytes, err := os.ReadFile(filepath.Join(accountsDbDir, "largest_file_id"))
+	if err != nil || len(largestBytes) != 8 {
+		bankhashDb.Close()
+		db.Close()
+		return nil, fmt.Errorf("reading largest_file_id: expected 8 bytes: %v", err)
+	}
+	accountsDb.LargestFileId.Store(binary.LittleEndian.Uint64(largestBytes))
 
 	accountsDb.inProgressStoreRequests = list.New()
 	accountsDb.storeRequestChan = make(chan *list.Element)
@@ -579,7 +603,7 @@ func (accountsDb *AccountsDb) readIndexedAccount(pubkey solana.PublicKey) (*acco
 		return nil, fmt.Errorf("unmarshal index entry: %w", err)
 	}
 
-	appendVecFileName := fmt.Sprintf("%s/%d.%d", accountsDb.AcctsDir, acctIdxEntry.Slot, acctIdxEntry.FileId)
+	appendVecFileName := accountsDb.appendVecPath(acctIdxEntry.Slot, acctIdxEntry.FileId)
 
 	appendVecFile, err := os.Open(appendVecFileName)
 	if err != nil {
@@ -746,8 +770,8 @@ func (accountsDb *AccountsDb) storeWorker() {
 }
 
 func (accountsDb *AccountsDb) storeAccountsInternal(accts []*accounts.Account, slot uint64) {
-	fileId := accountsDb.LargestFileId.Add(1)
-	appendVecFileName := fmt.Sprintf("%s/%d.%d", accountsDb.AcctsDir, slot, fileId)
+	fileId := accountsDb.nextFileId(accountsDb.chooseShard())
+	appendVecFileName := accountsDb.appendVecPath(slot, fileId)
 	appendVecFile, err := os.OpenFile(appendVecFileName, os.O_RDWR|os.O_CREATE, 0666)
 	if err != nil {
 		//mlog.Log.Debugf("unable to open appendvec file %s for writing to accountsdb", appendVecFileName)
@@ -784,7 +808,7 @@ func (accountsDb *AccountsDb) storeAccountsInternal(accts []*accounts.Account, s
 			}
 			c.Close()
 
-			existingAppendVecFileName := fmt.Sprintf("%s/%d.%d", accountsDb.AcctsDir, acctIdxEntry.Slot, acctIdxEntry.FileId)
+			existingAppendVecFileName := accountsDb.appendVecPath(acctIdxEntry.Slot, acctIdxEntry.FileId)
 			existingAppendVecFile, err := os.OpenFile(existingAppendVecFileName, os.O_RDWR, 0666)
 			if err != nil {
 				panic(err)
@@ -886,7 +910,7 @@ func (accountsDb *AccountsDb) parallelStoreAccounts(n int, accts []*accounts.Acc
 						return fmt.Errorf("unmarshaling index entry: %w", err)
 					}
 
-					existingAppendVecFileName := fmt.Sprintf("%s/%d.%d", accountsDb.AcctsDir, existingIdxEntry.Slot, existingIdxEntry.FileId)
+					existingAppendVecFileName := accountsDb.appendVecPath(existingIdxEntry.Slot, existingIdxEntry.FileId)
 					existingAppendVecFile, err := os.OpenFile(existingAppendVecFileName, os.O_RDWR, 0666)
 					if err != nil {
 						return fmt.Errorf("open %s: %w", existingAppendVecFileName, err)
@@ -931,8 +955,8 @@ func (accountsDb *AccountsDb) parallelStoreAccounts(n int, accts []*accounts.Acc
 	}
 	newAppendVecGroup := errgroup.Group{}
 	newAppendVecGroup.Go(func() error {
-		fileId := accountsDb.LargestFileId.Add(1)
-		appendVecFileName := fmt.Sprintf("%s/%d.%d", accountsDb.AcctsDir, slot, fileId)
+		fileId := accountsDb.nextFileId(accountsDb.chooseShard())
+		appendVecFileName := accountsDb.appendVecPath(slot, fileId)
 		appendVecFile, err := os.OpenFile(appendVecFileName, os.O_RDWR|os.O_CREATE, 0666)
 		if err != nil {
 			return err

--- a/pkg/accountsdb/accountsdb.go
+++ b/pkg/accountsdb/accountsdb.go
@@ -13,7 +13,6 @@ import (
 	"path/filepath"
 	"runtime/trace"
 	"sync"
-	"sync/atomic"
 
 	"github.com/Overclock-Validator/mithril/pkg/accounts"
 	"github.com/Overclock-Validator/mithril/pkg/addresses"
@@ -28,8 +27,8 @@ import (
 type AccountsDb struct {
 	Index            *pebble.DB
 	BankHashStore    *pebble.DB
-	AcctsDir         string
-	LargestFileId    atomic.Uint64
+	AcctsDir         string // primary shard's accounts dir; its parent is the metadata dir
+	Shards           *Shards
 	VoteAcctCache    otter.Cache[solana.PublicKey, *accounts.Account]
 	CommonAcctsCache otter.Cache[solana.PublicKey, *accounts.Account]
 	ProgramCache     otter.Cache[solana.PublicKey, *ProgramCacheEntry]
@@ -87,33 +86,37 @@ func NewAccountsIndexPebbleOptions(logger pebble.Logger) *pebble.Options {
 	}
 }
 
-func OpenDb(accountsDbDir string) (*AccountsDb, error) {
-	// check for existence of the 'accounts' directory, which holds the appendvecs
-	appendVecsDir := fmt.Sprintf("%s/accounts", accountsDbDir)
-	_, err := os.Stat(appendVecsDir)
+func OpenDb(accountsPaths []string) (*AccountsDb, error) {
+	if len(accountsPaths) == 0 {
+		return nil, fmt.Errorf("OpenDb: no accounts paths configured")
+	}
+	// The first path holds all metadata (index, manifest, state); every path
+	// holds an "accounts" dir with that disk's shard data.
+	accountsDbDir := accountsPaths[0]
+
+	// num_shards records the shard count the DB was built with.
+	b, err := os.ReadFile(filepath.Join(accountsDbDir, "num_shards"))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("reading num_shards: %w", err)
+	}
+	if len(b) != 8 {
+		return nil, fmt.Errorf("num_shards: expected 8 bytes, got %d", len(b))
+	}
+	numShards := int(binary.LittleEndian.Uint64(b))
+	if numShards != len(accountsPaths) {
+		return nil, fmt.Errorf("configured %d accounts dir(s) but AccountsDB was built with %d shard(s); rebuild required", len(accountsPaths), numShards)
 	}
 
-	// attempt to open largest_file_id file
-	largestFileIdFn := fmt.Sprintf("%s/largest_file_id", accountsDbDir)
-	lfi, err := os.Open(largestFileIdFn)
-	if err != nil {
-		mlog.Log.Infof("failed to open %s\n", largestFileIdFn)
-		return nil, err
+	shardDirs := make([]string, len(accountsPaths))
+	for i, p := range accountsPaths {
+		shardDirs[i] = filepath.Join(p, "accounts")
 	}
 
-	largestFileIdBytes := make([]byte, 8)
-	bytesRead, err := lfi.Read(largestFileIdBytes)
-	if err != nil {
-		mlog.Log.Infof("error reading %s: %s\n", largestFileIdFn, err)
+	// check for existence of the primary 'accounts' directory, which holds the appendvecs
+	appendVecsDir := shardDirs[0]
+	if _, err := os.Stat(appendVecsDir); err != nil {
 		return nil, err
-	} else if bytesRead != 8 {
-		mlog.Log.Infof("error reading %s: expected 8 bytes, got %d\n", largestFileIdFn, bytesRead)
-		return nil, fmt.Errorf("only got %d bytes", bytesRead)
 	}
-
-	largestFileId := binary.LittleEndian.Uint64(largestFileIdBytes)
 
 	indexDir := filepath.Join(accountsDbDir, "mithril_db")
 	db, err := pebble.Open(indexDir, NewAccountsIndexPebbleOptions(silentLogger{}))
@@ -127,8 +130,10 @@ func OpenDb(accountsDbDir string) (*AccountsDb, error) {
 		return nil, fmt.Errorf("opening bankhashDir=%s: %w", bankhashDir, err)
 	}
 
-	accountsDb := &AccountsDb{Index: db, BankHashStore: bankhashDb, AcctsDir: appendVecsDir}
-	accountsDb.LargestFileId.Store(largestFileId)
+	// The counter seeds runtime fileId minting; left at 0 so the first minted id
+	// lands in segment 1, just past segment 0 (the coalesced "data" big file).
+	shards := newShards(shardDirs)
+	accountsDb := &AccountsDb{Index: db, BankHashStore: bankhashDb, AcctsDir: appendVecsDir, Shards: shards}
 
 	accountsDb.inProgressStoreRequests = list.New()
 	accountsDb.storeRequestChan = make(chan *list.Element)
@@ -282,7 +287,7 @@ func (accountsDb *AccountsDb) getStoredAccount(slot uint64, pubkey solana.Public
 	}
 	c.Close()
 
-	appendVecFileName := fmt.Sprintf("%s/%d.%d", accountsDb.AcctsDir, acctIdxEntry.Slot, acctIdxEntry.FileId)
+	appendVecFileName := accountsDb.Shards.path(acctIdxEntry.Slot, acctIdxEntry.FileId)
 
 	appendVecFile, err := os.Open(appendVecFileName)
 	if err != nil {
@@ -421,8 +426,8 @@ func (accountsDb *AccountsDb) storeWorker() {
 }
 
 func (accountsDb *AccountsDb) storeAccountsInternal(accts []*accounts.Account, slot uint64) {
-	fileId := accountsDb.LargestFileId.Add(1)
-	appendVecFileName := fmt.Sprintf("%s/%d.%d", accountsDb.AcctsDir, slot, fileId)
+	fileId := accountsDb.Shards.mint(accountsDb.Shards.choose())
+	appendVecFileName := accountsDb.Shards.path(slot, fileId)
 	appendVecFile, err := os.OpenFile(appendVecFileName, os.O_RDWR|os.O_CREATE, 0666)
 	if err != nil {
 		//mlog.Log.Debugf("unable to open appendvec file %s for writing to accountsdb", appendVecFileName)
@@ -459,7 +464,7 @@ func (accountsDb *AccountsDb) storeAccountsInternal(accts []*accounts.Account, s
 			}
 			c.Close()
 
-			existingAppendVecFileName := fmt.Sprintf("%s/%d.%d", accountsDb.AcctsDir, acctIdxEntry.Slot, acctIdxEntry.FileId)
+			existingAppendVecFileName := accountsDb.Shards.path(acctIdxEntry.Slot, acctIdxEntry.FileId)
 			existingAppendVecFile, err := os.OpenFile(existingAppendVecFileName, os.O_RDWR, 0666)
 			if err != nil {
 				panic(err)
@@ -561,7 +566,7 @@ func (accountsDb *AccountsDb) parallelStoreAccounts(n int, accts []*accounts.Acc
 						return fmt.Errorf("unmarshaling index entry: %w", err)
 					}
 
-					existingAppendVecFileName := fmt.Sprintf("%s/%d.%d", accountsDb.AcctsDir, existingIdxEntry.Slot, existingIdxEntry.FileId)
+					existingAppendVecFileName := accountsDb.Shards.path(existingIdxEntry.Slot, existingIdxEntry.FileId)
 					existingAppendVecFile, err := os.OpenFile(existingAppendVecFileName, os.O_RDWR, 0666)
 					if err != nil {
 						return fmt.Errorf("open %s: %w", existingAppendVecFileName, err)
@@ -606,8 +611,8 @@ func (accountsDb *AccountsDb) parallelStoreAccounts(n int, accts []*accounts.Acc
 	}
 	newAppendVecGroup := errgroup.Group{}
 	newAppendVecGroup.Go(func() error {
-		fileId := accountsDb.LargestFileId.Add(1)
-		appendVecFileName := fmt.Sprintf("%s/%d.%d", accountsDb.AcctsDir, slot, fileId)
+		fileId := accountsDb.Shards.mint(accountsDb.Shards.choose())
+		appendVecFileName := accountsDb.Shards.path(slot, fileId)
 		appendVecFile, err := os.OpenFile(appendVecFileName, os.O_RDWR|os.O_CREATE, 0666)
 		if err != nil {
 			return err

--- a/pkg/accountsdb/accountsdb.go
+++ b/pkg/accountsdb/accountsdb.go
@@ -68,11 +68,14 @@ type AccountsDb struct {
 
 	// Batch-fold state (segment.go/fold.go/recovery.go). foldMu serializes
 	// CommitBatch, recovery, rewind, and compaction.
-	foldMu         sync.Mutex
-	lastBatchSeq   uint64        // guarded by foldMu; seeded by RecoverFoldState
-	durableThrough atomic.Uint64 // observability: highest durably folded slot
-	foldHooks      foldTestHooks // test-only crash injection
-	compactCursor  string        // guarded by foldMu; scan resume point across CompactOnce cycles
+	foldMu               sync.Mutex
+	lastBatchSeq         uint64                    // guarded by foldMu; seeded by RecoverFoldState
+	durableThrough       atomic.Uint64             // observability: highest durably folded slot
+	foldHooks            foldTestHooks             // test-only crash injection
+	coalescedFiles       sync.Map                  // file ID -> physical path; immutable compact outputs
+	coalescedScans       map[uint64]*coalescedScan // guarded by foldMu
+	coalescedCompactHook func(string) error        // test-only crash injection
+	compactCursor        string                    // guarded by foldMu; scan resume point across CompactOnce cycles
 
 	// A list of store requests. They are added to the back as they arrive and
 	// removed from the front as they are persisted.
@@ -142,8 +145,8 @@ func OpenDb(accountsDbDir string) (*AccountsDb, error) {
 }
 
 func OpenDbPaths(accountsPaths []string) (*AccountsDb, error) {
-	if len(accountsPaths) == 0 {
-		return nil, fmt.Errorf("OpenDb: no accounts paths configured")
+	if err := ValidateAccountsPaths(accountsPaths); err != nil {
+		return nil, err
 	}
 	// The first path holds all metadata (index, manifest, state); every path
 	// holds an "accounts" dir with that disk's shard data.
@@ -204,6 +207,11 @@ func OpenDbPaths(accountsPaths []string) (*AccountsDb, error) {
 	}
 	accountsDb.LargestFileId.Store(binary.LittleEndian.Uint64(largestBytes))
 
+	if err := accountsDb.loadCoalescedFiles(); err != nil {
+		bankhashDb.Close()
+		db.Close()
+		return nil, err
+	}
 	accountsDb.inProgressStoreRequests = list.New()
 	accountsDb.storeRequestChan = make(chan *list.Element)
 	accountsDb.storeWorkerDone = make(chan struct{})

--- a/pkg/accountsdb/appendvec_test.go
+++ b/pkg/accountsdb/appendvec_test.go
@@ -21,7 +21,7 @@ func TestBuildIndexEntriesDoesNotReadPastSliceLen(t *testing.T) {
 	copy(backing[len(real):], phantom)
 	data := backing[:len(real)] // len excludes phantom; cap and manifest include it.
 
-	pubkeys, entries, _, err := BuildIndexEntriesFromAppendVecs(data, uint64(cap(data)), 7, 9)
+	pubkeys, entries, _, err := BuildIndexEntriesFromAppendVecs(data, uint64(cap(data)), 7, 9, 0)
 	require.NoError(t, err)
 	require.Equal(t, []solana.PublicKey{realKey}, pubkeys)
 	require.Len(t, entries, 1)
@@ -37,7 +37,7 @@ func TestBuildIndexEntriesBoundsOversizedManifestByDataLen(t *testing.T) {
 	var pubkeys []solana.PublicKey
 	require.NotPanics(t, func() {
 		var err error
-		pubkeys, _, _, err = BuildIndexEntriesFromAppendVecs(data, uint64(len(data)+hdrLen), 8, 10)
+		pubkeys, _, _, err = BuildIndexEntriesFromAppendVecs(data, uint64(len(data)+hdrLen), 8, 10, 0)
 		require.NoError(t, err)
 	})
 	require.Equal(t, []solana.PublicKey{key}, pubkeys)
@@ -54,7 +54,7 @@ func TestBuildIndexEntriesStopsAtDefaultZeroLamportTerminator(t *testing.T) {
 	binary.LittleEndian.PutUint64(terminator[dataLenOffset:dataLenOffset+8], ^uint64(0))
 	data := append(append(append([]byte{}, first...), terminator...), afterTerminator...)
 
-	pubkeys, entries, _, err := BuildIndexEntriesFromAppendVecs(data, uint64(len(data)), 12, 13)
+	pubkeys, entries, _, err := BuildIndexEntriesFromAppendVecs(data, uint64(len(data)), 12, 13, 0)
 	require.NoError(t, err)
 	require.Equal(t, []solana.PublicKey{firstKey}, pubkeys)
 	require.Len(t, entries, 1)
@@ -67,7 +67,7 @@ func TestBuildIndexEntriesTerminatorRequiresDefaultKeyAndZeroLamports(t *testing
 	zeroLamportAccount := marshalAppendVecTestAccount(t, zeroLamportKey, 0, []byte("tombstone"))
 	data := append(defaultKeyAccount, zeroLamportAccount...)
 
-	pubkeys, entries, _, err := BuildIndexEntriesFromAppendVecs(data, uint64(len(data)), 18, 19)
+	pubkeys, entries, _, err := BuildIndexEntriesFromAppendVecs(data, uint64(len(data)), 18, 19, 0)
 	require.NoError(t, err)
 	require.Equal(t, []solana.PublicKey{defaultKey, zeroLamportKey}, pubkeys)
 	require.Len(t, entries, 2)
@@ -80,7 +80,7 @@ func TestBuildIndexEntriesRejectsTruncatedAccountData(t *testing.T) {
 	copy(data[pubkeyOffset:pubkeyOffset+32], key[:])
 	binary.LittleEndian.PutUint64(data[lamportsOffset:lamportsOffset+8], 1)
 
-	pubkeys, entries, stakeEntries, err := BuildIndexEntriesFromAppendVecs(data, uint64(len(data)), 14, 15)
+	pubkeys, entries, stakeEntries, err := BuildIndexEntriesFromAppendVecs(data, uint64(len(data)), 14, 15, 0)
 	require.ErrorContains(t, err, "truncated appendvec account data")
 	assert.Nil(t, pubkeys)
 	assert.Nil(t, entries)
@@ -92,7 +92,7 @@ func TestBuildIndexEntriesAcceptsFinalAccountWithoutAlignmentPadding(t *testing.
 	encoded := marshalAppendVecTestAccount(t, key, 77, []byte{1, 2, 3})
 	data := encoded[: hdrLen+3 : hdrLen+3]
 
-	pubkeys, entries, _, err := BuildIndexEntriesFromAppendVecs(data, uint64(len(encoded)), 16, 17)
+	pubkeys, entries, _, err := BuildIndexEntriesFromAppendVecs(data, uint64(len(encoded)), 16, 17, 0)
 	require.NoError(t, err)
 	require.Equal(t, []solana.PublicKey{key}, pubkeys)
 	require.Len(t, entries, 1)

--- a/pkg/accountsdb/batch.go
+++ b/pkg/accountsdb/batch.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"math"
 	"os"
-	"path/filepath"
 	"runtime"
 	"sort"
 	"sync"
@@ -253,7 +252,7 @@ func (db *AccountsDb) getAccountsBatchWithStats(ctx context.Context, slot uint64
 	err = runBatchWorkers(ctx, len(chunks), func(job int) error {
 		chunk := chunks[job]
 		jobStats := &chunkStats[job]
-		path := filepath.Join(db.AcctsDir, fmt.Sprintf("%d.%d", chunk.id.slot, chunk.id.fileID))
+		path := db.appendVecPath(chunk.id.slot, chunk.id.fileID)
 		file, openErr := os.Open(path)
 		if openErr != nil {
 			jobStats.openFailures++

--- a/pkg/accountsdb/compact.go
+++ b/pkg/accountsdb/compact.go
@@ -268,7 +268,7 @@ func (db *AccountsDb) compactFile(c compactCandidate, minDeadFraction float64) (
 		return false, 0, err
 	}
 
-	pubkeys, idxEntries, _, err := BuildIndexEntriesFromAppendVecs(data, uint64(len(data)), c.slot, c.fileId)
+	pubkeys, idxEntries, _, err := BuildIndexEntriesFromAppendVecs(data, uint64(len(data)), c.slot, c.fileId, 0)
 	if err != nil {
 		return false, 0, err
 	}
@@ -317,7 +317,7 @@ func (db *AccountsDb) compactFile(c compactCandidate, minDeadFraction float64) (
 
 	// Allocate the output fileId, persisting the high-water mark before the
 	// first data byte (I7 — a crash must never lead to fileId reuse).
-	newFileId := db.LargestFileId.Add(1)
+	newFileId := db.nextFileId(0)
 	if err := db.persistLargestFileId(); err != nil {
 		return false, 0, err
 	}

--- a/pkg/accountsdb/compact.go
+++ b/pkg/accountsdb/compact.go
@@ -71,7 +71,7 @@ type CompactStats struct {
 	FilesCompacted    int
 	FilesDeleted      int // fully-dead fast path (no bytes moved)
 	LiveBytesMoved    int64
-	BytesReclaimed    int64 // source bytes freed (compacted + deleted)
+	BytesReclaimed    int64 // net bytes freed; may be negative during bounded evacuation
 }
 
 const (
@@ -82,6 +82,8 @@ const (
 
 type compactCandidate struct {
 	name         string
+	path         string
+	coalesced    bool
 	slot         uint64
 	fileId       uint64
 	size         int64
@@ -120,6 +122,9 @@ func (db *AccountsDb) CompactOnce(cfg CompactionConfig) (CompactStats, error) {
 		return stats, err
 	}
 
+	for id := range pinned {
+		delete(db.coalescedScans, id)
+	}
 	bootstrapHigh := db.bootstrapHighFileId()
 	entries, err := os.ReadDir(db.AcctsDir)
 	if err != nil {
@@ -147,8 +152,28 @@ func (db *AccountsDb) CompactOnce(cfg CompactionConfig) (CompactStats, error) {
 			continue
 		}
 		candidates = append(candidates, compactCandidate{
-			name: name, slot: slot, fileId: fileId, size: info.Size(), manifestPath: mpath,
+			name: name, path: filepath.Join(db.AcctsDir, name), slot: slot, fileId: fileId, size: info.Size(), manifestPath: mpath,
 		})
+	}
+	for i := range candidates {
+		_, candidates[i].coalesced = db.coalescedFiles.Load(candidates[i].fileId)
+	}
+	if db.Shards != nil {
+		for i, dir := range db.Shards.dirs {
+			id := uint64(i)
+			if _, ok := pinned[id]; ok {
+				continue
+			}
+			path := filepath.Join(dir, "data")
+			info, e := os.Stat(path)
+			if os.IsNotExist(e) {
+				continue
+			}
+			if e != nil {
+				return stats, e
+			}
+			candidates = append(candidates, compactCandidate{name: fmt.Sprintf("snapshot-%020d", id), path: path, fileId: id, size: info.Size(), coalesced: true})
+		}
 	}
 	// Deterministic order + resume after the previous cycle's cursor so large
 	// directories make steady progress instead of rescanning the same prefix.
@@ -172,6 +197,22 @@ func (db *AccountsDb) CompactOnce(cfg CompactionConfig) (CompactStats, error) {
 			break
 		}
 		db.compactCursor = c.name
+		if c.coalesced {
+			stats.CandidatesScanned++
+			r, e := db.compactCoalesced(c, cfg.MaxScanBytesPerCycle-scannedBytes, cfg.MaxMoveBytesPerCycle-stats.LiveBytesMoved, cfg.MinDeadFraction, stats.LiveBytesMoved == 0)
+			if e != nil {
+				return stats, fmt.Errorf("accountsdb: compact %s: %w", c.name, e)
+			}
+			scannedBytes += r.scanned
+			stats.LiveBytesMoved += r.moved
+			stats.BytesReclaimed += r.freed - r.moved
+			if r.moved > 0 {
+				stats.FilesCompacted++
+			} else if r.deleted {
+				stats.FilesDeleted++
+			}
+			continue
+		}
 		scannedBytes += c.size
 		stats.CandidatesScanned++
 
@@ -443,6 +484,9 @@ func removeSourceFiles(acctsDir, srcPath, manifestPath string) error {
 }
 
 func humanBytes(n int64) string {
+	if n < 0 {
+		return "-" + humanBytes(-n)
+	}
 	switch {
 	case n >= 1<<30:
 		return fmt.Sprintf("%.1fGiB", float64(n)/float64(1<<30))

--- a/pkg/accountsdb/compact_coalesced.go
+++ b/pkg/accountsdb/compact_coalesced.go
@@ -1,0 +1,323 @@
+package accountsdb
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"hash"
+	"hash/crc32"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/cockroachdb/pebble"
+)
+
+// Packed snapshot appendvecs may have unaligned starts, no final padding and
+// O_DIRECT gaps. The canonical index, not a sequential parser, identifies live
+// records. A bounded assessment pass measures live bytes; a second pass moves
+// them in durable batches. Only then may the source be unlinked.
+//
+// The cursor is deliberately volatile. Restart/error simply repeats assessment
+// of the remaining references. After each batch, either the old file is still
+// authoritative or the new data+manifest+index are durable; both files coexist
+// until evacuation finishes. Interrupted work therefore needs no new redo log.
+// Rewind pins are checked every cycle, and invalidate any in-progress scan.
+type coalescedScan struct {
+	cursor    []byte
+	liveBytes int64
+	moving    bool
+}
+
+type coalescedCompactResult struct {
+	scanned, moved, freed int64
+	deleted               bool
+}
+
+const maxCoalescedBatchRecords = 8192 // bounds manifest and Pebble batch memory
+
+// Coalesced compaction outputs keep each account's index Slot unchanged.
+// Their physical filename is 0.<id>; the manifest identifies that addressing
+// mode. Ordinary fold/compact segments retain their existing addressing.
+func (db *AccountsDb) loadCoalescedFiles() error {
+	entries, err := os.ReadDir(db.AcctsDir)
+	if err != nil {
+		return err
+	}
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), segManifestSuffix) {
+			continue
+		}
+		path := filepath.Join(db.AcctsDir, e.Name())
+		hdr, err := readManifestHeader(path)
+		if err != nil || hdr.Kind != ManifestKindCoalescedCompact {
+			continue
+		}
+		m, err := readCoalescedManifest(path)
+		if err != nil {
+			return err
+		}
+		if m.ThroughSlot != 0 || e.Name() != SegmentDataName(0, m.FileId)+segManifestSuffix {
+			return fmt.Errorf("invalid coalesced compact manifest %s", path)
+		}
+		db.coalescedFiles.Store(m.FileId, filepath.Join(db.AcctsDir, SegmentDataName(0, m.FileId)))
+	}
+	return nil
+}
+
+func (db *AccountsDb) compactCoalesced(c compactCandidate, scanBudget, moveBudget int64, minDead float64, allowOversizedRecord bool) (res coalescedCompactResult, err error) {
+	if db.coalescedScans == nil {
+		db.coalescedScans = make(map[uint64]*coalescedScan)
+	}
+	s := db.coalescedScans[c.fileId]
+	if s == nil {
+		s = &coalescedScan{}
+		db.coalescedScans[c.fileId] = s
+	}
+	defer func() {
+		if err != nil {
+			delete(db.coalescedScans, c.fileId)
+		}
+	}()
+	src, err := os.Open(c.path)
+	if err != nil {
+		return res, err
+	}
+	defer src.Close()
+	var opts *pebble.IterOptions
+	if c.manifestPath != "" {
+		m, e := readCoalescedManifest(c.manifestPath)
+		if e != nil {
+			return res, e
+		}
+		// Each output contains a consecutive, sorted range of keys from the
+		// source scan. Restrict future scans to that range, instead of scanning
+		// the full account index once per small replacement segment.
+		if len(m.Records) > 0 {
+			opts = &pebble.IterOptions{LowerBound: m.Records[0].Pubkey[:], UpperBound: append(m.Records[len(m.Records)-1].Pubkey[:], 0)}
+		}
+	}
+	it, err := db.Index.NewIter(opts)
+	if err != nil {
+		return res, err
+	}
+	defer it.Close()
+	valid := it.First()
+	if s.cursor != nil {
+		valid = it.SeekGE(s.cursor)
+		if valid && bytes.Equal(it.Key(), s.cursor) {
+			valid = it.Next()
+		}
+	}
+	var out *coalescedOutput
+	defer func() {
+		if out != nil {
+			out.file.Close()
+		}
+	}()
+	var header [hdrLen]byte
+	copyBuf := make([]byte, 64<<10)
+	for valid {
+		cost := int64(len(it.Key()) + len(it.Value()))
+		if res.scanned > 0 && res.scanned+cost > scanBudget {
+			break
+		}
+		res.scanned += cost
+		key := it.Key()
+		if len(key) == 32 {
+			entry, e := UnmarshalAcctIdxEntryValue(it.Value())
+			if e != nil {
+				return res, e
+			}
+			if entry.FileId == c.fileId {
+				if res.scanned > cost && res.scanned+hdrLen > scanBudget {
+					break
+				}
+				if entry.Offset > uint64(c.size) || uint64(c.size)-entry.Offset < hdrLen {
+					return res, fmt.Errorf("indexed record outside %s at %d", c.path, entry.Offset)
+				}
+				if _, e = src.ReadAt(header[:], int64(entry.Offset)); e != nil {
+					return res, e
+				}
+				res.scanned += hdrLen
+				if !bytes.Equal(header[pubkeyOffset:pubkeyOffset+32], key) {
+					return res, fmt.Errorf("indexed pubkey mismatch in %s at %d", c.path, entry.Offset)
+				}
+				dataLen := binary.LittleEndian.Uint64(header[dataLenOffset : dataLenOffset+8])
+				if dataLen > uint64(c.size)-entry.Offset-hdrLen {
+					return res, fmt.Errorf("truncated indexed record in %s at %d", c.path, entry.Offset)
+				}
+				if !s.moving {
+					s.liveBytes += int64(hdrLen) + int64(dataLen)
+				} else {
+					padded := int64(hdrLen) + int64((dataLen+7)&^uint64(7))
+					// Budgets stop between records. Like legacy compaction, one indivisible
+					// record may exceed a very small configured budget; it never requires
+					// an allocation proportional to account data size.
+					if (res.moved+padded > moveBudget && (out != nil || !allowOversizedRecord)) || (out != nil && (res.scanned+int64(dataLen) > scanBudget || len(out.records) >= maxCoalescedBatchRecords)) {
+						break
+					}
+					if out == nil {
+						out, e = db.newCoalescedOutput()
+						if e != nil {
+							return res, e
+						}
+					}
+					var pk [32]byte
+					copy(pk[:], key)
+					rec := ManifestRecord{Pubkey: pk, OwnerSlot: entry.Slot, Offset: uint64(res.moved)}
+					if _, e = out.writer.Write(header[:]); e != nil {
+						return res, e
+					}
+					if _, e = io.CopyBuffer(out.writer, io.NewSectionReader(src, int64(entry.Offset)+hdrLen, int64(dataLen)), copyBuf); e != nil {
+						return res, e
+					}
+					var padding [7]byte
+					if _, e = out.writer.Write(padding[:(8-dataLen%8)%8]); e != nil {
+						return res, e
+					}
+					out.records = append(out.records, rec)
+					res.moved += padded
+					res.scanned += int64(dataLen)
+				}
+			}
+		}
+		s.cursor = append(s.cursor[:0], key...)
+		valid = it.Next()
+		if res.scanned >= scanBudget || (s.moving && res.moved >= moveBudget) {
+			break
+		}
+	}
+	if e := it.Error(); e != nil {
+		return res, e
+	}
+	exhausted := !valid
+	if out != nil {
+		if e := db.commitCoalescedOutput(out, res.moved); e != nil {
+			return res, e
+		}
+	}
+	if !exhausted {
+		return res, nil
+	}
+	if !s.moving && s.liveBytes > 0 {
+		if 1-float64(s.liveBytes)/float64(c.size) < minDead {
+			delete(db.coalescedScans, c.fileId)
+			return res, nil
+		}
+		s.moving = true
+		s.cursor = nil
+		return res, nil
+	}
+	// No live references were found, or every remaining reference was moved.
+	// A fold cannot reintroduce references to this immutable source. An allowed
+	// rewind that could do so would pin the source and reset the scan next cycle.
+	db.appendVecReadMu.Lock()
+	defer db.appendVecReadMu.Unlock()
+	// Also covers a previous ambiguous Commit/Sync error: never unlink using
+	// an in-memory index view whose durability has not been re-established.
+	if e := db.Index.Flush(); e != nil {
+		return res, e
+	}
+	if e := db.coalescedCompactStage("before-unlink"); e != nil {
+		return res, e
+	}
+	if e := removeSourceFiles(filepath.Dir(c.path), c.path, c.manifestPath); e != nil {
+		return res, e
+	}
+	db.coalescedFiles.Delete(c.fileId)
+	delete(db.coalescedScans, c.fileId)
+	res.deleted = true
+	res.freed = c.size
+	return res, nil
+}
+
+type coalescedOutput struct {
+	file    *os.File
+	writer  io.Writer
+	crc     hash.Hash32
+	id      uint64
+	records []ManifestRecord
+}
+
+func (db *AccountsDb) newCoalescedOutput() (*coalescedOutput, error) {
+	id := db.nextFileId(0)
+	if err := db.persistLargestFileId(); err != nil {
+		return nil, err
+	}
+	f, err := os.OpenFile(filepath.Join(db.AcctsDir, SegmentDataName(0, id)), os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0644)
+	if err != nil {
+		return nil, err
+	}
+	crc := crc32.NewIEEE()
+	return &coalescedOutput{file: f, writer: io.MultiWriter(f, crc), crc: crc, id: id}, nil
+}
+
+func (db *AccountsDb) commitCoalescedOutput(out *coalescedOutput, size int64) error {
+	if err := out.file.Sync(); err != nil {
+		return err
+	}
+	if err := fsyncDir(db.AcctsDir); err != nil {
+		return err
+	}
+	if err := db.coalescedCompactStage("after-data"); err != nil {
+		return err
+	}
+	m := &SegmentManifest{Version: segManifestVersion, Kind: ManifestKindCoalescedCompact, FileId: out.id, DataLen: uint64(size), DataCRC: out.crc.Sum32(), Records: out.records}
+	if err := WriteSegmentManifest(db.AcctsDir, m); err != nil {
+		return err
+	}
+	if err := db.coalescedCompactStage("after-manifest"); err != nil {
+		return err
+	}
+	db.appendVecReadMu.Lock()
+	defer db.appendVecReadMu.Unlock()
+	db.coalescedFiles.Store(out.id, out.file.Name())
+	batch := db.Index.NewBatch()
+	defer batch.Close()
+	var b [24]byte
+	for _, r := range out.records {
+		(&AccountIndexEntry{Slot: r.OwnerSlot, FileId: out.id, Offset: r.Offset}).Marshal(&b)
+		if err := batch.Set(r.Pubkey[:], b[:], nil); err != nil {
+			return err
+		}
+	}
+	opts := pebble.Sync
+	if db.IndexWALDisabled {
+		opts = pebble.NoSync
+	}
+	if err := batch.Commit(opts); err != nil {
+		return err
+	}
+	if db.IndexWALDisabled {
+		if err := db.Index.Flush(); err != nil {
+			return err
+		}
+	}
+	return db.coalescedCompactStage("after-index")
+}
+
+func (db *AccountsDb) coalescedCompactStage(stage string) error {
+	if db.coalescedCompactHook != nil {
+		return db.coalescedCompactHook(stage)
+	}
+	return nil
+}
+
+// This manifest kind is written only by the bounded coalesced compactor.
+func readCoalescedManifest(path string) (*SegmentManifest, error) {
+	m, err := ReadSegmentManifest(path)
+	if err != nil {
+		return nil, err
+	}
+	if m.Kind != ManifestKindCoalescedCompact || m.ThroughSlot != 0 || len(m.Records) == 0 || len(m.Records) > maxCoalescedBatchRecords {
+		return nil, fmt.Errorf("invalid coalesced compact manifest %s", path)
+	}
+	for i := 1; i < len(m.Records); i++ {
+		if bytes.Compare(m.Records[i-1].Pubkey[:], m.Records[i].Pubkey[:]) >= 0 {
+			return nil, fmt.Errorf("unsorted coalesced compact manifest %s", path)
+		}
+	}
+	return m, nil
+}

--- a/pkg/accountsdb/compact_coalesced_test.go
+++ b/pkg/accountsdb/compact_coalesced_test.go
@@ -1,0 +1,349 @@
+package accountsdb
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/Overclock-Validator/mithril/pkg/accounts"
+	"github.com/cockroachdb/pebble"
+	"github.com/gagliardetto/solana-go"
+	"github.com/stretchr/testify/require"
+)
+
+func newCoalescedTestDb(t *testing.T, shards int) (*AccountsDb, []string, []*accounts.Account) {
+	t.Helper()
+	paths := make([]string, shards)
+	for i := range paths {
+		paths[i] = t.TempDir()
+		require.NoError(t, os.Mkdir(filepath.Join(paths[i], "accounts"), 0755))
+	}
+	var b [8]byte
+	for name, n := range map[string]uint64{"num_shards": uint64(shards), "largest_file_id": uint64(shards - 1), "bootstrap_high_file_id": uint64(shards - 1)} {
+		binary.LittleEndian.PutUint64(b[:], n)
+		require.NoError(t, os.WriteFile(filepath.Join(paths[0], name), b[:], 0644))
+	}
+	db, err := OpenDbPaths(paths)
+	require.NoError(t, err)
+	db.RootedDurable = true
+	db.InitCaches()
+	var live []*accounts.Account
+	for shard := range paths {
+		var data bytes.Buffer
+		for j := 0; j < 3; j++ {
+			// Nonzero dead bytes, O_DIRECT gaps, unaligned starts, and no final
+			// padding: sequential appendvec parsing cannot recover these boundaries.
+			data.Write(bytes.Repeat([]byte{0xab}, 4096+j))
+			a := foldAcct(byte(1+shard*3+j), uint64(100+j), []byte{byte(j), 1, 2, 3, 4})
+			a.Slot = uint64(70 + j)
+			off := uint64(data.Len())
+			var record bytes.Buffer
+			require.NoError(t, (&AppendVecAccount{Pubkey: a.Key, Lamports: a.Lamports, Owner: a.Owner, RentEpoch: a.RentEpoch, DataLen: uint64(len(a.Data)), Data: a.Data}).Marshal(&record))
+			data.Write(record.Bytes()[:hdrLen+len(a.Data)])
+			var idx [24]byte
+			(&AccountIndexEntry{Slot: a.Slot, FileId: uint64(shard), Offset: off}).Marshal(&idx)
+			require.NoError(t, db.Index.Set(a.Key[:], idx[:], pebble.NoSync))
+			live = append(live, a)
+		}
+		require.NoError(t, os.WriteFile(filepath.Join(paths[shard], "accounts", "data"), data.Bytes(), 0644))
+	}
+	require.NoError(t, db.Index.Flush())
+	return db, paths, live
+}
+
+func reopenCoalescedTestDb(t *testing.T, db *AccountsDb, paths []string) *AccountsDb {
+	t.Helper()
+	db.CloseDb()
+	re, err := OpenDbPaths(paths)
+	require.NoError(t, err)
+	re.RootedDurable = true
+	re.InitCaches()
+	_, err = re.RecoverFoldState()
+	require.NoError(t, err)
+	return re
+}
+
+func checkCoalescedAccounts(t *testing.T, db *AccountsDb, live []*accounts.Account) {
+	t.Helper()
+	keys := make([]solana.PublicKey, len(live))
+	for i, a := range live {
+		keys[i] = a.Key
+		require.Equal(t, a, mustColdRead(t, db, 100, a.Key))
+	}
+	// Force actual batch reads too, after the individual cold reads populated caches.
+	for _, k := range keys {
+		db.CommonAcctsCache.Delete(k)
+		db.VoteAcctCache.Delete(k)
+	}
+	got, err := db.GetAccountsBatch(context.Background(), 100, keys)
+	require.NoError(t, err)
+	require.Equal(t, live, got)
+}
+
+func coalescedSourcesExist(paths []string) bool {
+	for _, p := range paths {
+		if _, err := os.Stat(filepath.Join(p, "accounts", "data")); err == nil {
+			return true
+		}
+	}
+	return false
+}
+
+func TestCoalescedCompactionBoundedReopen(t *testing.T) {
+	for _, walOff := range []bool{false, true} {
+		t.Run(fmt.Sprintf("wal-off=%v", walOff), func(t *testing.T) {
+			old := DisableIndexWAL
+			DisableIndexWAL = walOff
+			defer func() { DisableIndexWAL = old }()
+			db, paths, live := newCoalescedTestDb(t, 2)
+			defer func() { db.CloseDb() }()
+			checkCoalescedAccounts(t, db, live)
+			cfg := CompactionConfig{MinDeadFraction: 0.5, MaxMoveBytesPerCycle: 160, MaxScanBytesPerCycle: 300}
+			var reclaimed int64
+			cycles := 0
+			reopened := false
+			for coalescedSourcesExist(paths) && cycles < 200 {
+				stats, err := db.CompactOnce(cfg)
+				require.NoError(t, err)
+				require.LessOrEqual(t, stats.LiveBytesMoved, int64(144), "one indivisible record per move budget")
+				reclaimed += stats.BytesReclaimed
+				cycles++
+				checkCoalescedAccounts(t, db, live)
+				if stats.LiveBytesMoved > 0 && !reopened {
+					require.True(t, coalescedSourcesExist(paths), "partial evacuation retains the source")
+					db = reopenCoalescedTestDb(t, db, paths)
+					reopened = true
+				}
+			}
+			require.Less(t, cycles, 200, "bounded scans must make progress")
+			require.True(t, reopened)
+			require.Positive(t, reclaimed)
+			require.Greater(t, cycles, 3)
+			db = reopenCoalescedTestDb(t, db, paths)
+			checkCoalescedAccounts(t, db, live)
+			// Compacted files are themselves candidates after their records die.
+			for _, a := range live {
+				require.NoError(t, db.Index.Delete(a.Key[:], pebble.NoSync))
+			}
+			require.NoError(t, db.Index.Flush())
+			for i := 0; i < 100; i++ {
+				_, err := db.CompactOnce(cfg)
+				require.NoError(t, err)
+			}
+			count := 0
+			db.coalescedFiles.Range(func(_, _ any) bool { count++; return true })
+			require.Zero(t, count)
+		})
+	}
+}
+
+func TestCoalescedCompactionThresholdAndFullyDead(t *testing.T) {
+	db, paths, live := newCoalescedTestDb(t, 2)
+	defer db.CloseDb()
+	for i := 0; i < 3; i++ {
+		stats, err := db.CompactOnce(CompactionConfig{MinDeadFraction: 0.999})
+		require.NoError(t, err)
+		require.Zero(t, stats.LiveBytesMoved)
+		require.Zero(t, stats.FilesDeleted)
+	}
+	checkCoalescedAccounts(t, db, live)
+	for _, a := range live {
+		require.NoError(t, db.Index.Delete(a.Key[:], pebble.NoSync))
+	}
+	stats, err := db.CompactOnce(CompactionConfig{})
+	require.NoError(t, err)
+	require.Equal(t, 2, stats.FilesDeleted)
+	require.False(t, coalescedSourcesExist(paths))
+}
+
+func TestCoalescedCompactionFailureRecovery(t *testing.T) {
+	for _, walOff := range []bool{false, true} {
+		for _, stage := range []string{"after-data", "after-manifest", "after-index", "before-unlink"} {
+			t.Run(fmt.Sprintf("wal-off=%v/%s", walOff, stage), func(t *testing.T) {
+				old := DisableIndexWAL
+				DisableIndexWAL = walOff
+				defer func() { DisableIndexWAL = old }()
+				db, paths, live := newCoalescedTestDb(t, 1)
+				defer func() { db.CloseDb() }()
+				boom := errors.New("injected compaction failure")
+				db.coalescedCompactHook = func(s string) error {
+					if s == stage {
+						return boom
+					}
+					return nil
+				}
+				cfg := CompactionConfig{MinDeadFraction: 0.5}
+				_, err := db.CompactOnce(cfg)
+				require.NoError(t, err) // assessment
+				_, err = db.CompactOnce(cfg)
+				require.ErrorIs(t, err, boom)
+				require.True(t, coalescedSourcesExist(paths))
+				checkCoalescedAccounts(t, db, live)
+				db = reopenCoalescedTestDb(t, db, paths)
+				checkCoalescedAccounts(t, db, live)
+				for i := 0; i < 10 && coalescedSourcesExist(paths); i++ {
+					_, err = db.CompactOnce(cfg)
+					require.NoError(t, err)
+				}
+				require.False(t, coalescedSourcesExist(paths))
+				checkCoalescedAccounts(t, db, live)
+			})
+		}
+	}
+}
+
+func TestCoalescedCompactionPinsInvalidateProgress(t *testing.T) {
+	db, paths, live := newCoalescedTestDb(t, 1)
+	defer func() { db.CloseDb() }()
+	cfg := CompactionConfig{MinDeadFraction: 0.5, RewindHorizonBatches: 1}
+	commitTestBatch(t, db, 101, foldAcct(9, 9, []byte("boundary")))
+	_, err := db.CompactOnce(cfg)
+	require.NoError(t, err)
+	require.NotNil(t, db.coalescedScans[0])
+	commitTestBatch(t, db, 102, foldAcct(1, 999, []byte("changed")))
+	_, err = db.CompactOnce(cfg)
+	require.NoError(t, err)
+	require.Nil(t, db.coalescedScans[0], "new undo pin invalidates an earlier scan")
+	require.True(t, coalescedSourcesExist(paths))
+	_, err = db.RewindToBatchBoundary(101)
+	require.NoError(t, err)
+	checkCoalescedAccounts(t, db, live)
+	// Re-establish a head that does not pin the source and complete evacuation.
+	commitTestBatch(t, db, 103, foldAcct(9, 10, []byte("next")))
+	for i := 0; i < 10 && coalescedSourcesExist(paths); i++ {
+		_, err = db.CompactOnce(cfg)
+		require.NoError(t, err)
+	}
+	require.False(t, coalescedSourcesExist(paths))
+	db = reopenCoalescedTestDb(t, db, paths)
+	checkCoalescedAccounts(t, db, live)
+}
+
+func TestCoalescedCompactionRejectsInvalidIndex(t *testing.T) {
+	for _, kind := range []string{"outside", "wrong-key", "truncated"} {
+		t.Run(kind, func(t *testing.T) {
+			db, paths, live := newCoalescedTestDb(t, 1)
+			defer db.CloseDb()
+			if kind == "truncated" {
+				require.NoError(t, os.Truncate(filepath.Join(paths[0], "accounts", "data"), 4096+hdrLen+1))
+			} else {
+				offset := uint64(0)
+				if kind == "outside" {
+					offset = 1 << 40
+				}
+				var b [24]byte
+				(&AccountIndexEntry{Slot: 70, FileId: 0, Offset: offset}).Marshal(&b)
+				require.NoError(t, db.Index.Set(live[0].Key[:], b[:], pebble.NoSync))
+			}
+			_, err := db.CompactOnce(CompactionConfig{})
+			require.Error(t, err)
+			require.True(t, coalescedSourcesExist(paths))
+		})
+	}
+}
+
+func TestCoalescedCompactionConcurrentReaders(t *testing.T) {
+	db, paths, live := newCoalescedTestDb(t, 2)
+	defer db.CloseDb()
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+	errs := make(chan error, 1)
+	keys := []solana.PublicKey{live[0].Key, live[3].Key}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			for _, k := range keys {
+				db.CommonAcctsCache.Delete(k)
+			}
+			got, err := db.GetAccountsBatch(context.Background(), 100, keys)
+			if err == nil && (len(got) != 2 || !bytes.Equal(got[0].Data, live[0].Data) || !bytes.Equal(got[1].Data, live[3].Data)) {
+				err = errors.New("changed account data")
+			}
+			if err != nil {
+				errs <- err
+				return
+			}
+		}
+	}()
+	for i := 0; i < 30 && coalescedSourcesExist(paths); i++ {
+		_, err := db.CompactOnce(CompactionConfig{MinDeadFraction: 0.5, MaxMoveBytesPerCycle: 150})
+		require.NoError(t, err)
+	}
+	close(stop)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+	require.False(t, coalescedSourcesExist(paths))
+}
+
+// Exit without CloseDb to test the actual on-disk commit boundaries. In
+// particular, a graceful test teardown must not flush a WAL-disabled index
+// and accidentally make an unsafe compaction appear durable.
+func TestCoalescedCompactionProcessExit(t *testing.T) {
+	if root := os.Getenv("MITHRIL_TEST_COMPACT_ROOT"); root != "" {
+		DisableIndexWAL = os.Getenv("MITHRIL_TEST_COMPACT_WAL_OFF") == "true"
+		db, err := OpenDbPaths([]string{root})
+		if err != nil {
+			t.Fatal(err)
+		}
+		db.RootedDurable = true
+		db.coalescedCompactHook = func(stage string) error {
+			if stage == os.Getenv("MITHRIL_TEST_COMPACT_STAGE") {
+				os.Exit(93)
+			}
+			return nil
+		}
+		for i := 0; i < 3; i++ {
+			if _, err = db.CompactOnce(CompactionConfig{MinDeadFraction: 0.5}); err != nil {
+				t.Fatal(err)
+			}
+		}
+		t.Fatal("crash point not reached")
+	}
+	for _, walOff := range []bool{false, true} {
+		for _, stage := range []string{"after-data", "after-manifest", "after-index", "before-unlink"} {
+			t.Run(fmt.Sprintf("wal-off=%v/%s", walOff, stage), func(t *testing.T) {
+				old := DisableIndexWAL
+				DisableIndexWAL = walOff
+				defer func() { DisableIndexWAL = old }()
+				db, paths, live := newCoalescedTestDb(t, 1)
+				db.CloseDb()
+				cmd := exec.Command(os.Args[0], "-test.run=^TestCoalescedCompactionProcessExit$")
+				cmd.Env = append(os.Environ(), "MITHRIL_TEST_COMPACT_ROOT="+paths[0], "MITHRIL_TEST_COMPACT_STAGE="+stage, fmt.Sprintf("MITHRIL_TEST_COMPACT_WAL_OFF=%v", walOff))
+				output, err := cmd.CombinedOutput()
+				var exit *exec.ExitError
+				require.ErrorAs(t, err, &exit, string(output))
+				require.Equal(t, 93, exit.ExitCode(), string(output))
+				db, err = OpenDbPaths(paths)
+				require.NoError(t, err)
+				defer db.CloseDb()
+				db.RootedDurable = true
+				db.InitCaches()
+				_, err = db.RecoverFoldState()
+				require.NoError(t, err)
+				checkCoalescedAccounts(t, db, live)
+				for i := 0; i < 10 && coalescedSourcesExist(paths); i++ {
+					_, err = db.CompactOnce(CompactionConfig{MinDeadFraction: 0.5})
+					require.NoError(t, err)
+				}
+				require.False(t, coalescedSourcesExist(paths))
+				checkCoalescedAccounts(t, db, live)
+			})
+		}
+	}
+}

--- a/pkg/accountsdb/fold.go
+++ b/pkg/accountsdb/fold.go
@@ -159,7 +159,7 @@ func (db *AccountsDb) CommitBatch(
 	sort.Slice(keys, func(i, j int) bool { return bytes.Compare(keys[i][:], keys[j][:]) < 0 })
 
 	// (2) fileId allocation; persist high-water BEFORE the first data byte (I7).
-	fileId := db.LargestFileId.Add(1)
+	fileId := db.nextFileId(0)
 	if err := db.persistLargestFileId(); err != nil {
 		return BatchCommitResult{}, err
 	}

--- a/pkg/accountsdb/index.go
+++ b/pkg/accountsdb/index.go
@@ -100,7 +100,10 @@ func WriteStakePubkeyIndex(path string, entries []StakeIndexEntry) error {
 // - pubkeys: all account pubkeys
 // - acctIdxEntries: index entries for each account
 // - stakeEntries: stake account pubkeys with their appendvec location hints
-func BuildIndexEntriesFromAppendVecs(data []byte, fileSize uint64, slot uint64, fileId uint64) ([]solana.PublicKey, []AccountIndexEntry, []StakeIndexEntry, error) {
+// baseOffset is added to every account offset so that, when append-vecs are
+// coalesced into a shard's big file, the stored offsets are absolute within that
+// file. Pass 0 for a stand-alone (one-file-per-append-vec) layout.
+func BuildIndexEntriesFromAppendVecs(data []byte, fileSize uint64, slot uint64, fileId uint64, baseOffset uint64) ([]solana.PublicKey, []AccountIndexEntry, []StakeIndexEntry, error) {
 	pubkeys := make([]solana.PublicKey, 0, 20000)
 	acctIdxEntries := make([]AccountIndexEntry, 0, 20000)
 	stakeEntries := make([]StakeIndexEntry, 0, 1000)
@@ -119,6 +122,8 @@ func BuildIndexEntriesFromAppendVecs(data []byte, fileSize uint64, slot uint64, 
 			}
 			return nil, nil, nil, fmt.Errorf("parse appendvec slot=%d file_id=%d: %w", slot, fileId, err)
 		}
+		// make the offset absolute within the (possibly coalesced) big file
+		acctIdxEntries[len(acctIdxEntries)-1].Offset += baseOffset
 		// Collect stake account entries with appendvec location hints
 		if bytes.Equal(owner[:], addresses.StakeProgramAddr[:]) {
 			idx := len(acctIdxEntries) - 1

--- a/pkg/accountsdb/index.go
+++ b/pkg/accountsdb/index.go
@@ -90,7 +90,10 @@ func WriteStakePubkeyIndex(path string, entries []StakeIndexEntry) error {
 // - pubkeys: all account pubkeys
 // - acctIdxEntries: index entries for each account
 // - stakeEntries: stake account pubkeys with their appendvec location hints
-func BuildIndexEntriesFromAppendVecs(data []byte, fileSize uint64, slot uint64, fileId uint64) ([]solana.PublicKey, []AccountIndexEntry, []StakeIndexEntry, error) {
+// baseOffset is added to every account offset so that, when append-vecs are
+// coalesced into a shard's big file, the stored offsets are absolute within that
+// file. Pass 0 for a stand-alone (one-file-per-append-vec) layout.
+func BuildIndexEntriesFromAppendVecs(data []byte, fileSize uint64, slot uint64, fileId uint64, baseOffset uint64) ([]solana.PublicKey, []AccountIndexEntry, []StakeIndexEntry, error) {
 	pubkeys := make([]solana.PublicKey, 0, 20000)
 	acctIdxEntries := make([]AccountIndexEntry, 0, 20000)
 	stakeEntries := make([]StakeIndexEntry, 0, 1000)
@@ -108,6 +111,8 @@ func BuildIndexEntriesFromAppendVecs(data []byte, fileSize uint64, slot uint64, 
 			acctIdxEntries = acctIdxEntries[:len(acctIdxEntries)-1]
 			break
 		}
+		// make the offset absolute within the (possibly coalesced) big file
+		acctIdxEntries[len(acctIdxEntries)-1].Offset += baseOffset
 		// Collect stake account entries with appendvec location hints
 		if bytes.Equal(owner[:], addresses.StakeProgramAddr[:]) {
 			idx := len(acctIdxEntries) - 1

--- a/pkg/accountsdb/segment.go
+++ b/pkg/accountsdb/segment.go
@@ -44,6 +44,8 @@ const (
 	// its only job is proving the data file is not an orphan.
 	ManifestKindFold    = uint8(1)
 	ManifestKindCompact = uint8(2)
+	// Compact output addressed by file ID, retaining each index entry's Slot.
+	ManifestKindCoalescedCompact = uint8(3)
 )
 
 // ErrTornManifest reports a manifest that fails CRC or structural validation.

--- a/pkg/accountsdb/shards.go
+++ b/pkg/accountsdb/shards.go
@@ -1,0 +1,85 @@
+package accountsdb
+
+import (
+	"fmt"
+	"path/filepath"
+	"sync/atomic"
+)
+
+// A fileId encodes both the disk and the file holding an append-vec:
+//
+//	shard   = fileId % N
+//	segment = fileId / N
+//
+// Segment 0 is the coalesced snapshot big file ("data", holding both the full and
+// incremental snapshots); any higher segment is a runtime append-vec written as
+// "<slot>.<fileId>" in the shard dir. Offsets stored in the index are absolute
+// within the resolved file.
+const segData = 0
+
+// Shards resolves append-vec file ids onto one directory per physical disk and
+// mints new ids for runtime writes.
+type Shards struct {
+	dirs    []string // one per disk, each is "<mount>/accounts"
+	counter atomic.Uint64
+	rr      atomic.Uint64
+}
+
+func newShards(dirs []string) *Shards {
+	return &Shards{dirs: dirs}
+}
+
+func (s *Shards) n() uint64 { return uint64(len(s.dirs)) }
+
+// choose round-robins runtime writes across shards. Runtime append-vec volume is
+// low, so an even file-count spread is enough; bulk unpack placement lives in the
+// build-time writer.
+func (s *Shards) choose() int {
+	return int(s.rr.Add(1) % s.n())
+}
+
+// mint allocates a fresh runtime fileId (segment >= 1) on shard. The counter starts
+// at 0, so the first minted id lands in segment 1, just past the segment-0 big file.
+func (s *Shards) mint(shard int) uint64 {
+	return s.counter.Add(1)*s.n() + uint64(shard)
+}
+
+// path returns the on-disk file holding the data addressed by (slot, fileId).
+func (s *Shards) path(slot, fileId uint64) string {
+	dir := s.dirs[fileId%s.n()]
+	if fileId/s.n() == segData {
+		return filepath.Join(dir, "data")
+	}
+	return filepath.Join(dir, fmt.Sprintf("%d.%d", slot, fileId))
+}
+
+// appendVecPath keeps legacy stores readable and resolves coalesced snapshot data.
+func (db *AccountsDb) appendVecPath(slot, fileId uint64) string {
+	if db.Shards != nil {
+		return db.Shards.path(slot, fileId)
+	}
+	return filepath.Join(db.AcctsDir, fmt.Sprintf("%d.%d", slot, fileId))
+}
+
+func (db *AccountsDb) chooseShard() int {
+	if db.Shards == nil {
+		return 0
+	}
+	return db.Shards.choose()
+}
+
+// nextFileId shares the durable high-water mark with fold and compaction.
+// Fold segments stay on the primary disk alongside their recovery manifests.
+func (db *AccountsDb) nextFileId(shard int) uint64 {
+	n := uint64(1)
+	if db.Shards != nil {
+		n = db.Shards.n()
+	}
+	for {
+		prev := db.LargestFileId.Load()
+		next := (prev/n+1)*n + uint64(shard)
+		if db.LargestFileId.CompareAndSwap(prev, next) {
+			return next
+		}
+	}
+}

--- a/pkg/accountsdb/shards.go
+++ b/pkg/accountsdb/shards.go
@@ -1,0 +1,54 @@
+package accountsdb
+
+import (
+	"fmt"
+	"path/filepath"
+	"sync/atomic"
+)
+
+// A fileId encodes both the disk and the file holding an append-vec:
+//
+//	shard   = fileId % N
+//	segment = fileId / N
+//
+// Segment 0 is the coalesced snapshot big file ("data", holding both the full and
+// incremental snapshots); any higher segment is a runtime append-vec written as
+// "<slot>.<fileId>" in the shard dir. Offsets stored in the index are absolute
+// within the resolved file.
+const segData = 0
+
+// Shards resolves append-vec file ids onto one directory per physical disk and
+// mints new ids for runtime writes.
+type Shards struct {
+	dirs    []string // one per disk, each is "<mount>/accounts"
+	counter atomic.Uint64
+	rr      atomic.Uint64
+}
+
+func newShards(dirs []string) *Shards {
+	return &Shards{dirs: dirs}
+}
+
+func (s *Shards) n() uint64 { return uint64(len(s.dirs)) }
+
+// choose round-robins runtime writes across shards. Runtime append-vec volume is
+// low, so an even file-count spread is enough; bulk unpack placement lives in the
+// build-time writer.
+func (s *Shards) choose() int {
+	return int(s.rr.Add(1) % s.n())
+}
+
+// mint allocates a fresh runtime fileId (segment >= 1) on shard. The counter starts
+// at 0, so the first minted id lands in segment 1, just past the segment-0 big file.
+func (s *Shards) mint(shard int) uint64 {
+	return s.counter.Add(1)*s.n() + uint64(shard)
+}
+
+// path returns the on-disk file holding the data addressed by (slot, fileId).
+func (s *Shards) path(slot, fileId uint64) string {
+	dir := s.dirs[fileId%s.n()]
+	if fileId/s.n() == segData {
+		return filepath.Join(dir, "data")
+	}
+	return filepath.Join(dir, fmt.Sprintf("%d.%d", slot, fileId))
+}

--- a/pkg/accountsdb/shards.go
+++ b/pkg/accountsdb/shards.go
@@ -55,6 +55,9 @@ func (s *Shards) path(slot, fileId uint64) string {
 
 // appendVecPath keeps legacy stores readable and resolves coalesced snapshot data.
 func (db *AccountsDb) appendVecPath(slot, fileId uint64) string {
+	if path, ok := db.coalescedFiles.Load(fileId); ok {
+		return path.(string)
+	}
 	if db.Shards != nil {
 		return db.Shards.path(slot, fileId)
 	}

--- a/pkg/accountsdb/shards_integration_test.go
+++ b/pkg/accountsdb/shards_integration_test.go
@@ -1,0 +1,73 @@
+package accountsdb
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Overclock-Validator/mithril/pkg/accounts"
+	"github.com/gagliardetto/solana-go"
+	"github.com/stretchr/testify/require"
+)
+
+// Exercise the snapshot layout through the APIs used by Alpenglow replay, then
+// fold, restart, and rewind across the snapshot-to-durable-segment boundary.
+func TestShardedSnapshotFoldReopenAndRewind(t *testing.T) {
+	paths := []string{t.TempDir(), t.TempDir()}
+	for _, p := range paths {
+		require.NoError(t, os.MkdirAll(filepath.Join(p, "accounts"), 0755))
+	}
+	var b [8]byte
+	binary.LittleEndian.PutUint64(b[:], 2)
+	require.NoError(t, os.WriteFile(filepath.Join(paths[0], "num_shards"), b[:], 0644))
+	binary.LittleEndian.PutUint64(b[:], 1)
+	for _, name := range []string{"largest_file_id", "bootstrap_high_file_id"} {
+		require.NoError(t, os.WriteFile(filepath.Join(paths[0], name), b[:], 0644))
+	}
+	db, err := OpenDbPaths(paths)
+	require.NoError(t, err)
+	defer func() { db.CloseDb() }()
+	db.InitCaches()
+	db.RootedDurable = true
+	old := []*accounts.Account{foldAcct(1, 11, []byte("one")), foldAcct(2, 22, []byte("two"))}
+	keys := []solana.PublicKey{old[0].Key, old[1].Key}
+	for i, acct := range old {
+		acct.Slot = 100
+		var data bytes.Buffer
+		// Start at an unaligned host offset, as packed snapshot appendvecs may do.
+		data.Write([]byte{0, 0, 0})
+		av := AppendVecAccount{Pubkey: acct.Key, Lamports: acct.Lamports, Owner: acct.Owner, RentEpoch: acct.RentEpoch, DataLen: uint64(len(acct.Data)), Data: acct.Data}
+		require.NoError(t, av.Marshal(&data))
+		require.NoError(t, os.WriteFile(filepath.Join(paths[i], "accounts", "data"), data.Bytes(), 0644))
+		var idx [24]byte
+		(&AccountIndexEntry{Slot: 100, FileId: uint64(i), Offset: 3}).Marshal(&idx)
+		require.NoError(t, db.Index.Set(acct.Key[:], idx[:], nil))
+	}
+	got, err := db.GetAccountsBatch(context.Background(), 100, keys)
+	require.NoError(t, err)
+	require.Equal(t, old, got)
+	for i, k := range keys {
+		require.Equal(t, old[i], mustColdRead(t, db, 100, k))
+	}
+	first, err := db.CommitBatch([]accounts.SlotDelta{{Slot: 101, Delta: []*accounts.Account{foldAcct(1, 33, []byte("new"))}}}, 101, map[uint64][32]byte{101: bh(101)}, []byte("ctx-101"))
+	require.NoError(t, err)
+	require.Zero(t, first.FileId%2)
+	db.CloseDb()
+	db, err = OpenDbPaths(paths)
+	require.NoError(t, err)
+	db.InitCaches()
+	db.RootedDurable = true
+	_, err = db.RecoverFoldState()
+	require.NoError(t, err)
+	require.Equal(t, uint64(33), mustColdRead(t, db, 101, keys[0]).Lamports)
+	require.Equal(t, old[1], mustColdRead(t, db, 101, keys[1]))
+	second, err := db.CommitBatch([]accounts.SlotDelta{{Slot: 102, Delta: []*accounts.Account{foldAcct(2, 44, []byte("new-two"))}}}, 102, map[uint64][32]byte{102: bh(102)}, []byte("ctx-102"))
+	require.NoError(t, err)
+	require.Greater(t, second.FileId, first.FileId)
+	_, err = db.RewindToBatchBoundary(101)
+	require.NoError(t, err)
+	require.Equal(t, old[1], mustColdRead(t, db, 101, keys[1]))
+}

--- a/pkg/accountsdb/shards_test.go
+++ b/pkg/accountsdb/shards_test.go
@@ -1,0 +1,49 @@
+package accountsdb
+
+import (
+	"testing"
+)
+
+func TestShardsPathAddressing(t *testing.T) {
+	dirs := []string{"/d0", "/d1", "/d2"}
+	s := newShards(dirs)
+
+	cases := []struct {
+		fileId uint64
+		want   string
+	}{
+		{0, "/d0/data"},  // segment 0 (coalesced big file), shard 0
+		{1, "/d1/data"},  // shard 1
+		{2, "/d2/data"},  // shard 2
+		{3, "/d0/100.3"}, // segment 1 -> runtime per-file, shard 0
+		{6, "/d0/100.6"}, // segment 2, shard 0
+		{8, "/d2/100.8"}, // shard 2
+		{10, "/d1/100.10"},
+	}
+	for _, c := range cases {
+		if got := s.path(100, c.fileId); got != c.want {
+			t.Errorf("path(100,%d) = %q, want %q", c.fileId, got, c.want)
+		}
+	}
+}
+
+func TestShardsMintEncodesShardAndSegment(t *testing.T) {
+	s := newShards([]string{"/d0", "/d1", "/d2"})
+	// counter left at 0 (matches OpenDb): first mint lands in segment 1.
+
+	seen := map[uint64]bool{}
+	for i := 0; i < 30; i++ {
+		shard := i % 3
+		id := s.mint(shard)
+		if int(id%s.n()) != shard {
+			t.Fatalf("mint(shard=%d) gave id=%d with id%%N=%d", shard, id, id%s.n())
+		}
+		if id/s.n() < 1 {
+			t.Fatalf("runtime id=%d landed in the segment-0 big file", id)
+		}
+		if seen[id] {
+			t.Fatalf("mint produced duplicate id=%d", id)
+		}
+		seen[id] = true
+	}
+}

--- a/pkg/accountsdb/storage_paths.go
+++ b/pkg/accountsdb/storage_paths.go
@@ -1,0 +1,85 @@
+package accountsdb
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ValidateStorageDirectories rejects aliases and overlapping roots before a
+// caller removes artifacts or opens truncating writers. Nonexistent suffixes
+// are resolved through their nearest existing parent, including symlinks.
+func ValidateStorageDirectories(paths []string) error {
+	if len(paths) == 0 {
+		return fmt.Errorf("no storage directories configured")
+	}
+	resolved := make([]string, len(paths))
+	infos := make([]os.FileInfo, len(paths))
+	for i, p := range paths {
+		if strings.TrimSpace(p) == "" {
+			return fmt.Errorf("storage directory %d is empty", i)
+		}
+		abs, err := filepath.Abs(p)
+		if err != nil {
+			return err
+		}
+		ancestor := filepath.Clean(abs)
+		var suffix []string
+		for {
+			_, err = os.Lstat(ancestor)
+			if err == nil {
+				break
+			}
+			if !os.IsNotExist(err) {
+				return fmt.Errorf("checking storage directory %q: %w", p, err)
+			}
+			suffix = append(suffix, filepath.Base(ancestor))
+			ancestor = filepath.Dir(ancestor)
+		}
+		real, err := filepath.EvalSymlinks(ancestor)
+		if err != nil {
+			return fmt.Errorf("resolving storage directory %q: %w", p, err)
+		}
+		info, err := os.Stat(real)
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() {
+			return fmt.Errorf("storage path %q is not a directory", ancestor)
+		}
+		if len(suffix) == 0 {
+			infos[i] = info
+		}
+		for j := len(suffix) - 1; j >= 0; j-- {
+			real = filepath.Join(real, suffix[j])
+		}
+		resolved[i] = real
+		for j := 0; j < i; j++ {
+			sameFile := infos[i] != nil && infos[j] != nil && os.SameFile(infos[i], infos[j])
+			overlap := pathContains(real, resolved[j]) || pathContains(resolved[j], real)
+			if sameFile || overlap {
+				return fmt.Errorf("storage directories %q and %q alias or overlap", paths[j], p)
+			}
+		}
+	}
+	return nil
+}
+
+// ValidateAccountsPaths also checks existing accounts subdirectories: two
+// otherwise distinct roots may contain symlinks to the same data directory.
+func ValidateAccountsPaths(paths []string) error {
+	if err := ValidateStorageDirectories(paths); err != nil {
+		return err
+	}
+	data := make([]string, len(paths))
+	for i, p := range paths {
+		data[i] = filepath.Join(p, "accounts")
+	}
+	return ValidateStorageDirectories(data)
+}
+
+func pathContains(parent, child string) bool {
+	rel, err := filepath.Rel(parent, child)
+	return err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(os.PathSeparator))
+}

--- a/pkg/accountsdb/storage_paths_test.go
+++ b/pkg/accountsdb/storage_paths_test.go
@@ -1,0 +1,47 @@
+package accountsdb
+
+import (
+	"github.com/stretchr/testify/require"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestValidateStorageDirectories(t *testing.T) {
+	root := t.TempDir()
+	a, b := filepath.Join(root, "a"), filepath.Join(root, "b")
+	require.NoError(t, os.Mkdir(a, 0755))
+	require.NoError(t, os.Mkdir(b, 0755))
+	alias := filepath.Join(root, "alias")
+	require.NoError(t, os.Symlink(a, alias))
+	file := filepath.Join(root, "file")
+	require.NoError(t, os.WriteFile(file, []byte("sentinel"), 0644))
+	cases := []struct {
+		name  string
+		paths []string
+		valid bool
+	}{
+		{"empty", nil, false}, {"empty-path", []string{""}, false},
+		{"siblings", []string{a, b}, true}, {"new-siblings", []string{a + "/new", b + "/new"}, true},
+		{"same", []string{a, a}, false}, {"clean", []string{a, a + "/../a"}, false},
+		{"symlink", []string{a, alias}, false}, {"new-symlink-suffix", []string{a + "/new", alias + "/new"}, false},
+		{"nested", []string{a, a + "/new"}, false}, {"root", []string{a, "/"}, false},
+		{"file", []string{file}, false}, {"file-parent", []string{file + "/new"}, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := ValidateStorageDirectories(c.paths)
+			if c.valid {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+			}
+		})
+	}
+	require.NoError(t, os.Symlink(a, filepath.Join(b, "accounts")))
+	require.NoError(t, os.Mkdir(filepath.Join(a, "accounts"), 0755))
+	require.Error(t, ValidateAccountsPaths([]string{a, b}), "aliased accounts subdirectories")
+	_, err := OpenDbPaths([]string{a, alias})
+	require.Error(t, err)
+	require.NoDirExists(t, filepath.Join(a, "mithril_db"), "validation must precede database creation")
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -52,6 +52,7 @@ type DebugConfig struct {
 type DevelopmentConfig struct {
 	ZstdDecoderConcurrency        int         `toml:"zstd_decoder_concurrency" mapstructure:"zstd_decoder_concurrency"`                 // was: zstd-decoder-concurrency
 	MaxConcurrentFlushers         int         `toml:"max_concurrent_flushers" mapstructure:"max_concurrent_flushers"`                   // was: max-concurrent-flushers
+	FlushSortWorkers              int         `toml:"flush_sort_workers" mapstructure:"flush_sort_workers"`                             // Snapshot index-flush concurrent sort workers (0 = NumCPU)
 	SnapshotDirectIO              bool        `toml:"snapshot_directio" mapstructure:"snapshot_directio"`                               // Write snapshot big files with O_DIRECT (bypasses page cache)
 	SnapshotAppendVecWorkers      int         `toml:"snapshot_append_vec_workers" mapstructure:"snapshot_append_vec_workers"`           // Snapshot appendvec write workers
 	SnapshotIndexBuilderWorkers   int         `toml:"snapshot_index_builder_workers" mapstructure:"snapshot_index_builder_workers"`     // Snapshot index parsing workers

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -65,6 +65,7 @@ type DebugConfig struct {
 type DevelopmentConfig struct {
 	ZstdDecoderConcurrency        int         `toml:"zstd_decoder_concurrency" mapstructure:"zstd_decoder_concurrency"`                 // was: zstd-decoder-concurrency
 	MaxConcurrentFlushers         int         `toml:"max_concurrent_flushers" mapstructure:"max_concurrent_flushers"`                   // was: max-concurrent-flushers
+	FlushSortWorkers              int         `toml:"flush_sort_workers" mapstructure:"flush_sort_workers"`                             // Snapshot index-flush concurrent sort workers (0 = NumCPU)
 	SnapshotDirectIO              bool        `toml:"snapshot_directio" mapstructure:"snapshot_directio"`                               // Write snapshot big files with O_DIRECT (bypasses page cache)
 	SnapshotAppendVecWorkers      int         `toml:"snapshot_append_vec_workers" mapstructure:"snapshot_append_vec_workers"`           // Snapshot appendvec write workers
 	SnapshotIndexBuilderWorkers   int         `toml:"snapshot_index_builder_workers" mapstructure:"snapshot_index_builder_workers"`     // Snapshot index parsing workers

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -52,6 +52,7 @@ type DebugConfig struct {
 type DevelopmentConfig struct {
 	ZstdDecoderConcurrency        int         `toml:"zstd_decoder_concurrency" mapstructure:"zstd_decoder_concurrency"`                 // was: zstd-decoder-concurrency
 	MaxConcurrentFlushers         int         `toml:"max_concurrent_flushers" mapstructure:"max_concurrent_flushers"`                   // was: max-concurrent-flushers
+	SnapshotDirectIO              bool        `toml:"snapshot_directio" mapstructure:"snapshot_directio"`                               // Write snapshot big files with O_DIRECT (bypasses page cache)
 	SnapshotAppendVecWorkers      int         `toml:"snapshot_append_vec_workers" mapstructure:"snapshot_append_vec_workers"`           // Snapshot appendvec write workers
 	SnapshotIndexBuilderWorkers   int         `toml:"snapshot_index_builder_workers" mapstructure:"snapshot_index_builder_workers"`     // Snapshot index parsing workers
 	SnapshotIndexCommitterWorkers int         `toml:"snapshot_index_committer_workers" mapstructure:"snapshot_index_committer_workers"` // Snapshot index shard enqueue workers

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -65,6 +65,7 @@ type DebugConfig struct {
 type DevelopmentConfig struct {
 	ZstdDecoderConcurrency        int         `toml:"zstd_decoder_concurrency" mapstructure:"zstd_decoder_concurrency"`                 // was: zstd-decoder-concurrency
 	MaxConcurrentFlushers         int         `toml:"max_concurrent_flushers" mapstructure:"max_concurrent_flushers"`                   // was: max-concurrent-flushers
+	SnapshotDirectIO              bool        `toml:"snapshot_directio" mapstructure:"snapshot_directio"`                               // Write snapshot big files with O_DIRECT (bypasses page cache)
 	SnapshotAppendVecWorkers      int         `toml:"snapshot_append_vec_workers" mapstructure:"snapshot_append_vec_workers"`           // Snapshot appendvec write workers
 	SnapshotIndexBuilderWorkers   int         `toml:"snapshot_index_builder_workers" mapstructure:"snapshot_index_builder_workers"`     // Snapshot index parsing workers
 	SnapshotIndexCommitterWorkers int         `toml:"snapshot_index_committer_workers" mapstructure:"snapshot_index_committer_workers"` // Snapshot index shard enqueue workers

--- a/pkg/snapshot/build_db.go
+++ b/pkg/snapshot/build_db.go
@@ -1,9 +1,7 @@
 package snapshot
 
 import (
-	"bytes"
 	"context"
-	"encoding/binary"
 	"fmt"
 	"io"
 	"os"
@@ -27,6 +25,9 @@ const (
 	DefaultSnapshotAppendVecCopyingWorkers    = 32
 	DefaultSnapshotIndexShards                = 64
 	DefaultSnapshotMaxConcurrentFlushers      = 8
+	// DefaultSnapshotDirectIO keeps O_DIRECT big-file writes off by default;
+	// buffered is the safe default and O_DIRECT is an opt-in tuning knob.
+	DefaultSnapshotDirectIO = false
 )
 
 var (
@@ -34,13 +35,17 @@ var (
 	SnapshotIndexEntryBuilderWorkers   = DefaultSnapshotIndexEntryBuilderWorkers
 	SnapshotAppendVecCopyingWorkers    = DefaultSnapshotAppendVecCopyingWorkers
 	SnapshotIndexShards                = DefaultSnapshotIndexShards
+	SnapshotDirectIO                   = DefaultSnapshotDirectIO
 	SnapshotIndexTempDir               string
 )
 
 // CleanAccountsDbDir removes all artifacts from a previous incomplete snapshot run.
 // This prevents corruption from Ctrl+C or partial downloads.
 // Exported so it can be called early in startup before any failures.
-func CleanAccountsDbDir(accountsDbDir string) {
+func CleanAccountsDbDir(accountsPaths []string) {
+	if len(accountsPaths) == 0 {
+		return
+	}
 	// List of all files/directories that may be left from a previous incomplete run
 	artifacts := []string{
 		"accounts",
@@ -48,11 +53,19 @@ func CleanAccountsDbDir(accountsDbDir string) {
 		"mithril_db_log_shards",
 		"bankhash_db",
 		"largest_file_id",
+		"num_shards",
 		"manifest",
 		"mithril_state.json", // State file for tracking valid builds and replay progress
 	}
 	for _, artifact := range artifacts {
-		path := filepath.Join(accountsDbDir, artifact)
+		path := filepath.Join(accountsPaths[0], artifact)
+		if err := os.RemoveAll(path); err != nil {
+			mlog.Log.Errorf("failed to remove %s: %v", path, err)
+		}
+	}
+	// remove the accounts dir on the other shard disks too
+	for _, p := range accountsPaths[1:] {
+		path := filepath.Join(p, "accounts")
 		if err := os.RemoveAll(path); err != nil {
 			mlog.Log.Errorf("failed to remove %s: %v", path, err)
 		}
@@ -205,12 +218,13 @@ func logSnapshotBootstrapTuning() {
 	if indexTempDir == "" {
 		indexTempDir = "(accountsdb)"
 	}
-	mlog.Log.Infof("Snapshot bootstrap tuning: append_vec_workers=%d index_builder_workers=%d index_committer_workers=%d index_shards=%d max_concurrent_flushers=%d zstd_decoder_concurrency=%d index_temp_dir=%s",
+	mlog.Log.Infof("Snapshot bootstrap tuning: append_vec_workers=%d index_builder_workers=%d index_committer_workers=%d index_shards=%d max_concurrent_flushers=%d directio=%v zstd_decoder_concurrency=%d index_temp_dir=%s",
 		snapshotAppendVecCopyingWorkers(),
 		snapshotIndexEntryBuilderWorkers(),
 		snapshotIndexEntryCommitterWorkers(),
 		snapshotIndexShards(),
 		snapshotMaxConcurrentFlushers(),
+		SnapshotDirectIO,
 		ZstdDecoderConcurrency,
 		indexTempDir)
 }
@@ -245,11 +259,16 @@ func BuildAccountsDbPaths(
 	ctx context.Context,
 	snapshotFile string,
 	incrementalSnapshotFile string,
-	accountsDbDir string,
+	accountsPaths []string,
 	dp *progress.DualProgress,
 ) (*accountsdb.AccountsDb, *SnapshotManifest, error) {
+	if len(accountsPaths) == 0 {
+		return nil, nil, fmt.Errorf("no accounts paths configured")
+	}
+	// The first path holds all metadata; every path holds a shard's accounts dir.
+	accountsDbDir := accountsPaths[0]
 	// Clean any leftover artifacts from previous incomplete runs (e.g., Ctrl+C)
-	CleanAccountsDbDir(accountsDbDir)
+	CleanAccountsDbDir(accountsPaths)
 
 	mlog.Log.Infof("Parsing full snapshot manifest...")
 	manifest, err := UnmarshalManifestFromSnapshot(ctx, snapshotFile, accountsDbDir)
@@ -270,15 +289,21 @@ func BuildAccountsDbPaths(
 
 	start := time.Now()
 
-	appendVecsOutputDir := filepath.Join(accountsDbDir, "accounts")
-	if err = os.MkdirAll(appendVecsOutputDir, 0775); err != nil {
-		return nil, nil, err
+	shardDirs := make([]string, len(accountsPaths))
+	for i, p := range accountsPaths {
+		shardDirs[i] = filepath.Join(p, "accounts")
+		if err = os.MkdirAll(shardDirs[i], 0775); err != nil {
+			return nil, nil, err
+		}
+	}
+	shardFiles, err := openShardBigFiles(shardDirs)
+	if err != nil {
+		return nil, nil, fmt.Errorf("opening shard big files: %w", err)
 	}
 	logSnapshotBootstrapTuning()
 
 	defer ants.Release()
 
-	var largestFileId atomic.Uint64
 	wg := &sync.WaitGroup{}
 
 	logsDir, cleanupIndexWorkDir, err := prepareSnapshotIndexWorkDir(accountsDbDir)
@@ -294,7 +319,7 @@ func BuildAccountsDbPaths(
 		entries: make([]accountsdb.StakeIndexEntry, 0, 1000000), // Pre-allocate for ~1M stake accounts
 	}
 
-	pools, err := initWorkerPools(wg, sl, manifest, incrementalManifest, accountsDbDir, &largestFileId, stakeCollector)
+	pools, err := initWorkerPools(wg, sl, manifest, incrementalManifest, shardFiles, stakeCollector)
 	if err != nil {
 		return nil, nil, fmt.Errorf("initializing worker pools: %w", err)
 	}
@@ -311,7 +336,7 @@ func BuildAccountsDbPaths(
 
 	// Process snapshots sequentially for better performance (less lock contention)
 	// Full snapshot first
-	err = readTar(ctx, wg, snapshotFile, pools.appendVecCopying, readTarOptions{progress: dp})
+	err = readTar(ctx, wg, snapshotFile, pools.appendVecCopying, pools.tarBufs, readTarOptions{progress: dp})
 
 	// Wait for ALL worker tasks from full snapshot to complete before starting incremental
 	wg.Wait()
@@ -331,13 +356,18 @@ func BuildAccountsDbPaths(
 
 	// Process incremental snapshot (if provided)
 	if incrementalSnapshotFile != "" {
-		err = readTar(ctx, wg, incrementalSnapshotFile, pools.appendVecCopying,
+		err = readTar(ctx, wg, incrementalSnapshotFile, pools.appendVecCopying, pools.tarBufs,
 			readTarOptions{isIncremental: true})
 		if err != nil {
 			return nil, nil, err
 		}
 		// Wait for all incremental worker tasks to complete
 		wg.Wait()
+	}
+
+	// flush and close every shard's big file now that all appends are done
+	if err := shardFiles.close(); err != nil {
+		return nil, nil, fmt.Errorf("closing shard big files: %w", err)
 	}
 
 	mlog.Log.Debugf("done processing snapshots in %s.", fmtDuration(time.Since(start)))
@@ -360,12 +390,7 @@ func BuildAccountsDbPaths(
 
 	mlog.Log.Infof("Snapshot processed in %s.", fmtDuration(time.Since(start)))
 
-	var largestFileIdBytes [8]byte
-	binary.LittleEndian.PutUint64(largestFileIdBytes[:], largestFileId.Load())
-
-	path := filepath.Join(accountsDbDir, "largest_file_id")
-	if err := os.WriteFile(path, largestFileIdBytes[:], 0644); err != nil {
-		mlog.Log.Errorf("error while writing largest file ID=%d to %s: %s", largestFileId.Load(), path, err)
+	if err := writeShardMetadata(accountsDbDir, len(shardDirs)); err != nil {
 		return nil, nil, err
 	}
 
@@ -390,7 +415,7 @@ func BuildAccountsDbPaths(
 	}
 	bankhashDb.Close()
 
-	accountsDb, err := accountsdb.OpenDb(accountsDbDir)
+	accountsDb, err := accountsdb.OpenDb(accountsPaths)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -416,11 +441,38 @@ type readTarOptions struct {
 	isIncremental bool
 }
 
+// tarBufPool recycles the byte buffers that appendvec data is read into, saving
+// ~420k allocations totalling ~470 GB. A buffer returns to the pool once the index
+// builder is done reading it. Owned by snapshotWorkerPools so it may be GCed after
+// snapshot unpacking.
+type tarBufPool struct{ sync.Pool }
+
+func newTarBufPool() *tarBufPool {
+	return &tarBufPool{Pool: sync.Pool{New: func() any { b := []byte(nil); return &b }}}
+}
+
+func (p *tarBufPool) get(size int) *[]byte {
+	bp := p.Get().(*[]byte)
+	if cap(*bp) < size {
+		*bp = make([]byte, size)
+	} else {
+		*bp = (*bp)[:size]
+	}
+	return bp
+}
+
+func (p *tarBufPool) put(bp *[]byte) {
+	if bp != nil {
+		p.Put(bp)
+	}
+}
+
 func readTar(
 	ctx context.Context,
 	wg *sync.WaitGroup,
 	filename string,
 	appendVecCopyingPool *ants.PoolWithFunc,
+	bufs *tarBufPool,
 	options readTarOptions,
 ) error {
 	dp := options.progress
@@ -449,13 +501,19 @@ func readTar(
 		}
 	}
 
+	var totalTarNext, totalReadCopy, totalDispatch time.Duration
+	var entryCount int
+	var bytesOut int64
+	readTarStart := time.Now()
 	for {
 		if ctx.Err() != nil {
 			mlog.Log.Infof("Context cancelled, stopping snapshot unpack: %v", ctx.Err())
 			cleanupPartial("cancelled")
 			return ctx.Err()
 		}
+		t0 := time.Now()
 		header, err := tarReader.Next()
+		totalTarNext += time.Since(t0)
 		if err == io.EOF {
 			break
 		} else if err != nil {
@@ -468,29 +526,45 @@ func readTar(
 			continue
 		}
 
-		writer := bytes.NewBuffer(make([]byte, 0, header.Size))
-		tarBytesRead, err := io.Copy(writer, tarReader)
+		t1 := time.Now()
+		bp := bufs.get(int(header.Size))
+		_, err = io.ReadFull(tarReader, *bp)
+		totalReadCopy += time.Since(t1)
 		if err != nil {
-			mlog.Log.Errorf("err copying data to reader: %s\n", err)
-			cleanupPartial("copy error")
+			mlog.Log.Errorf("err reading tar entry data: %s\n", err)
+			cleanupPartial("read error")
+			bufs.put(bp)
 			return err
 		}
-		statsd.Count(statsd.SnapshotTarBytesRead, tarBytesRead, nil)
+		entryCount++
+		bytesOut += header.Size
+		statsd.Count(statsd.SnapshotTarBytesRead, header.Size, nil)
 
 		// Update extract progress
 		if dp != nil {
-			dp.Extract.Add(tarBytesRead)
+			dp.Extract.Add(header.Size)
 		}
 
-		task := appendVecCopyingTask{TarBuffer: writer, Filename: header.Name, FromIncrementalSnapshot: options.isIncremental}
+		task := appendVecCopyingTask{Buf: *bp, BufRef: bp, Filename: header.Name, FromIncrementalSnapshot: options.isIncremental}
 		wg.Add(1)
+		t2 := time.Now()
 		err = appendVecCopyingPool.Invoke(task)
+		totalDispatch += time.Since(t2)
 		if err != nil {
 			mlog.Log.Errorf("error calling appendVecCopyingPool.Invoke: %v", err)
 			cleanupPartial("pool error")
 			return err
 		}
 	}
+
+	elapsed := time.Since(readTarStart)
+	mibps := 0.0
+	if elapsed > 0 {
+		mibps = float64(bytesOut) / (1 << 20) / elapsed.Seconds()
+	}
+	mlog.Log.Infof("readTar timing: entries=%d bytesOut=%dMB elapsed=%s avgMiBps=%.0f tarNext=%s readCopy=%s dispatch=%s",
+		entryCount, bytesOut/(1<<20), fmtDuration(elapsed), mibps,
+		fmtDuration(totalTarNext), fmtDuration(totalReadCopy), fmtDuration(totalDispatch))
 
 	// Successfully processed the entire tar — finalize by renaming from .partial
 	if err := FinalizePartialDownload(savePath); err != nil {
@@ -506,6 +580,7 @@ type snapshotWorkerPools struct {
 	appendVecCopying    *ants.PoolWithFunc
 	indexEntryBuilder   *ants.PoolWithFunc
 	indexEntryCommitter *ants.PoolWithFunc
+	tarBufs             *tarBufPool
 }
 
 // stakeIndexCollector aggregates stake account pubkeys from multiple worker goroutines
@@ -539,13 +614,13 @@ func initWorkerPools(
 	sl *ShardLogger,
 	manifest *SnapshotManifest,
 	incrementalManifest *SnapshotManifest,
-	accountsDbDir string,
-	largestFileId *atomic.Uint64,
+	shardFiles *shardBigFiles,
 	stakeCollector *stakeIndexCollector,
 ) (*snapshotWorkerPools, error) {
 	indexEntryCommitterWorkers := snapshotIndexEntryCommitterWorkers()
 	indexEntryBuilderWorkers := snapshotIndexEntryBuilderWorkers()
 	appendVecCopyingWorkers := snapshotAppendVecCopyingWorkers()
+	tarBufs := newTarBufPool()
 
 	indexEntryCommitterPool, err := ants.NewPoolWithFunc(indexEntryCommitterWorkers, func(i any) {
 		tasks := indexEntryCommitterInProgress.Add(1)
@@ -570,7 +645,8 @@ func initWorkerPools(
 		start := time.Now()
 		defer wg.Done()
 		task := i.(indexEntryBuilderTask)
-		pubkeys, entries, stakeEntries, err := accountsdb.BuildIndexEntriesFromAppendVecs(task.Data, task.FileSize, task.Slot, task.FileId)
+		pubkeys, entries, stakeEntries, err := accountsdb.BuildIndexEntriesFromAppendVecs(task.Data, task.FileSize, task.Slot, task.FileId, task.BaseOffset)
+		tarBufs.put(task.BufRef) // done reading task.Data; recycle the buffer
 		if err != nil {
 			mlog.Log.Errorf("BuildIndexEntriesFromAppendVecs: %v", err)
 			return
@@ -599,40 +675,15 @@ func initWorkerPools(
 		defer wg.Done()
 		task := i.(appendVecCopyingTask)
 		filename := task.Filename
-		writer := task.TarBuffer
+		appendVecBytes := task.Buf
 
-		outFilename := filepath.Join(accountsDbDir, filename)
-
-		// validate that the path doesn't escape accountsDbDir (via '../' sequences)
-		cleanPath := filepath.Clean(outFilename)
-		if !strings.HasPrefix(cleanPath, filepath.Clean(accountsDbDir)+string(os.PathSeparator)) {
-			panic(fmt.Sprintf("invalid path in tar archive: %s", filename))
-		}
-
-		appendVecBytes := writer.Bytes()
-		err := os.WriteFile(cleanPath, appendVecBytes, 0644)
-		if err != nil {
-			mlog.Log.Errorf("err writing new file=%s: %v", cleanPath, err)
-			appendVecCopyingInProgress.Add(-1)
-			return
-		}
-
-		var slot, fileId uint64
-		if n, err := fmt.Sscanf(filepath.Base(filename), "%d.%d", &slot, &fileId); n != 2 || err != nil {
+		// origFileId is the snapshot's id, used only to look up the valid data
+		// length in the manifest
+		var slot, origFileId uint64
+		if n, err := fmt.Sscanf(filepath.Base(filename), "%d.%d", &slot, &origFileId); n != 2 || err != nil {
 			panic(fmt.Sprintf(
 				"failed to parse slot and file from filename=%s basename=%s; parsed n=%d arguments (expected 2) and had err=%v",
 				filename, filepath.Base(filename), n, err))
-		}
-
-		for {
-			prevLargestFileId := largestFileId.Load()
-			if fileId <= prevLargestFileId {
-				break
-			}
-			swapped := largestFileId.CompareAndSwap(prevLargestFileId, fileId)
-			if swapped {
-				break
-			}
 		}
 
 		// find the relevant appendvec storage info. use the info from the incremental
@@ -644,7 +695,7 @@ func initWorkerPools(
 				panic("tried to process incremental snapshot without having parsed incremental snapshot manifest first!")
 			}
 			for _, av := range incrementalManifest.AccountsDb.Storages[slot].AcctVecs {
-				if av.Id == fileId {
+				if av.Id == origFileId {
 					fileSize = av.FileSize
 					usedIncrementalSnapshotVal = true
 					break
@@ -654,7 +705,7 @@ func initWorkerPools(
 
 		if !usedIncrementalSnapshotVal {
 			for _, av := range manifest.AccountsDb.Storages[slot].AcctVecs {
-				if av.Id == fileId {
+				if av.Id == origFileId {
 					fileSize = av.FileSize
 					break
 				}
@@ -664,9 +715,20 @@ func initWorkerPools(
 		if fileSize == 0 {
 			panic("programming error - fileSize for appendvec was 0")
 		}
+		if uint64(len(appendVecBytes)) < fileSize {
+			panic(fmt.Sprintf("appendvec blob (%d bytes) shorter than manifest fileSize (%d)", len(appendVecBytes), fileSize))
+		}
+
+		fileId, base, err := shardFiles.write(appendVecBytes[:fileSize])
+		if err != nil {
+			mlog.Log.Errorf("err writing appendvec to shard big file: %v", err)
+			appendVecCopyingInProgress.Add(-1)
+			tarBufs.put(task.BufRef)
+			return
+		}
 
 		appendVecCopyingInProgress.Add(-1)
-		nextTask := indexEntryBuilderTask{Data: appendVecBytes, FileSize: fileSize, Slot: slot, FileId: fileId}
+		nextTask := indexEntryBuilderTask{Data: appendVecBytes, FileSize: fileSize, Slot: slot, FileId: fileId, BaseOffset: base, BufRef: task.BufRef}
 		wg.Add(1)
 		statsd.Timing(statsd.TasksAppendVecCopyingLatency, uint64(time.Since(start)), nil)
 		err = indexEntryBuilderPool.Invoke(nextTask)
@@ -679,9 +741,10 @@ func initWorkerPools(
 	}
 
 	return &snapshotWorkerPools{
-		appendVecCopyingPool,
-		indexEntryBuilderPool,
-		indexEntryCommitterPool,
+		appendVecCopying:    appendVecCopyingPool,
+		indexEntryBuilder:   indexEntryBuilderPool,
+		indexEntryCommitter: indexEntryCommitterPool,
+		tarBufs:             tarBufs,
 	}, nil
 }
 

--- a/pkg/snapshot/build_db.go
+++ b/pkg/snapshot/build_db.go
@@ -51,7 +51,8 @@ var (
 func CleanAccountsDbDir(accountsDbDir string) { CleanAccountsDbDirs([]string{accountsDbDir}) }
 
 func CleanAccountsDbDirs(accountsPaths []string) {
-	if len(accountsPaths) == 0 {
+	if err := accountsdb.ValidateAccountsPaths(accountsPaths); err != nil {
+		mlog.Log.Errorf("refusing AccountsDB cleanup: %v", err)
 		return
 	}
 	// List of all files/directories that may be left from a previous incomplete run
@@ -293,8 +294,8 @@ func BuildAccountsDbPaths(
 	accountsPaths []string,
 	dp *progress.DualProgress,
 ) (*accountsdb.AccountsDb, *SnapshotManifest, error) {
-	if len(accountsPaths) == 0 {
-		return nil, nil, fmt.Errorf("no accounts paths configured")
+	if err := accountsdb.ValidateAccountsPaths(accountsPaths); err != nil {
+		return nil, nil, err
 	}
 	// The first path holds all metadata; every path holds a shard's accounts dir.
 	accountsDbDir := accountsPaths[0]
@@ -337,6 +338,7 @@ func BuildAccountsDbPaths(
 	if err != nil {
 		return nil, nil, fmt.Errorf("opening shard big files: %w", err)
 	}
+	defer shardFiles.close() // also drain and release writers on bootstrap errors
 	logSnapshotBootstrapTuning()
 
 	defer ants.Release()
@@ -411,6 +413,9 @@ func BuildAccountsDbPaths(
 			return nil, nil, err
 		}
 	}
+
+	// Workers have drained; release their pools before the memory-intensive sort.
+	pools.Release()
 
 	// flush and close every shard's big file now that all appends are done
 	if err := shardFiles.close(); err != nil {
@@ -943,9 +948,20 @@ func initWorkerPools(
 }
 
 func (p *snapshotWorkerPools) Release() {
-	p.appendVecCopying.Release()
-	p.indexEntryBuilder.Release()
-	p.indexEntryCommitter.Release()
+	// Call only after waitForSnapshotWorkers. Idempotent for deferred cleanup.
+	if p.appendVecCopying != nil {
+		p.appendVecCopying.Release()
+		p.appendVecCopying = nil
+	}
+	if p.indexEntryBuilder != nil {
+		p.indexEntryBuilder.Release()
+		p.indexEntryBuilder = nil
+	}
+	if p.indexEntryCommitter != nil {
+		p.indexEntryCommitter.Release()
+		p.indexEntryCommitter = nil
+	}
+	p.tarBufs = nil
 }
 
 // Ingest SSTs into a fresh pebble DB and return it.

--- a/pkg/snapshot/build_db.go
+++ b/pkg/snapshot/build_db.go
@@ -1,7 +1,6 @@
 package snapshot
 
 import (
-	"bytes"
 	"context"
 	"encoding/binary"
 	"fmt"
@@ -28,6 +27,9 @@ const (
 	DefaultSnapshotAppendVecCopyingWorkers    = 32
 	DefaultSnapshotIndexShards                = 64
 	DefaultSnapshotMaxConcurrentFlushers      = 8
+	// DefaultSnapshotDirectIO keeps O_DIRECT big-file writes off by default;
+	// buffered is the safe default and O_DIRECT is an opt-in tuning knob.
+	DefaultSnapshotDirectIO = false
 )
 
 var (
@@ -35,13 +37,19 @@ var (
 	SnapshotIndexEntryBuilderWorkers   = DefaultSnapshotIndexEntryBuilderWorkers
 	SnapshotAppendVecCopyingWorkers    = DefaultSnapshotAppendVecCopyingWorkers
 	SnapshotIndexShards                = DefaultSnapshotIndexShards
+	SnapshotDirectIO                   = DefaultSnapshotDirectIO
 	SnapshotIndexTempDir               string
 )
 
 // CleanAccountsDbDir removes all artifacts from a previous incomplete snapshot run.
 // This prevents corruption from Ctrl+C or partial downloads.
 // Exported so it can be called early in startup before any failures.
-func CleanAccountsDbDir(accountsDbDir string) {
+func CleanAccountsDbDir(accountsDbDir string) { CleanAccountsDbDirs([]string{accountsDbDir}) }
+
+func CleanAccountsDbDirs(accountsPaths []string) {
+	if len(accountsPaths) == 0 {
+		return
+	}
 	// List of all files/directories that may be left from a previous incomplete run
 	artifacts := []string{
 		"accounts",
@@ -55,16 +63,24 @@ func CleanAccountsDbDir(accountsDbDir string) {
 		"mithril_db_log_shards",
 		"bankhash_db",
 		"largest_file_id",
+		"num_shards",
 		"manifest",
 		"mithril_state.json", // State file for tracking valid builds and replay progress
 	}
 	for _, artifact := range artifacts {
-		path := filepath.Join(accountsDbDir, artifact)
+		path := filepath.Join(accountsPaths[0], artifact)
 		if err := os.RemoveAll(path); err != nil {
 			mlog.Log.Errorf("failed to remove %s: %v", path, err)
 		}
 	}
-	partials, _ := filepath.Glob(filepath.Join(accountsDbDir, ".snapshot-status-cache-*.partial"))
+	// remove the accounts dir on the other shard disks too
+	for _, p := range accountsPaths[1:] {
+		path := filepath.Join(p, "accounts")
+		if err := os.RemoveAll(path); err != nil {
+			mlog.Log.Errorf("failed to remove %s: %v", path, err)
+		}
+	}
+	partials, _ := filepath.Glob(filepath.Join(accountsPaths[0], ".snapshot-status-cache-*.partial"))
 	for _, partial := range partials {
 		if err := os.Remove(partial); err != nil && !os.IsNotExist(err) {
 			mlog.Log.Errorf("failed to remove stale status-cache partial %s: %v", partial, err)
@@ -219,12 +235,13 @@ func logSnapshotBootstrapTuning() {
 	if indexTempDir == "" {
 		indexTempDir = "(accountsdb)"
 	}
-	mlog.Log.Infof("Snapshot bootstrap tuning: append_vec_workers=%d index_builder_workers=%d index_committer_workers=%d index_shards=%d max_concurrent_flushers=%d zstd_decoder_concurrency=%d index_temp_dir=%s",
+	mlog.Log.Infof("Snapshot bootstrap tuning: append_vec_workers=%d index_builder_workers=%d index_committer_workers=%d index_shards=%d max_concurrent_flushers=%d directio=%v zstd_decoder_concurrency=%d index_temp_dir=%s",
 		snapshotAppendVecCopyingWorkers(),
 		snapshotIndexEntryBuilderWorkers(),
 		snapshotIndexEntryCommitterWorkers(),
 		snapshotIndexShards(),
 		snapshotMaxConcurrentFlushers(),
+		SnapshotDirectIO,
 		ZstdDecoderConcurrency,
 		indexTempDir)
 }
@@ -259,11 +276,16 @@ func BuildAccountsDbPaths(
 	ctx context.Context,
 	snapshotFile string,
 	incrementalSnapshotFile string,
-	accountsDbDir string,
+	accountsPaths []string,
 	dp *progress.DualProgress,
 ) (*accountsdb.AccountsDb, *SnapshotManifest, error) {
+	if len(accountsPaths) == 0 {
+		return nil, nil, fmt.Errorf("no accounts paths configured")
+	}
+	// The first path holds all metadata; every path holds a shard's accounts dir.
+	accountsDbDir := accountsPaths[0]
 	// Clean any leftover artifacts from previous incomplete runs (e.g., Ctrl+C)
-	CleanAccountsDbDir(accountsDbDir)
+	CleanAccountsDbDirs(accountsPaths)
 
 	mlog.Log.Infof("Parsing full snapshot manifest...")
 	manifest, err := UnmarshalManifestFromSnapshot(ctx, snapshotFile, accountsDbDir)
@@ -290,15 +312,21 @@ func BuildAccountsDbPaths(
 
 	start := time.Now()
 
-	appendVecsOutputDir := filepath.Join(accountsDbDir, "accounts")
-	if err = os.MkdirAll(appendVecsOutputDir, 0775); err != nil {
-		return nil, nil, err
+	shardDirs := make([]string, len(accountsPaths))
+	for i, p := range accountsPaths {
+		shardDirs[i] = filepath.Join(p, "accounts")
+		if err = os.MkdirAll(shardDirs[i], 0775); err != nil {
+			return nil, nil, err
+		}
+	}
+	shardFiles, err := openShardBigFiles(shardDirs)
+	if err != nil {
+		return nil, nil, fmt.Errorf("opening shard big files: %w", err)
 	}
 	logSnapshotBootstrapTuning()
 
 	defer ants.Release()
 
-	var largestFileId atomic.Uint64
 	wg := &sync.WaitGroup{}
 
 	logsDir, cleanupIndexWorkDir, err := prepareSnapshotIndexWorkDir(accountsDbDir)
@@ -314,7 +342,7 @@ func BuildAccountsDbPaths(
 		entries: make([]accountsdb.StakeIndexEntry, 0, 1000000), // Pre-allocate for ~1M stake accounts
 	}
 
-	pools, err := initWorkerPools(wg, sl, manifest, incrementalManifest, accountsDbDir, &largestFileId, stakeCollector)
+	pools, err := initWorkerPools(wg, sl, manifest, incrementalManifest, shardFiles, stakeCollector)
 	if err != nil {
 		return nil, nil, fmt.Errorf("initializing worker pools: %w", err)
 	}
@@ -370,6 +398,11 @@ func BuildAccountsDbPaths(
 		}
 	}
 
+	// flush and close every shard's big file now that all appends are done
+	if err := shardFiles.close(); err != nil {
+		return nil, nil, fmt.Errorf("closing shard big files: %w", err)
+	}
+
 	mlog.Log.Debugf("done processing snapshots in %s.", fmtDuration(time.Since(start)))
 
 	// Show indexing progress for shard flush (no gap between DualProgress and this)
@@ -390,12 +423,13 @@ func BuildAccountsDbPaths(
 
 	mlog.Log.Infof("Snapshot processed in %s.", fmtDuration(time.Since(start)))
 
-	var largestFileIdBytes [8]byte
-	binary.LittleEndian.PutUint64(largestFileIdBytes[:], largestFileId.Load())
+	if err := writeShardMetadata(accountsDbDir, len(shardDirs)); err != nil {
+		return nil, nil, err
+	}
 
-	path := filepath.Join(accountsDbDir, "largest_file_id")
-	if err := os.WriteFile(path, largestFileIdBytes[:], 0644); err != nil {
-		mlog.Log.Errorf("error while writing largest file ID=%d to %s: %s", largestFileId.Load(), path, err)
+	var largestFileIdBytes [8]byte
+	binary.LittleEndian.PutUint64(largestFileIdBytes[:], uint64(len(shardDirs)-1))
+	if err := os.WriteFile(filepath.Join(accountsDbDir, "largest_file_id"), largestFileIdBytes[:], 0644); err != nil {
 		return nil, nil, err
 	}
 
@@ -427,7 +461,7 @@ func BuildAccountsDbPaths(
 	}
 	bankhashDb.Close()
 
-	accountsDb, err := accountsdb.OpenDb(accountsDbDir)
+	accountsDb, err := accountsdb.OpenDbPaths(accountsPaths)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -454,6 +488,32 @@ type readTarOptions struct {
 	// Atomically retain the raw snapshots/status_cache member here. A
 	// successfully consumed incremental archive replaces the full seed.
 	statusCachePath string
+}
+
+// tarBufPool recycles the byte buffers that appendvec data is read into, saving
+// ~420k allocations totalling ~470 GB. A buffer returns to the pool once the index
+// builder is done reading it. Owned by snapshotWorkerPools so it may be GCed after
+// snapshot unpacking.
+type tarBufPool struct{ sync.Pool }
+
+func newTarBufPool() *tarBufPool {
+	return &tarBufPool{Pool: sync.Pool{New: func() any { b := []byte(nil); return &b }}}
+}
+
+func (p *tarBufPool) get(size int) *[]byte {
+	bp := p.Get().(*[]byte)
+	if cap(*bp) < size {
+		*bp = make([]byte, size)
+	} else {
+		*bp = (*bp)[:size]
+	}
+	return bp
+}
+
+func (p *tarBufPool) put(bp *[]byte) {
+	if bp != nil {
+		p.Put(bp)
+	}
 }
 
 func readTar(
@@ -491,6 +551,10 @@ func readTar(
 		}
 	}
 
+	var totalTarNext, totalReadCopy, totalDispatch time.Duration
+	var entryCount int
+	var bytesOut int64
+	readTarStart := time.Now()
 	for {
 		if pools != nil {
 			if workerErr := pools.Err(); workerErr != nil {
@@ -503,7 +567,9 @@ func readTar(
 			cleanupPartial("cancelled")
 			return ctx.Err()
 		}
+		t0 := time.Now()
 		header, err := tarReader.Next()
+		totalTarNext += time.Since(t0)
 		if err == io.EOF {
 			break
 		} else if err != nil {
@@ -528,28 +594,41 @@ func readTar(
 			continue
 		}
 
-		writer := bytes.NewBuffer(make([]byte, 0, header.Size))
-		tarBytesRead, err := io.Copy(writer, tarReader)
-		if err != nil {
-			mlog.Log.Errorf("err copying data to reader: %s\n", err)
-			cleanupPartial("copy error")
-			return err
-		}
-		statsd.Count(statsd.SnapshotTarBytesRead, tarBytesRead, nil)
-
-		// Update extract progress
-		if dp != nil {
-			dp.Extract.Add(tarBytesRead)
-		}
-
-		task := appendVecCopyingTask{TarBuffer: writer, Filename: header.Name, FromIncrementalSnapshot: options.isIncremental}
 		if pools == nil {
 			cleanupPartial("worker pool unavailable")
 			return fmt.Errorf("snapshot archive contains appendvec %q but no worker pool is available", header.Name)
 		}
+		bufs := pools.tarBufs
+		t1 := time.Now()
+		bp := bufs.get(int(header.Size))
+		_, err = io.ReadFull(tarReader, *bp)
+		totalReadCopy += time.Since(t1)
+		if err != nil {
+			mlog.Log.Errorf("err reading tar entry data: %s\n", err)
+			cleanupPartial("read error")
+			bufs.put(bp)
+			return err
+		}
+		entryCount++
+		bytesOut += header.Size
+		statsd.Count(statsd.SnapshotTarBytesRead, header.Size, nil)
+
+		// Update extract progress
+		if dp != nil {
+			dp.Extract.Add(header.Size)
+		}
+
+		task := appendVecCopyingTask{Buf: *bp, BufRef: bp, Filename: header.Name, FromIncrementalSnapshot: options.isIncremental}
+		if pools == nil {
+			cleanupPartial("worker pool unavailable")
+			return fmt.Errorf("snapshot archive contains appendvec %q but no worker pool is available", header.Name)
+		}
+		t2 := time.Now()
 		err = invokeSnapshotTask(wg, pools.appendVecCopying, task)
+		totalDispatch += time.Since(t2)
 		if err != nil {
 			mlog.Log.Errorf("error calling appendVecCopyingPool.Invoke: %v", err)
+			bufs.put(bp)
 			cleanupPartial("pool error")
 			return err
 		}
@@ -566,6 +645,15 @@ func readTar(
 		return err
 	}
 
+	elapsed := time.Since(readTarStart)
+	mibps := 0.0
+	if elapsed > 0 {
+		mibps = float64(bytesOut) / (1 << 20) / elapsed.Seconds()
+	}
+	mlog.Log.Infof("readTar timing: entries=%d bytesOut=%dMB elapsed=%s avgMiBps=%.0f tarNext=%s readCopy=%s dispatch=%s",
+		entryCount, bytesOut/(1<<20), fmtDuration(elapsed), mibps,
+		fmtDuration(totalTarNext), fmtDuration(totalReadCopy), fmtDuration(totalDispatch))
+
 	// Successfully processed the entire tar — finalize by renaming from .partial
 	if err := FinalizePartialDownload(savePath); err != nil {
 		mlog.Log.Errorf("Failed to finalize snapshot download: %v", err)
@@ -581,6 +669,7 @@ type snapshotWorkerPools struct {
 	indexEntryBuilder   *ants.PoolWithFunc
 	indexEntryCommitter *ants.PoolWithFunc
 	errors              *snapshotWorkerErrors
+	tarBufs             *tarBufPool
 }
 
 type snapshotWorkerErrors struct {
@@ -677,14 +766,14 @@ func initWorkerPools(
 	sl *ShardLogger,
 	manifest *SnapshotManifest,
 	incrementalManifest *SnapshotManifest,
-	accountsDbDir string,
-	largestFileId *atomic.Uint64,
+	shardFiles *shardBigFiles,
 	stakeCollector *stakeIndexCollector,
 ) (*snapshotWorkerPools, error) {
 	indexEntryCommitterWorkers := snapshotIndexEntryCommitterWorkers()
 	indexEntryBuilderWorkers := snapshotIndexEntryBuilderWorkers()
 	appendVecCopyingWorkers := snapshotAppendVecCopyingWorkers()
 	workerErrors := &snapshotWorkerErrors{}
+	tarBufs := newTarBufPool()
 
 	indexEntryCommitterPool, err := ants.NewPoolWithFunc(indexEntryCommitterWorkers, func(i any) {
 		tasks := indexEntryCommitterInProgress.Add(1)
@@ -718,11 +807,12 @@ func initWorkerPools(
 		defer wg.Done()
 		defer indexEntryBuilderInProgress.Add(-1)
 		defer workerErrors.Recover("index entry builder")
+		task := i.(indexEntryBuilderTask)
+		defer tarBufs.put(task.BufRef)
 		if workerErrors.Err() != nil {
 			return
 		}
-		task := i.(indexEntryBuilderTask)
-		pubkeys, entries, stakeEntries, err := accountsdb.BuildIndexEntriesFromAppendVecs(task.Data, task.FileSize, task.Slot, task.FileId)
+		pubkeys, entries, stakeEntries, err := accountsdb.BuildIndexEntriesFromAppendVecs(task.Data, task.FileSize, task.Slot, task.FileId, task.BaseOffset)
 		if err != nil {
 			workerErrors.Record(fmt.Errorf("building index entries: %w", err))
 			return
@@ -750,46 +840,28 @@ func initWorkerPools(
 		defer wg.Done()
 		defer appendVecCopyingInProgress.Add(-1)
 		defer workerErrors.Recover("appendvec copying")
+		task := i.(appendVecCopyingTask)
+		handedOff := false
+		defer func() {
+			if !handedOff {
+				tarBufs.put(task.BufRef)
+			}
+		}()
 		if workerErrors.Err() != nil {
 			return
 		}
-		task := i.(appendVecCopyingTask)
 		filename := task.Filename
-		writer := task.TarBuffer
+		appendVecBytes := task.Buf
 
-		outFilename := filepath.Join(accountsDbDir, filename)
-
-		// validate that the path doesn't escape accountsDbDir (via '../' sequences)
-		cleanPath := filepath.Clean(outFilename)
-		if !strings.HasPrefix(cleanPath, filepath.Clean(accountsDbDir)+string(os.PathSeparator)) {
+		cleanName := filepath.Clean(filename)
+		if filepath.IsAbs(filename) || !strings.HasPrefix(cleanName, "accounts/") || strings.Count(cleanName, "/") != 1 {
 			workerErrors.Record(fmt.Errorf("invalid path in tar archive: %s", filename))
 			return
 		}
-
-		appendVecBytes := writer.Bytes()
-		err := os.WriteFile(cleanPath, appendVecBytes, 0644)
-		if err != nil {
-			workerErrors.Record(fmt.Errorf("writing appendvec %s: %w", cleanPath, err))
+		var slot, origFileId uint64
+		if n, err := fmt.Sscanf(filepath.Base(filename), "%d.%d", &slot, &origFileId); n != 2 || err != nil {
+			workerErrors.Record(fmt.Errorf("failed to parse appendvec filename=%s: %v", filename, err))
 			return
-		}
-
-		var slot, fileId uint64
-		if n, err := fmt.Sscanf(filepath.Base(filename), "%d.%d", &slot, &fileId); n != 2 || err != nil {
-			workerErrors.Record(fmt.Errorf(
-				"failed to parse slot and file from filename=%s basename=%s; parsed n=%d arguments (expected 2) and had err=%v",
-				filename, filepath.Base(filename), n, err))
-			return
-		}
-
-		for {
-			prevLargestFileId := largestFileId.Load()
-			if fileId <= prevLargestFileId {
-				break
-			}
-			swapped := largestFileId.CompareAndSwap(prevLargestFileId, fileId)
-			if swapped {
-				break
-			}
 		}
 
 		// find the relevant appendvec storage info. use the info from the incremental
@@ -802,7 +874,7 @@ func initWorkerPools(
 				return
 			}
 			for _, av := range incrementalManifest.AccountsDb.Storages[slot].AcctVecs {
-				if av.Id == fileId {
+				if av.Id == origFileId {
 					fileSize = av.FileSize
 					usedIncrementalSnapshotVal = true
 					break
@@ -812,7 +884,7 @@ func initWorkerPools(
 
 		if !usedIncrementalSnapshotVal {
 			for _, av := range manifest.AccountsDb.Storages[slot].AcctVecs {
-				if av.Id == fileId {
+				if av.Id == origFileId {
 					fileSize = av.FileSize
 					break
 				}
@@ -820,13 +892,23 @@ func initWorkerPools(
 		}
 
 		if fileSize == 0 {
-			workerErrors.Record(fmt.Errorf("manifest has no file size for appendvec slot=%d file_id=%d", slot, fileId))
+			workerErrors.Record(fmt.Errorf("manifest has no file size for appendvec slot=%d file_id=%d", slot, origFileId))
+			return
+		}
+		if uint64(len(appendVecBytes)) < fileSize {
+			panic(fmt.Sprintf("appendvec blob (%d bytes) shorter than manifest fileSize (%d)", len(appendVecBytes), fileSize))
+		}
+
+		fileId, base, err := shardFiles.write(appendVecBytes[:fileSize])
+		if err != nil {
+			workerErrors.Record(fmt.Errorf("writing appendvec to shard big file: %w", err))
 			return
 		}
 
-		nextTask := indexEntryBuilderTask{Data: appendVecBytes, FileSize: fileSize, Slot: slot, FileId: fileId}
+		nextTask := indexEntryBuilderTask{Data: appendVecBytes, FileSize: fileSize, Slot: slot, FileId: fileId, BaseOffset: base, BufRef: task.BufRef}
 		statsd.Timing(statsd.TasksAppendVecCopyingLatency, uint64(time.Since(start)), nil)
 		err = invokeSnapshotTask(wg, indexEntryBuilderPool, nextTask)
+		handedOff = err == nil
 		if err != nil {
 			workerErrors.Record(fmt.Errorf("submitting index entry builder task: %w", err))
 		}
@@ -842,6 +924,7 @@ func initWorkerPools(
 		indexEntryBuilderPool,
 		indexEntryCommitterPool,
 		workerErrors,
+		tarBufs,
 	}, nil
 }
 

--- a/pkg/snapshot/build_db.go
+++ b/pkg/snapshot/build_db.go
@@ -26,7 +26,7 @@ const (
 	DefaultSnapshotIndexEntryCommitterWorkers = 64
 	DefaultSnapshotIndexEntryBuilderWorkers   = 64
 	DefaultSnapshotAppendVecCopyingWorkers    = 32
-	DefaultSnapshotIndexShards                = 64
+	DefaultSnapshotIndexShards                = 256
 	DefaultSnapshotMaxConcurrentFlushers      = 8
 	// DefaultSnapshotFlushSortWorkers == 0 means "auto": use runtime.NumCPU().
 	DefaultSnapshotFlushSortWorkers = 0

--- a/pkg/snapshot/build_db.go
+++ b/pkg/snapshot/build_db.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -27,6 +28,8 @@ const (
 	DefaultSnapshotAppendVecCopyingWorkers    = 32
 	DefaultSnapshotIndexShards                = 64
 	DefaultSnapshotMaxConcurrentFlushers      = 8
+	// DefaultSnapshotFlushSortWorkers == 0 means "auto": use runtime.NumCPU().
+	DefaultSnapshotFlushSortWorkers = 0
 	// DefaultSnapshotDirectIO keeps O_DIRECT big-file writes off by default;
 	// buffered is the safe default and O_DIRECT is an opt-in tuning knob.
 	DefaultSnapshotDirectIO = false
@@ -37,6 +40,7 @@ var (
 	SnapshotIndexEntryBuilderWorkers   = DefaultSnapshotIndexEntryBuilderWorkers
 	SnapshotAppendVecCopyingWorkers    = DefaultSnapshotAppendVecCopyingWorkers
 	SnapshotIndexShards                = DefaultSnapshotIndexShards
+	SnapshotFlushSortWorkers           = DefaultSnapshotFlushSortWorkers
 	SnapshotDirectIO                   = DefaultSnapshotDirectIO
 	SnapshotIndexTempDir               string
 )
@@ -230,17 +234,27 @@ func snapshotMaxConcurrentFlushers() int {
 	return positiveOrDefault(MaxConcurrentFlushers, DefaultSnapshotMaxConcurrentFlushers)
 }
 
+// snapshotFlushSortWorkers is how many shard buffers may be sorted concurrently
+// during the index flush. 0 (the default) means auto: one per logical CPU.
+func snapshotFlushSortWorkers() int {
+	if SnapshotFlushSortWorkers > 0 {
+		return SnapshotFlushSortWorkers
+	}
+	return runtime.NumCPU()
+}
+
 func logSnapshotBootstrapTuning() {
 	indexTempDir := SnapshotIndexTempDir
 	if indexTempDir == "" {
 		indexTempDir = "(accountsdb)"
 	}
-	mlog.Log.Infof("Snapshot bootstrap tuning: append_vec_workers=%d index_builder_workers=%d index_committer_workers=%d index_shards=%d max_concurrent_flushers=%d directio=%v zstd_decoder_concurrency=%d index_temp_dir=%s",
+	mlog.Log.Infof("Snapshot bootstrap tuning: append_vec_workers=%d index_builder_workers=%d index_committer_workers=%d index_shards=%d max_concurrent_flushers=%d flush_sort_workers=%d directio=%v zstd_decoder_concurrency=%d index_temp_dir=%s",
 		snapshotAppendVecCopyingWorkers(),
 		snapshotIndexEntryBuilderWorkers(),
 		snapshotIndexEntryCommitterWorkers(),
 		snapshotIndexShards(),
 		snapshotMaxConcurrentFlushers(),
+		snapshotFlushSortWorkers(),
 		SnapshotDirectIO,
 		ZstdDecoderConcurrency,
 		indexTempDir)

--- a/pkg/snapshot/build_db.go
+++ b/pkg/snapshot/build_db.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -25,6 +26,8 @@ const (
 	DefaultSnapshotAppendVecCopyingWorkers    = 32
 	DefaultSnapshotIndexShards                = 64
 	DefaultSnapshotMaxConcurrentFlushers      = 8
+	// DefaultSnapshotFlushSortWorkers == 0 means "auto": use runtime.NumCPU().
+	DefaultSnapshotFlushSortWorkers = 0
 	// DefaultSnapshotDirectIO keeps O_DIRECT big-file writes off by default;
 	// buffered is the safe default and O_DIRECT is an opt-in tuning knob.
 	DefaultSnapshotDirectIO = false
@@ -35,6 +38,7 @@ var (
 	SnapshotIndexEntryBuilderWorkers   = DefaultSnapshotIndexEntryBuilderWorkers
 	SnapshotAppendVecCopyingWorkers    = DefaultSnapshotAppendVecCopyingWorkers
 	SnapshotIndexShards                = DefaultSnapshotIndexShards
+	SnapshotFlushSortWorkers           = DefaultSnapshotFlushSortWorkers
 	SnapshotDirectIO                   = DefaultSnapshotDirectIO
 	SnapshotIndexTempDir               string
 )
@@ -213,17 +217,27 @@ func snapshotMaxConcurrentFlushers() int {
 	return positiveOrDefault(MaxConcurrentFlushers, DefaultSnapshotMaxConcurrentFlushers)
 }
 
+// snapshotFlushSortWorkers is how many shard buffers may be sorted concurrently
+// during the index flush. 0 (the default) means auto: one per logical CPU.
+func snapshotFlushSortWorkers() int {
+	if SnapshotFlushSortWorkers > 0 {
+		return SnapshotFlushSortWorkers
+	}
+	return runtime.NumCPU()
+}
+
 func logSnapshotBootstrapTuning() {
 	indexTempDir := SnapshotIndexTempDir
 	if indexTempDir == "" {
 		indexTempDir = "(accountsdb)"
 	}
-	mlog.Log.Infof("Snapshot bootstrap tuning: append_vec_workers=%d index_builder_workers=%d index_committer_workers=%d index_shards=%d max_concurrent_flushers=%d directio=%v zstd_decoder_concurrency=%d index_temp_dir=%s",
+	mlog.Log.Infof("Snapshot bootstrap tuning: append_vec_workers=%d index_builder_workers=%d index_committer_workers=%d index_shards=%d max_concurrent_flushers=%d flush_sort_workers=%d directio=%v zstd_decoder_concurrency=%d index_temp_dir=%s",
 		snapshotAppendVecCopyingWorkers(),
 		snapshotIndexEntryBuilderWorkers(),
 		snapshotIndexEntryCommitterWorkers(),
 		snapshotIndexShards(),
 		snapshotMaxConcurrentFlushers(),
+		snapshotFlushSortWorkers(),
 		SnapshotDirectIO,
 		ZstdDecoderConcurrency,
 		indexTempDir)

--- a/pkg/snapshot/build_db_with_incr.go
+++ b/pkg/snapshot/build_db_with_incr.go
@@ -45,8 +45,8 @@ func BuildAccountsDbAuto(
 	snapCfg snapshotdl.SnapshotConfig,
 	dp *progress.DualProgress,
 ) (*accountsdb.AccountsDb, *SnapshotManifest, error) {
-	if len(accountsPaths) == 0 {
-		return nil, nil, fmt.Errorf("no accounts paths configured")
+	if err := accountsdb.ValidateAccountsPaths(accountsPaths); err != nil {
+		return nil, nil, err
 	}
 	// The first path holds all metadata; every path holds a shard's accounts dir.
 	accountsDbDir := accountsPaths[0]
@@ -76,6 +76,7 @@ func BuildAccountsDbAuto(
 	if err != nil {
 		return nil, nil, fmt.Errorf("opening shard big files: %w", err)
 	}
+	defer shardFiles.close() // also drain and release writers on bootstrap errors
 	logSnapshotBootstrapTuning()
 
 	defer ants.Release()
@@ -257,6 +258,9 @@ func BuildAccountsDbAuto(
 	if err != nil {
 		return nil, nil, err
 	}
+
+	// Workers have drained; release their pools before the memory-intensive sort.
+	pools.Release()
 
 	// flush and close every shard's big file now that all appends are done
 	if err := shardFiles.close(); err != nil {

--- a/pkg/snapshot/build_db_with_incr.go
+++ b/pkg/snapshot/build_db_with_incr.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/Overclock-Validator/mithril/pkg/accountsdb"
@@ -40,14 +39,19 @@ func BuildAccountsDbAuto(
 	snapshotDownloadPath string,
 	fullSnapshotSlot int,
 	referenceSlot int,
-	accountsDbDir string,
+	accountsPaths []string,
 	rpcEndpoints []string,
 	blockDir string,
 	snapCfg snapshotdl.SnapshotConfig,
 	dp *progress.DualProgress,
 ) (*accountsdb.AccountsDb, *SnapshotManifest, error) {
+	if len(accountsPaths) == 0 {
+		return nil, nil, fmt.Errorf("no accounts paths configured")
+	}
+	// The first path holds all metadata; every path holds a shard's accounts dir.
+	accountsDbDir := accountsPaths[0]
 	// Clean any leftover artifacts from previous incomplete runs (e.g., Ctrl+C)
-	CleanAccountsDbDir(accountsDbDir)
+	CleanAccountsDbDirs(accountsPaths)
 
 	mlog.Log.Infof("Parsing full snapshot manifest...")
 	manifest, err := UnmarshalManifestFromSnapshot(ctx, fullSnapshotFile, accountsDbDir)
@@ -61,16 +65,22 @@ func BuildAccountsDbAuto(
 
 	start := time.Now()
 
-	appendVecsOutputDir := filepath.Join(accountsDbDir, "accounts")
-	if err = os.MkdirAll(appendVecsOutputDir, 0775); err != nil {
-		return nil, nil, err
+	shardDirs := make([]string, len(accountsPaths))
+	for i, p := range accountsPaths {
+		shardDirs[i] = filepath.Join(p, "accounts")
+		if err = os.MkdirAll(shardDirs[i], 0775); err != nil {
+			return nil, nil, err
+		}
+	}
+	shardFiles, err := openShardBigFiles(shardDirs)
+	if err != nil {
+		return nil, nil, fmt.Errorf("opening shard big files: %w", err)
 	}
 	logSnapshotBootstrapTuning()
 
 	defer ants.Release()
 
 	incrementalManifest := &SnapshotManifest{}
-	var largestFileId atomic.Uint64
 	wg := &sync.WaitGroup{}
 
 	numShards := snapshotIndexShards()
@@ -86,7 +96,7 @@ func BuildAccountsDbAuto(
 		entries: make([]accountsdb.StakeIndexEntry, 0, 1000000), // Pre-allocate for ~1M stake accounts
 	}
 
-	pools, err := initWorkerPools(wg, sl, manifest, incrementalManifest, accountsDbDir, &largestFileId, stakeCollector)
+	pools, err := initWorkerPools(wg, sl, manifest, incrementalManifest, shardFiles, stakeCollector)
 	if err != nil {
 		return nil, nil, fmt.Errorf("initializing worker pools: %w", err)
 	}
@@ -248,6 +258,11 @@ func BuildAccountsDbAuto(
 		return nil, nil, err
 	}
 
+	// flush and close every shard's big file now that all appends are done
+	if err := shardFiles.close(); err != nil {
+		return nil, nil, fmt.Errorf("closing shard big files: %w", err)
+	}
+
 	// Show indexing progress for shard flush
 	indexProgress := progress.NewIndexingProgress("Flush (shard logs)")
 	indexProgress.Start(numShards)
@@ -261,12 +276,13 @@ func BuildAccountsDbAuto(
 	}
 	index.Close()
 
-	var largestFileIdBytes [8]byte
-	binary.LittleEndian.PutUint64(largestFileIdBytes[:], largestFileId.Load())
+	if err := writeShardMetadata(accountsDbDir, len(shardDirs)); err != nil {
+		return nil, nil, err
+	}
 
-	path := filepath.Join(accountsDbDir, "largest_file_id")
-	if err := os.WriteFile(path, largestFileIdBytes[:], 0644); err != nil {
-		mlog.Log.Errorf("error while writing largest file ID=%d to %s: %s", largestFileId.Load(), path, err)
+	var largestFileIdBytes [8]byte
+	binary.LittleEndian.PutUint64(largestFileIdBytes[:], uint64(len(shardDirs)-1))
+	if err := os.WriteFile(filepath.Join(accountsDbDir, "largest_file_id"), largestFileIdBytes[:], 0644); err != nil {
 		return nil, nil, err
 	}
 
@@ -298,7 +314,7 @@ func BuildAccountsDbAuto(
 	}
 	bankhashDb.Close()
 
-	accountsDb, err := accountsdb.OpenDb(accountsDbDir)
+	accountsDb, err := accountsdb.OpenDbPaths(accountsPaths)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/snapshot/build_db_with_incr.go
+++ b/pkg/snapshot/build_db_with_incr.go
@@ -2,13 +2,11 @@ package snapshot
 
 import (
 	"context"
-	"encoding/binary"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/Overclock-Validator/mithril/pkg/accountsdb"
@@ -40,14 +38,19 @@ func BuildAccountsDbAuto(
 	snapshotDownloadPath string,
 	fullSnapshotSlot int,
 	referenceSlot int,
-	accountsDbDir string,
+	accountsPaths []string,
 	rpcEndpoints []string,
 	blockDir string,
 	snapCfg snapshotdl.SnapshotConfig,
 	dp *progress.DualProgress,
 ) (*accountsdb.AccountsDb, *SnapshotManifest, error) {
+	if len(accountsPaths) == 0 {
+		return nil, nil, fmt.Errorf("no accounts paths configured")
+	}
+	// The first path holds all metadata; every path holds a shard's accounts dir.
+	accountsDbDir := accountsPaths[0]
 	// Clean any leftover artifacts from previous incomplete runs (e.g., Ctrl+C)
-	CleanAccountsDbDir(accountsDbDir)
+	CleanAccountsDbDir(accountsPaths)
 
 	mlog.Log.Infof("Parsing full snapshot manifest...")
 	manifest, err := UnmarshalManifestFromSnapshot(ctx, fullSnapshotFile, accountsDbDir)
@@ -58,16 +61,22 @@ func BuildAccountsDbAuto(
 
 	start := time.Now()
 
-	appendVecsOutputDir := filepath.Join(accountsDbDir, "accounts")
-	if err = os.MkdirAll(appendVecsOutputDir, 0775); err != nil {
-		return nil, nil, err
+	shardDirs := make([]string, len(accountsPaths))
+	for i, p := range accountsPaths {
+		shardDirs[i] = filepath.Join(p, "accounts")
+		if err = os.MkdirAll(shardDirs[i], 0775); err != nil {
+			return nil, nil, err
+		}
+	}
+	shardFiles, err := openShardBigFiles(shardDirs)
+	if err != nil {
+		return nil, nil, fmt.Errorf("opening shard big files: %w", err)
 	}
 	logSnapshotBootstrapTuning()
 
 	defer ants.Release()
 
 	incrementalManifest := &SnapshotManifest{}
-	var largestFileId atomic.Uint64
 	wg := &sync.WaitGroup{}
 
 	numShards := snapshotIndexShards()
@@ -83,7 +92,7 @@ func BuildAccountsDbAuto(
 		entries: make([]accountsdb.StakeIndexEntry, 0, 1000000), // Pre-allocate for ~1M stake accounts
 	}
 
-	pools, err := initWorkerPools(wg, sl, manifest, incrementalManifest, accountsDbDir, &largestFileId, stakeCollector)
+	pools, err := initWorkerPools(wg, sl, manifest, incrementalManifest, shardFiles, stakeCollector)
 	if err != nil {
 		return nil, nil, fmt.Errorf("initializing worker pools: %w", err)
 	}
@@ -114,7 +123,7 @@ func BuildAccountsDbAuto(
 		dp.Start()
 	}
 
-	err = readTar(ctx, wg, fullSnapshotFile, pools.appendVecCopying, readTarOptions{savePath: fullSavePath, progress: dp})
+	err = readTar(ctx, wg, fullSnapshotFile, pools.appendVecCopying, pools.tarBufs, readTarOptions{savePath: fullSavePath, progress: dp})
 	if err != nil {
 		if dp != nil {
 			dp.Interrupt(err)
@@ -197,7 +206,7 @@ func BuildAccountsDbAuto(
 			}
 		}
 
-		err = readTar(ctx, wg, incrementalSnapshotPath, pools.appendVecCopying, readTarOptions{savePath: incrSavePath, isIncremental: true})
+		err = readTar(ctx, wg, incrementalSnapshotPath, pools.appendVecCopying, pools.tarBufs, readTarOptions{savePath: incrSavePath, isIncremental: true})
 		wg.Wait()
 		// Check if we should retry
 		if err == nil {
@@ -208,6 +217,11 @@ func BuildAccountsDbAuto(
 	}
 	if err != nil {
 		return nil, nil, err
+	}
+
+	// flush and close every shard's big file now that all appends are done
+	if err := shardFiles.close(); err != nil {
+		return nil, nil, fmt.Errorf("closing shard big files: %w", err)
 	}
 
 	// Show indexing progress for shard flush
@@ -223,12 +237,7 @@ func BuildAccountsDbAuto(
 	}
 	index.Close()
 
-	var largestFileIdBytes [8]byte
-	binary.LittleEndian.PutUint64(largestFileIdBytes[:], largestFileId.Load())
-
-	path := filepath.Join(accountsDbDir, "largest_file_id")
-	if err := os.WriteFile(path, largestFileIdBytes[:], 0644); err != nil {
-		mlog.Log.Errorf("error while writing largest file ID=%d to %s: %s", largestFileId.Load(), path, err)
+	if err := writeShardMetadata(accountsDbDir, len(shardDirs)); err != nil {
 		return nil, nil, err
 	}
 
@@ -253,7 +262,7 @@ func BuildAccountsDbAuto(
 	}
 	bankhashDb.Close()
 
-	accountsDb, err := accountsdb.OpenDb(accountsDbDir)
+	accountsDb, err := accountsdb.OpenDb(accountsPaths)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/snapshot/build_db_worker_test.go
+++ b/pkg/snapshot/build_db_worker_test.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
-	"sync/atomic"
 	"testing"
 
 	"github.com/Overclock-Validator/mithril/pkg/accountsdb"
@@ -51,22 +50,24 @@ func TestSnapshotWorkerParseFailurePropagatesAfterDrain(t *testing.T) {
 	manifest.AccountsDb.Storages = map[uint64]SlotAcctVecs{
 		slot: {Slot: slot, AcctVecs: []AcctVec{{Id: fileID, FileSize: uint64(len(malformed))}}},
 	}
+	shardFiles, err := openShardBigFiles([]string{filepath.Join(accountsDir, "accounts")})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, shardFiles.close()) })
 	wg := &sync.WaitGroup{}
 	pools, err := initWorkerPools(
 		wg,
 		shardLogger,
 		manifest,
 		nil,
-		accountsDir,
-		&atomic.Uint64{},
+		shardFiles,
 		&stakeIndexCollector{},
 	)
 	require.NoError(t, err)
 	t.Cleanup(pools.Release)
 
 	err = invokeSnapshotTask(wg, pools.appendVecCopying, appendVecCopyingTask{
-		Filename:  "accounts/20.21",
-		TarBuffer: bytes.NewBuffer(malformed),
+		Filename: "accounts/20.21",
+		Buf:      malformed,
 	})
 	require.NoError(t, err)
 	require.ErrorContains(t, waitForSnapshotWorkers(wg, pools), "truncated appendvec account data")

--- a/pkg/snapshot/directio_linux.go
+++ b/pkg/snapshot/directio_linux.go
@@ -1,0 +1,7 @@
+//go:build linux
+
+package snapshot
+
+import "syscall"
+
+func directIOFlag() (int, error) { return syscall.O_DIRECT, nil }

--- a/pkg/snapshot/directio_other.go
+++ b/pkg/snapshot/directio_other.go
@@ -1,0 +1,9 @@
+//go:build !linux
+
+package snapshot
+
+import "fmt"
+
+func directIOFlag() (int, error) {
+	return 0, fmt.Errorf("snapshot direct I/O is only supported on Linux; disable snapshot_directio")
+}

--- a/pkg/snapshot/shard.go
+++ b/pkg/snapshot/shard.go
@@ -10,7 +10,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
-	"slices"
+	"sort"
 	"sync"
 	"sync/atomic"
 
@@ -31,20 +31,12 @@ type shardRequest struct {
 	v accountsdb.AccountIndexEntry
 }
 
-// ShardProgressCallback is called with (bytesDone, totalBytes) to report shard flush progress
-type ShardProgressCallback func(bytesDone, totalBytes int64)
-
 // ShardLogger manages multiple sharded log files
 type ShardLogger struct {
 	shards     []*shard
 	filePrefix string
 	wg         *sync.WaitGroup
 	flushSem   *semaphore.Weighted
-
-	// Progress tracking
-	totalBytes atomic.Int64 // total bytes written to shard logs
-	bytesDone  atomic.Int64 // bytes flushed to cache
-	onProgress ShardProgressCallback
 
 	// closed flag to prevent sends after Close is called (defensive)
 	closed atomic.Bool
@@ -57,7 +49,6 @@ type shard struct {
 	file     *os.File
 	requests chan shardRequest
 	logSize  int
-	flushSem *semaphore.Weighted
 	parent   *ShardLogger // parent for progress reporting
 }
 
@@ -81,31 +72,15 @@ func NewShardLogger(numShards int, filePrefix string) *ShardLogger {
 
 	sl.wg.Add(numShards)
 	for i := range numShards {
-		sl.shards[i] = newShard(i, filePrefix, sl.flushSem, sl)
+		sl.shards[i] = newShard(i, filePrefix, sl)
 		go sl.shards[i].processRequests(sl.wg)
 	}
 
 	return sl
 }
 
-// SetProgressCallback sets a callback to receive progress updates during shard flushes.
-// The callback receives (bytesDone, totalBytes) and is called as bytes are flushed to cache.
-func (sl *ShardLogger) SetProgressCallback(cb ShardProgressCallback) {
-	sl.onProgress = cb
-}
-
-// TotalBytes returns the total bytes written to shard logs
-func (sl *ShardLogger) TotalBytes() int64 {
-	return sl.totalBytes.Load()
-}
-
-// BytesDone returns the bytes that have been flushed to cache
-func (sl *ShardLogger) BytesDone() int64 {
-	return sl.bytesDone.Load()
-}
-
 // newShard creates a new shard with the given ID
-func newShard(id int, filePrefix string, flushSem *semaphore.Weighted, parent *ShardLogger) *shard {
+func newShard(id int, filePrefix string, parent *ShardLogger) *shard {
 	filename := filepath.Join(filePrefix, fmt.Sprintf("%03d", id))
 	file, err := os.Create(filename)
 	if err != nil {
@@ -117,7 +92,6 @@ func newShard(id int, filePrefix string, flushSem *semaphore.Weighted, parent *S
 		writer:   bufio.NewWriter(file),
 		file:     file,
 		requests: make(chan shardRequest, 100),
-		flushSem: flushSem,
 		parent:   parent,
 	}
 
@@ -136,105 +110,78 @@ func (s *shard) processRequests(wg *sync.WaitGroup) {
 		s.writer.Write(kBytes[:])
 		req.v.Marshal(&vBytes)
 		s.writer.Write(vBytes[:24])
-
-		bytesWritten := int64(len(req.k) + vlen)
-		s.logSize += int(bytesWritten)
-
-		// Track total bytes for progress reporting and notify callback
-		if s.parent != nil {
-			total := s.parent.totalBytes.Add(bytesWritten)
-			if s.parent.onProgress != nil {
-				// Notify with bytesDone=0 during streaming (before flush)
-				// The callback can use totalBytes to show indexing progress
-				s.parent.onProgress(0, total)
-			}
-		}
+		s.logSize += len(req.k) + vlen
 	}
 }
 
-func (s *shard) logToSST(ctx context.Context) error {
-	err := s.flushSem.Acquire(ctx, 1)
-	if err != nil {
-		return fmt.Errorf("acquiring flush semaphore: %w", err)
-	}
-	defer s.flushSem.Release(1)
-	// Close/flush
+const recordSize = 32 + vlen
+
+// readLog flushes and closes the shard's log, then reads it fully back into a
+// pairs slice.
+func (s *shard) readLog() ([]shardRequest, error) {
 	if err := s.writer.Flush(); err != nil {
-		return fmt.Errorf("failed to flush writer: %w", err)
+		return nil, fmt.Errorf("failed to flush writer: %w", err)
 	}
 	filename := s.file.Name()
 	if err := s.file.Close(); err != nil {
-		return fmt.Errorf("failed to close file: %w", err)
+		return nil, fmt.Errorf("failed to close file: %w", err)
 	}
 
-	// Read contents from log
 	file, err := os.Open(filename)
 	if err != nil {
-		return fmt.Errorf("failed to reopen file for reading: %w", err)
+		return nil, fmt.Errorf("failed to reopen file for reading: %w", err)
 	}
 	defer file.Close()
 	fileInfo, err := file.Stat()
 	if err != nil {
-		return fmt.Errorf("stat %s: %w", filename, err)
+		return nil, fmt.Errorf("stat %s: %w", filename, err)
 	}
 	size := fileInfo.Size()
 
-	const recordSize = int64(32 + vlen)
 	if rem := size % recordSize; rem != 0 {
-		return fmt.Errorf("filename=%s had (size=%d) %% (recordSize=%d) = %d", filename, size, recordSize, rem)
+		return nil, fmt.Errorf("filename=%s had (size=%d) %% (recordSize=%d) = %d", filename, size, recordSize, rem)
 	}
-	i := 0
 	pairs := make([]shardRequest, size/recordSize)
 
 	reader := bufio.NewReader(file)
-	var buf [32 + vlen]byte
-	for {
-		_, err := io.ReadFull(reader, buf[:32+vlen])
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			return fmt.Errorf("logToSST read loop: %v", err)
+	var buf [recordSize]byte
+	for i := range pairs {
+		if _, err := io.ReadFull(reader, buf[:]); err != nil {
+			return nil, fmt.Errorf("readLog read loop: %w", err)
 		}
 		pairs[i].k = solana.PublicKey(buf[:32])
 		pairs[i].v.Unmarshal((*[24]byte)(buf[32:56]))
-		i++
-
-		// Track progress
-		if s.parent != nil {
-			done := s.parent.bytesDone.Add(recordSize)
-			if s.parent.onProgress != nil {
-				s.parent.onProgress(done, s.parent.totalBytes.Load())
-			}
-		}
 	}
 
-	// Truncate file and replace file/writer pointers
-	newFile, err := os.Create(filename)
-	if err != nil {
-		return fmt.Errorf("failed to truncate file: %w", err)
+	if err := os.Remove(filename); err != nil {
+		return nil, fmt.Errorf("removing read log %s: %w", filename, err)
 	}
-	s.file = newFile
-	s.writer = bufio.NewWriter(newFile)
-	s.logSize = 0
+	return pairs, nil
+}
 
-	// Sort
-	slices.SortFunc(pairs, func(a, b shardRequest) int {
-		if c := bytes.Compare(a.k[:], b.k[:]); c != 0 {
-			return c
-		}
-		// Make the bigger slot appear first.
-		if a.v.Slot > b.v.Slot {
-			return -1
-		} else if a.v.Slot == b.v.Slot {
-			return 0
-		} else {
-			return 1
-		}
-	})
-	var vBytes [vlen]byte
-	// Write to SST
-	sstFilename := fmt.Sprintf("%s.sst", filename)
+// byKeySlotDesc sorts entries by pubkey ascending, then by slot descending so the
+// first occurrence of each key is its highest slot (which writeSST keeps). It uses
+// sort.Interface (index-based Less) rather than slices.SortFunc so the comparator
+// indexes into the slice instead of receiving 56-byte shardRequest values by copy.
+type byKeySlotDesc []shardRequest
+
+func (p byKeySlotDesc) Len() int      { return len(p) }
+func (p byKeySlotDesc) Swap(i, j int) { p[i], p[j] = p[j], p[i] }
+func (p byKeySlotDesc) Less(i, j int) bool {
+	if c := bytes.Compare(p[i].k[:], p[j].k[:]); c != 0 {
+		return c < 0
+	}
+	return p[i].v.Slot > p[j].v.Slot // bigger slot first
+}
+
+func sortPairs(pairs []shardRequest) {
+	sort.Sort(byKeySlotDesc(pairs))
+}
+
+// writeSST writes the (already sorted) pairs to the shard's SST file, keeping the
+// first entry per key (highest slot) and skipping duplicates.
+func (s *shard) writeSST(pairs []shardRequest) error {
+	sstFilename := fmt.Sprintf("%s.sst", s.file.Name())
 	sstFile, err := vfs.Default.Create(sstFilename)
 	if err != nil {
 		return fmt.Errorf("create %s: %w", sstFilename, err)
@@ -242,18 +189,21 @@ func (s *shard) logToSST(ctx context.Context) error {
 	defer sstFile.Close()
 	w := sstable.NewWriter(objstorageprovider.NewFileWritable(sstFile), sstable.WriterOptions{})
 	defer w.Close()
-	lastWritten := -1
-	for i, kv := range pairs {
-		if lastWritten >= 0 && bytes.Equal(kv.k[:], pairs[lastWritten].k[:]) {
+	var vBytes [vlen]byte
+	var lastKey solana.PublicKey
+	wrote := false
+	for i := range pairs {
+		kv := &pairs[i]
+		if wrote && kv.k == lastKey {
 			continue
 		}
 		kv.v.Marshal(&vBytes)
 		if err := w.Set(kv.k[:], vBytes[:]); err != nil {
 			return fmt.Errorf("writing to SST: %w", err)
 		}
-		lastWritten = i
+		lastKey = kv.k
+		wrote = true
 	}
-
 	return nil
 }
 
@@ -277,8 +227,16 @@ func (sl *ShardLogger) Close(ctx context.Context) error {
 	return sl.CloseWithProgress(ctx, nil)
 }
 
+// flushJob carries a shard and its read-back log buffer through the flush pipeline.
+type flushJob struct {
+	s     *shard
+	pairs []shardRequest
+}
+
 // CloseWithProgress closes all shards with optional progress callback.
 // The callback is called after each shard flush completes with (completed, total) counts.
+//
+// The flush runs as a 3-stage pipeline (read log, sort, write SST).
 func (sl *ShardLogger) CloseWithProgress(ctx context.Context, onProgress func(completed, total int)) error {
 	// Mark as closed before closing channels to prevent late sends
 	sl.closed.Store(true)
@@ -291,15 +249,82 @@ func (sl *ShardLogger) CloseWithProgress(ctx context.Context, onProgress func(co
 	total := len(sl.shards)
 	var completed atomic.Int32
 
-	flushWg := &errgroup.Group{}
+	// Channels are sized to hold every shard, so a job never blocks on send and the
+	// only thing bounding in-flight memory is the flushSem buffer-slot semaphore.
+	sortCh := make(chan flushJob, total)
+	writeCh := make(chan flushJob, total)
+
+	g, gctx := errgroup.WithContext(ctx)
+
+	// Read stage: a shard buffer is only allocated once a slot is free.
+	shardCh := make(chan *shard, total)
 	for _, s := range sl.shards {
-		flushWg.Go(func() error {
-			err := s.logToSST(ctx)
-			if onProgress != nil {
-				onProgress(int(completed.Add(1)), total)
+		shardCh <- s
+	}
+	close(shardCh)
+
+	ioWorkers := snapshotMaxConcurrentFlushers()
+	var readWg sync.WaitGroup
+	for range ioWorkers {
+		readWg.Add(1)
+		g.Go(func() error {
+			defer readWg.Done()
+			for s := range shardCh {
+				if err := sl.flushSem.Acquire(gctx, 1); err != nil {
+					return err
+				}
+				pairs, err := s.readLog()
+				if err != nil {
+					sl.flushSem.Release(1)
+					return err
+				}
+				sortCh <- flushJob{s, pairs}
 			}
-			return err
+			return nil
 		})
 	}
-	return flushWg.Wait()
+	go func() {
+		readWg.Wait()
+		close(sortCh)
+	}()
+
+	// Sort stage: CPU-bound. The number of sort workers is tunable (
+	// flush-sort-workers, default NumCPU); the effective concurrency
+	// is still bounded by the live-buffer count (flushSem), so to
+	// sort more shards at once raise max-concurrent-flushers too.
+	var sortWg sync.WaitGroup
+	for range snapshotFlushSortWorkers() {
+		sortWg.Add(1)
+		g.Go(func() error {
+			defer sortWg.Done()
+			for job := range sortCh {
+				sortPairs(job.pairs)
+				writeCh <- job
+			}
+			return nil
+		})
+	}
+	go func() {
+		sortWg.Wait()
+		close(writeCh)
+	}()
+
+	// Write the SST and release the buffer slot.
+	for range ioWorkers {
+		g.Go(func() error {
+			for job := range writeCh {
+				err := job.s.writeSST(job.pairs)
+				sl.flushSem.Release(1)
+				if err != nil {
+					return err
+				}
+				if onProgress != nil {
+					onProgress(int(completed.Add(1)), total)
+				}
+			}
+			return nil
+		})
+	}
+
+	return g.Wait()
 }

--- a/pkg/snapshot/shard_test.go
+++ b/pkg/snapshot/shard_test.go
@@ -1,0 +1,100 @@
+package snapshot
+
+import (
+	"context"
+	"encoding/binary"
+	"testing"
+
+	"github.com/Overclock-Validator/mithril/pkg/accountsdb"
+	"github.com/gagliardetto/solana-go"
+)
+
+// TestFlushPipelineDedupAndOrder feeds a known set of key/slot entries through the
+// shard logger's flush pipeline and asserts the ingested index keeps exactly one
+// entry per key: the one with the highest slot. This pins the pipeline's transform
+// (sort key-ASC / slot-DESC, dedup keep-first) to the same behavior as the old
+// serial logToSST path.
+func TestFlushPipelineDedupAndOrder(t *testing.T) {
+	logsDir := t.TempDir()
+	const numShards = 8
+	sl := NewShardLogger(numShards, logsDir)
+
+	// Build a key -> expected (highest-slot) entry map while enqueuing several
+	// entries per key at differing slots, deliberately NOT in slot order.
+	const numKeys = 5000
+	expected := make(map[solana.PublicKey]accountsdb.AccountIndexEntry, numKeys)
+	makeKey := func(i int) solana.PublicKey {
+		var k solana.PublicKey
+		if i%50 == 0 {
+			// Force a shared 8-byte prefix but distinct later bytes, so the sort
+			// comparator must fall through to the full key, not just its first word.
+			binary.BigEndian.PutUint64(k[:8], 0xABCDEF0011223344)
+			binary.BigEndian.PutUint64(k[8:16], uint64(i))
+		} else {
+			binary.BigEndian.PutUint64(k[:8], uint64(i)*0x9E3779B97F4A7C15)
+			binary.BigEndian.PutUint32(k[8:12], uint32(i))
+		}
+		return k
+	}
+	for i := 0; i < numKeys; i++ {
+		k := makeKey(i)
+		// Three writes for this key at slots that peak in the middle, so the
+		// winner is neither the first nor the last enqueued.
+		slots := []uint64{uint64(i) + 10, uint64(i) + 100, uint64(i) + 50}
+		var best accountsdb.AccountIndexEntry
+		for j, slot := range slots {
+			e := accountsdb.AccountIndexEntry{Slot: slot, FileId: uint64(i), Offset: uint64(j)}
+			sl.EnqueueRequest(k, e)
+			if slot > best.Slot {
+				best = e
+			}
+		}
+		expected[k] = best
+	}
+
+	if err := sl.CloseWithProgress(context.Background(), nil); err != nil {
+		t.Fatalf("CloseWithProgress: %v", err)
+	}
+
+	indexDir := t.TempDir()
+	db, err := ingestSSTFiles(indexDir, logsDir)
+	if err != nil {
+		t.Fatalf("ingestSSTFiles: %v", err)
+	}
+	defer db.Close()
+
+	iter, err := db.NewIter(nil)
+	if err != nil {
+		t.Fatalf("NewIter: %v", err)
+	}
+	defer iter.Close()
+
+	var count int
+	var prevKey []byte
+	for iter.First(); iter.Valid(); iter.Next() {
+		key := append([]byte(nil), iter.Key()...)
+		if prevKey != nil && string(key) <= string(prevKey) {
+			t.Fatalf("keys not strictly ascending / deduped: %x then %x", prevKey, key)
+		}
+		prevKey = key
+
+		got, err := accountsdb.UnmarshalAcctIdxEntry(iter.Value())
+		if err != nil {
+			t.Fatalf("UnmarshalAcctIdxEntry: %v", err)
+		}
+		want, ok := expected[solana.PublicKey(key)]
+		if !ok {
+			t.Fatalf("unexpected key in index: %x", key)
+		}
+		if *got != want {
+			t.Fatalf("key %x: got %+v, want %+v", key, *got, want)
+		}
+		count++
+	}
+	if err := iter.Error(); err != nil {
+		t.Fatalf("iter error: %v", err)
+	}
+	if count != len(expected) {
+		t.Fatalf("index has %d keys, want %d", count, len(expected))
+	}
+}

--- a/pkg/snapshot/shard_writer.go
+++ b/pkg/snapshot/shard_writer.go
@@ -7,9 +7,9 @@ import (
 	"path/filepath"
 	"sync"
 	"sync/atomic"
-	"syscall"
 	"unsafe"
 
+	"github.com/Overclock-Validator/mithril/pkg/accountsdb"
 	"github.com/Overclock-Validator/mithril/pkg/mlog"
 )
 
@@ -53,8 +53,11 @@ type shardWriter struct {
 	wg     sync.WaitGroup
 	queued atomic.Int64 // bytes accepted but not yet written (backpressure signal)
 
-	errMu sync.Mutex
-	err   error
+	errMu     sync.Mutex
+	err       error
+	closed    bool // guarded by mu; close is terminal
+	closeOnce sync.Once
+	closeErr  error
 }
 
 type wItem struct {
@@ -73,7 +76,11 @@ func (s *shardWriter) newBuf() []byte {
 func newShardWriter(path string, direct bool) (*shardWriter, error) {
 	flags := os.O_CREATE | os.O_WRONLY | os.O_TRUNC
 	if direct {
-		flags |= syscall.O_DIRECT
+		flag, err := directIOFlag()
+		if err != nil {
+			return nil, err
+		}
+		flags |= flag
 	}
 	f, err := os.OpenFile(path, flags, 0644)
 	if err != nil {
@@ -119,6 +126,10 @@ func (s *shardWriter) append(blob []byte) (uint64, error) {
 	}
 
 	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return 0, os.ErrClosed
+	}
 	base := s.offset
 
 	// len(s.cur), not cap: alignedBuf over-allocates, so cap can exceed the logical
@@ -173,16 +184,27 @@ func (s *shardWriter) flushLocked() {
 }
 
 func (s *shardWriter) close() error {
-	s.mu.Lock()
-	s.flushLocked()
-	s.mu.Unlock()
-	close(s.queue)
-	s.wg.Wait()
-	cerr := s.f.Close()
-	if werr := s.loadErr(); werr != nil {
-		return werr
-	}
-	return cerr
+	s.closeOnce.Do(func() {
+		s.mu.Lock()
+		s.flushLocked()
+		s.closed = true
+		close(s.queue)
+		s.mu.Unlock()
+		s.wg.Wait()
+		s.closeErr = s.f.Close()
+		if werr := s.loadErr(); werr != nil {
+			s.closeErr = werr
+		}
+		// The writer may remain reachable through worker closures until bootstrap
+		// returns. Its 32 MiB of staging buffers are no longer needed during sorting.
+		s.mu.Lock()
+		s.cur = nil
+		close(s.free)
+		for range s.free {
+		}
+		s.mu.Unlock()
+	})
+	return s.closeErr
 }
 
 func (s *shardWriter) loadErr() error {
@@ -208,6 +230,9 @@ type shardBigFiles struct {
 }
 
 func openShardBigFiles(shardDirs []string) (*shardBigFiles, error) {
+	if err := accountsdb.ValidateStorageDirectories(shardDirs); err != nil {
+		return nil, err
+	}
 	direct := SnapshotDirectIO
 	mlog.Log.Infof("snapshot shard writers: %d shard(s), O_DIRECT=%v", len(shardDirs), direct)
 	sb := &shardBigFiles{

--- a/pkg/snapshot/shard_writer.go
+++ b/pkg/snapshot/shard_writer.go
@@ -1,0 +1,278 @@
+package snapshot
+
+import (
+	"encoding/binary"
+	"math"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"unsafe"
+
+	"github.com/Overclock-Validator/mithril/pkg/mlog"
+)
+
+const (
+	dioAlign      = 4096
+	shardBufSize  = 8 << 20 // staging buffer flushed to disk as one write
+	shardBufCount = 4       // buffers per writer: 1 filling + up to 3 draining
+)
+
+func alignUp(n int) int { return (n + dioAlign - 1) &^ (dioAlign - 1) }
+
+// alignedBuf returns a slice of length size whose backing array starts on a
+// dioAlign boundary, as required for O_DIRECT.
+func alignedBuf(size int) []byte {
+	b := make([]byte, size+dioAlign)
+	if off := int(uintptr(unsafe.Pointer(&b[0])) % dioAlign); off != 0 {
+		b = b[dioAlign-off:]
+	}
+	return b[:size]
+}
+
+// writeShardMetadata records the shard count the DB was built with. Its presence
+// also marks a complete build; OpenDb refuses to open a DB without it.
+func writeShardMetadata(metaDir string, numShards int) error {
+	var buf [8]byte
+	binary.LittleEndian.PutUint64(buf[:], uint64(numShards))
+	return os.WriteFile(filepath.Join(metaDir, "num_shards"), buf[:], 0644)
+}
+
+type shardWriter struct {
+	f      *os.File
+	direct bool
+
+	mu     sync.Mutex // guards cur/buflen/offset and enqueue ordering
+	cur    []byte
+	buflen int
+	offset uint64
+
+	free   chan []byte
+	queue  chan wItem
+	wg     sync.WaitGroup
+	queued atomic.Int64 // bytes accepted but not yet written (backpressure signal)
+
+	errMu sync.Mutex
+	err   error
+}
+
+type wItem struct {
+	b      []byte
+	n      int
+	pooled bool // return b to the free pool after writing
+}
+
+func (s *shardWriter) newBuf() []byte {
+	if s.direct {
+		return alignedBuf(shardBufSize)
+	}
+	return make([]byte, shardBufSize)
+}
+
+func newShardWriter(path string, direct bool) (*shardWriter, error) {
+	flags := os.O_CREATE | os.O_WRONLY | os.O_TRUNC
+	if direct {
+		flags |= syscall.O_DIRECT
+	}
+	f, err := os.OpenFile(path, flags, 0644)
+	if err != nil {
+		return nil, err
+	}
+	s := &shardWriter{
+		f:      f,
+		direct: direct,
+		free:   make(chan []byte, shardBufCount),
+		queue:  make(chan wItem, shardBufCount+4),
+	}
+	s.cur = s.newBuf()
+	for i := 0; i < shardBufCount-1; i++ {
+		s.free <- s.newBuf()
+	}
+	s.wg.Add(1)
+	go s.writeLoop()
+	return s, nil
+}
+
+func (s *shardWriter) writeLoop() {
+	defer s.wg.Done()
+	for it := range s.queue {
+		if it.n > 0 && s.loadErr() == nil {
+			if _, err := s.f.Write(it.b[:it.n]); err != nil {
+				s.storeErr(err)
+			}
+		}
+		s.queued.Add(int64(-it.n))
+		if it.pooled {
+			s.free <- it.b
+		}
+	}
+}
+
+// append copies blob into the staging buffer and returns the base offset where its
+// bytes will land in the file. Safe for concurrent callers; it serializes internally.
+func (s *shardWriter) append(blob []byte) (uint64, error) {
+	n := len(blob)
+	padded := n
+	if s.direct {
+		padded = alignUp(n)
+	}
+
+	s.mu.Lock()
+	base := s.offset
+
+	// len(s.cur), not cap: alignedBuf over-allocates, so cap can exceed the logical
+	// buffer size and let an oversized record slip into the in-buffer path.
+	if padded > len(s.cur) {
+		// Record larger than a staging buffer: flush current, write it standalone.
+		// blob is the caller's pooled tar buffer, which the index builder recycles as
+		// soon as it finishes parsing — before this async write is guaranteed to run.
+		// So we MUST queue a private copy; aliasing blob let the buffer be reused and
+		// overwritten before the writer flushed it, corrupting every account in this
+		// append-vec (~wrong pubkey on read-back).
+		s.flushLocked()
+		var b []byte
+		if s.direct {
+			b = alignedBuf(padded)
+			copy(b, blob)
+			clear(b[n:])
+		} else {
+			b = make([]byte, n)
+			copy(b, blob)
+		}
+		s.offset += uint64(padded)
+		s.queued.Add(int64(padded))
+		s.queue <- wItem{b: b, n: padded, pooled: false}
+		s.mu.Unlock()
+		return base, s.loadErr()
+	}
+
+	if s.buflen+padded > len(s.cur) {
+		s.flushLocked()
+	}
+	copy(s.cur[s.buflen:], blob)
+	if s.direct {
+		clear(s.cur[s.buflen+n : s.buflen+padded])
+	}
+	s.buflen += padded
+	s.offset += uint64(padded)
+	s.queued.Add(int64(padded))
+	s.mu.Unlock()
+	return base, s.loadErr()
+}
+
+// flushLocked hands the current buffer to the writer goroutine and swaps in a fresh
+// one. Called with s.mu held; blocks (backpressure) when no free buffer is available.
+func (s *shardWriter) flushLocked() {
+	if s.buflen == 0 {
+		return
+	}
+	s.queue <- wItem{b: s.cur, n: s.buflen, pooled: true}
+	s.cur = <-s.free
+	s.buflen = 0
+}
+
+func (s *shardWriter) close() error {
+	s.mu.Lock()
+	s.flushLocked()
+	s.mu.Unlock()
+	close(s.queue)
+	s.wg.Wait()
+	cerr := s.f.Close()
+	if werr := s.loadErr(); werr != nil {
+		return werr
+	}
+	return cerr
+}
+
+func (s *shardWriter) loadErr() error {
+	s.errMu.Lock()
+	defer s.errMu.Unlock()
+	return s.err
+}
+
+func (s *shardWriter) storeErr(err error) {
+	s.errMu.Lock()
+	if s.err == nil {
+		s.err = err
+	}
+	s.errMu.Unlock()
+}
+
+// shardBigFiles owns one coalesced big file ("data") per shard and picks a shard
+// per record by fewest in-flight (queued) bytes, so records flow to whichever disk
+// is draining fastest.
+type shardBigFiles struct {
+	data    []*shardWriter
+	written []atomic.Int64
+}
+
+func openShardBigFiles(shardDirs []string) (*shardBigFiles, error) {
+	direct := SnapshotDirectIO
+	mlog.Log.Infof("snapshot shard writers: %d shard(s), O_DIRECT=%v", len(shardDirs), direct)
+	sb := &shardBigFiles{
+		data:    make([]*shardWriter, len(shardDirs)),
+		written: make([]atomic.Int64, len(shardDirs)),
+	}
+	for i, dir := range shardDirs {
+		var err error
+		if sb.data[i], err = newShardWriter(filepath.Join(dir, "data"), direct); err != nil {
+			sb.close()
+			return nil, err
+		}
+	}
+	return sb, nil
+}
+
+func (sb *shardBigFiles) n() uint64 { return uint64(len(sb.data)) }
+
+func (sb *shardBigFiles) choose() int {
+	// Prefer the disk with the least queued bytes
+	best, bestQ := 0, int64(math.MaxInt64)
+	anyQueued := false
+	for i := range sb.data {
+		q := sb.data[i].queued.Load()
+		if q > 0 {
+			anyQueued = true
+		}
+		if q < bestQ {
+			best, bestQ = i, q
+		}
+	}
+	if anyQueued {
+		return best
+	}
+	// No queued bytes so spread evenly by cumulative bytes instead.
+	best, bestW := 0, int64(math.MaxInt64)
+	for i := range sb.data {
+		if w := sb.written[i].Load(); w < bestW {
+			best, bestW = i, w
+		}
+	}
+	return best
+}
+
+// write appends blob to the chosen shard's big file and returns the shard-encoded
+// fileId (segment 0) and the offset within that file.
+func (sb *shardBigFiles) write(blob []byte) (fileId, base uint64, err error) {
+	shard := sb.choose()
+	sb.written[shard].Add(int64(len(blob)))
+	base, err = sb.data[shard].append(blob)
+	if err != nil {
+		return 0, 0, err
+	}
+	return uint64(shard), base, nil
+}
+
+func (sb *shardBigFiles) close() error {
+	var firstErr error
+	for _, w := range sb.data {
+		if w == nil {
+			continue
+		}
+		if err := w.close(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}

--- a/pkg/snapshot/shard_writer_test.go
+++ b/pkg/snapshot/shard_writer_test.go
@@ -1,0 +1,154 @@
+package snapshot
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestShardWriterReadback verifies that bytes appended to a shardWriter can be read
+// back at the base offset it returned, for both buffered and O_DIRECT modes and
+// including a record larger than the staging buffer. Runs on an ext4 mount because
+// O_DIRECT is not supported on tmpfs.
+func TestShardWriterReadback(t *testing.T) {
+	dir := "/mnt/disk0"
+	if _, err := os.Stat(dir); err != nil {
+		t.Skipf("shard writer test needs an ext4 mount at %s: %v", dir, err)
+	}
+
+	for _, direct := range []bool{false, true} {
+		t.Run(fmt.Sprintf("direct=%v", direct), func(t *testing.T) {
+			path := filepath.Join(dir, fmt.Sprintf("shardwriter_test_%v", direct))
+			defer os.Remove(path)
+
+			w, err := newShardWriter(path, direct)
+			if err != nil {
+				if direct {
+					t.Skipf("O_DIRECT unsupported here: %v", err)
+				}
+				t.Fatal(err)
+			}
+
+			// varied sizes: tiny, unaligned, and one larger than the staging buffer
+			sizes := []int{1, 100, 4095, 4096, 4097, 1 << 20, shardBufSize + 1234, 7, 500000}
+			type rec struct {
+				base uint64
+				data []byte
+			}
+			var recs []rec
+			for i, sz := range sizes {
+				data := make([]byte, sz)
+				for j := range data {
+					data[j] = byte((i*31 + j) & 0xff)
+				}
+				base, err := w.append(data)
+				if err != nil {
+					t.Fatalf("append %d: %v", i, err)
+				}
+				recs = append(recs, rec{base, data})
+			}
+			if err := w.close(); err != nil {
+				t.Fatalf("close: %v", err)
+			}
+
+			f, err := os.Open(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer f.Close()
+			for i, r := range recs {
+				got := make([]byte, len(r.data))
+				if _, err := f.ReadAt(got, int64(r.base)); err != nil {
+					t.Fatalf("readAt rec %d (base=%d len=%d): %v", i, r.base, len(r.data), err)
+				}
+				if !bytes.Equal(got, r.data) {
+					t.Fatalf("rec %d mismatch at base=%d", i, r.base)
+				}
+			}
+		})
+	}
+}
+
+// TestShardBigFilesPlacement drives shardBigFiles across three real ext4 disks in
+// both buffered and O_DIRECT modes. It asserts (1) placement fans records across
+// more than one shard (queued steering plus the even-split fallback never collapse
+// onto shard 0) and (2) every record reads back at the path+offset its returned
+// fileId/base resolve to.
+func TestShardBigFilesPlacement(t *testing.T) {
+	dirs := []string{"/mnt/disk0", "/mnt/disk1", "/mnt/disk2"}
+	shardDirs := make([]string, len(dirs))
+	for i, d := range dirs {
+		shardDirs[i] = filepath.Join(d, "shardplace_test")
+		if err := os.MkdirAll(shardDirs[i], 0755); err != nil {
+			t.Skipf("need writable ext4 dirs (%s): %v", shardDirs[i], err)
+		}
+		defer os.RemoveAll(shardDirs[i])
+	}
+
+	for _, direct := range []bool{false, true} {
+		t.Run(fmt.Sprintf("direct=%v", direct), func(t *testing.T) {
+			old := SnapshotDirectIO
+			SnapshotDirectIO = direct
+			defer func() { SnapshotDirectIO = old }()
+
+			sb, err := openShardBigFiles(shardDirs)
+			if err != nil {
+				if direct {
+					t.Skipf("O_DIRECT unsupported here: %v", err)
+				}
+				t.Fatal(err)
+			}
+
+			type rec struct {
+				fileId, base uint64
+				data         []byte
+			}
+			var recs []rec
+			shardHits := map[uint64]int{}
+			// Mix of sizes, including several larger than the staging buffer so the
+			// writer actually issues writes (and updates queued backlog) mid-run.
+			sizes := []int{1000, 40000, 500000, shardBufSize + 777, 2 << 20}
+			for i := 0; i < 120; i++ {
+				sz := sizes[i%len(sizes)]
+				data := make([]byte, sz)
+				for j := range data {
+					data[j] = byte((i*7 + j) & 0xff)
+				}
+				fileId, base, err := sb.write(data)
+				if err != nil {
+					t.Fatalf("write %d: %v", i, err)
+				}
+				recs = append(recs, rec{fileId, base, data})
+				shardHits[fileId%sb.n()]++
+			}
+			if err := sb.close(); err != nil {
+				t.Fatalf("close: %v", err)
+			}
+
+			if len(shardHits) < 2 {
+				t.Fatalf("placement collapsed onto %d shard(s): %v", len(shardHits), shardHits)
+			}
+			t.Logf("direct=%v fan-out by shard: %v", direct, shardHits)
+
+			n := sb.n()
+			for i, r := range recs {
+				p := filepath.Join(shardDirs[r.fileId%n], "data") // segment 0 = coalesced big file
+				f, err := os.Open(p)
+				if err != nil {
+					t.Fatalf("open %s: %v", p, err)
+				}
+				got := make([]byte, len(r.data))
+				_, err = f.ReadAt(got, int64(r.base))
+				f.Close()
+				if err != nil {
+					t.Fatalf("rec %d readAt %s base=%d len=%d: %v", i, p, r.base, len(r.data), err)
+				}
+				if !bytes.Equal(got, r.data) {
+					t.Fatalf("rec %d mismatch: shard=%d seg=%d base=%d", i, r.fileId%n, r.fileId/n, r.base)
+				}
+			}
+		})
+	}
+}

--- a/pkg/snapshot/shard_writer_test.go
+++ b/pkg/snapshot/shard_writer_test.go
@@ -10,13 +10,10 @@ import (
 
 // TestShardWriterReadback verifies that bytes appended to a shardWriter can be read
 // back at the base offset it returned, for both buffered and O_DIRECT modes and
-// including a record larger than the staging buffer. Runs on an ext4 mount because
-// O_DIRECT is not supported on tmpfs.
+// including a record larger than the staging buffer. Set TMPDIR to a filesystem
+// supporting O_DIRECT to exercise direct mode; buffered mode always runs.
 func TestShardWriterReadback(t *testing.T) {
-	dir := "/mnt/disk0"
-	if _, err := os.Stat(dir); err != nil {
-		t.Skipf("shard writer test needs an ext4 mount at %s: %v", dir, err)
-	}
+	dir := t.TempDir()
 
 	for _, direct := range []bool{false, true} {
 		t.Run(fmt.Sprintf("direct=%v", direct), func(t *testing.T) {
@@ -77,15 +74,7 @@ func TestShardWriterReadback(t *testing.T) {
 // onto shard 0) and (2) every record reads back at the path+offset its returned
 // fileId/base resolve to.
 func TestShardBigFilesPlacement(t *testing.T) {
-	dirs := []string{"/mnt/disk0", "/mnt/disk1", "/mnt/disk2"}
-	shardDirs := make([]string, len(dirs))
-	for i, d := range dirs {
-		shardDirs[i] = filepath.Join(d, "shardplace_test")
-		if err := os.MkdirAll(shardDirs[i], 0755); err != nil {
-			t.Skipf("need writable ext4 dirs (%s): %v", shardDirs[i], err)
-		}
-		defer os.RemoveAll(shardDirs[i])
-	}
+	shardDirs := []string{t.TempDir(), t.TempDir(), t.TempDir()}
 
 	for _, direct := range []bool{false, true} {
 		t.Run(fmt.Sprintf("direct=%v", direct), func(t *testing.T) {

--- a/pkg/snapshot/snapshot.go
+++ b/pkg/snapshot/snapshot.go
@@ -65,15 +65,18 @@ func UnmarshalManifestFromSnapshot(ctx context.Context, filename string, account
 
 type appendVecCopyingTask struct {
 	Filename                string
-	TarBuffer               *bytes.Buffer
+	Buf                     []byte
+	BufRef                  *[]byte // pooled buffer backing Buf; returned after indexing
 	FromIncrementalSnapshot bool
 }
 
 type indexEntryBuilderTask struct {
-	Data     []byte
-	FileSize uint64
-	Slot     uint64
-	FileId   uint64
+	Data       []byte
+	FileSize   uint64
+	Slot       uint64
+	FileId     uint64
+	BaseOffset uint64
+	BufRef     *[]byte // pooled buffer backing Data; returned once parsed
 }
 
 type indexEntryCommitterTask struct {

--- a/pkg/snapshot/storage_paths_test.go
+++ b/pkg/snapshot/storage_paths_test.go
@@ -1,0 +1,67 @@
+package snapshot
+
+import (
+	"github.com/stretchr/testify/require"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestDuplicateShardDirectoriesDoNotTruncate(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "accounts")
+	require.NoError(t, os.Mkdir(dir, 0755))
+	file := filepath.Join(dir, "data")
+	require.NoError(t, os.WriteFile(file, []byte("keep me"), 0644))
+	alias := filepath.Join(root, "alias")
+	require.NoError(t, os.Symlink(dir, alias))
+	for _, paths := range [][]string{{dir, dir}, {dir, alias}, {dir, dir + "/nested"}} {
+		_, err := openShardBigFiles(paths)
+		require.Error(t, err)
+		data, err := os.ReadFile(file)
+		require.NoError(t, err)
+		require.Equal(t, "keep me", string(data))
+	}
+	CleanAccountsDbDirs([]string{root, root})
+	data, err := os.ReadFile(file)
+	require.NoError(t, err)
+	require.Equal(t, "keep me", string(data))
+}
+
+func TestDirectIOPlatformGuard(t *testing.T) {
+	flag, err := directIOFlag()
+	if runtime.GOOS == "linux" {
+		require.NoError(t, err)
+		require.NotZero(t, flag)
+		return
+	}
+	require.Error(t, err)
+	path := filepath.Join(t.TempDir(), "data")
+	require.NoError(t, os.WriteFile(path, []byte("keep me"), 0644))
+	_, err = newShardWriter(path, true)
+	require.Error(t, err)
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Equal(t, "keep me", string(data))
+	w, err := newShardWriter(path, false)
+	require.NoError(t, err)
+	require.NoError(t, w.close())
+}
+
+func TestShardWriterCloseReleasesBuffers(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "data")
+	w, err := newShardWriter(path, false)
+	require.NoError(t, err)
+	_, err = w.append([]byte("finished data"))
+	require.NoError(t, err)
+	require.NoError(t, w.close())
+	require.Nil(t, w.cur)
+	require.Empty(t, w.free)
+	require.NoError(t, w.close(), "deferred cleanup is idempotent")
+	_, err = w.append([]byte("late write"))
+	require.ErrorIs(t, err, os.ErrClosed)
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Equal(t, "finished data", string(data))
+}

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -752,7 +752,7 @@ func ValidateAccountsDbArtifacts(accountsDbDir string) error {
 		"mithril_db",
 		"bankhash_db",
 		"accounts",
-		"largest_file_id",
+		"num_shards",
 		"bank_hash",
 		"manifest",
 	}

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -597,7 +597,7 @@ func ValidateAccountsDbArtifacts(accountsDbDir string) error {
 		"mithril_db",
 		"bankhash_db",
 		"accounts",
-		"largest_file_id",
+		"num_shards",
 		"bank_hash",
 		"manifest",
 	}

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -752,7 +752,7 @@ func ValidateAccountsDbArtifacts(accountsDbDir string) error {
 		"mithril_db",
 		"bankhash_db",
 		"accounts",
-		"num_shards",
+		"largest_file_id",
 		"bank_hash",
 		"manifest",
 	}


### PR DESCRIPTION
This change speeds up snapshot unpacking by
1. Adding the ability to configure mithril to unpack the snapshot over multiple different directories
   - primarily useful when the machine has multiple NVMEs of different sizes and write speeds each mounted to a different directory. RAID0 can be unpredictable or inefficient in this situation
   - also changing the unpack process to use one big file per directory to hold all the appendvecs rather than storing each appendvec in its own file
   - the big file can optionally be written using O_DIRECT
3. Improving the index log-to-SST process with pipelining and reducing the number of copies made during the sort

On my test machine I find that `dev` takes `15m23s` to unpack a snapshot while `70f801f` can unpack the same snapshot in `6m53s`.