### PR TITLE
fix epoch boundary divergence & direct-mapped CPI

### DIFF
--- a/pkg/replay/block.go
+++ b/pkg/replay/block.go
@@ -2675,7 +2675,7 @@ func ReplayBlocks(
 
 		// post-epoch boundary rewards distribution
 		if partitionedEpochRewardsEnabled && partitionedRewardsInfo != nil && currentSlot >= partitionedRewardsInfo.FirstStakingRewardSlot && partitionedRewardsInfo.NumRewardPartitionsRemaining > 0 {
-			distributedAccts, parentDistributedAccts := distributePartitionedEpochRewardsForSlot(acctsDb, lastSlotCtx, replayCtx, partitionedRewardsInfo, currentSlot, block.BlockHeight)
+			distributedAccts, parentDistributedAccts := distributePartitionedEpochRewardsForSlot(acctsDb, lastSlotCtx, block.EpochUpdatedAccts, replayCtx, partitionedRewardsInfo, currentSlot, block.BlockHeight)
 			block.EpochUpdatedAccts = append(block.EpochUpdatedAccts, distributedAccts...)
 			block.ParentEpochUpdatedAccts = append(block.ParentEpochUpdatedAccts, parentDistributedAccts...)
 		}

--- a/pkg/replay/rewards.go
+++ b/pkg/replay/rewards.go
@@ -515,8 +515,8 @@ func beginPartitionedEpochRewardsDistribution(acctsDb *accountsdb.AccountsDb, sl
 		capitalizingEpochRewards(voteRewardsDistributed, streamResult.TotalStakerRewards)
 }
 
-func distributePartitionedEpochRewardsForSlot(acctsDb *accountsdb.AccountsDb, parentCtx *sealevel.SlotCtx, epochCtx *ReplayCtx, partitionedEpochRewardsInfo *rewards.PartitionedRewardDistributionInfo, currentSlot uint64, currentBlockHeight uint64) ([]*accounts.Account, []*accounts.Account) {
-	rewardLoader := epochRewardAccountLoader(acctsDb, currentSlot, parentCtx, nil)
+func distributePartitionedEpochRewardsForSlot(acctsDb *accountsdb.AccountsDb, parentCtx *sealevel.SlotCtx, stagedEpochAccts []*accounts.Account, epochCtx *ReplayCtx, partitionedEpochRewardsInfo *rewards.PartitionedRewardDistributionInfo, currentSlot uint64, currentBlockHeight uint64) ([]*accounts.Account, []*accounts.Account) {
+	rewardLoader := epochRewardAccountLoader(acctsDb, currentSlot, parentCtx, stagedEpochAccts)
 	epochRewardsAcct, err := rewardLoader(sealevel.SysvarEpochRewardsAddr)
 	if err != nil {
 		panic(fmt.Sprintf("unable to get EpochRewards from acctsdb: %s", err))
@@ -525,6 +525,14 @@ func distributePartitionedEpochRewardsForSlot(acctsDb *accountsdb.AccountsDb, pa
 	var epochRewards sealevel.SysvarEpochRewards
 	decoder := bin.NewBinDecoder(epochRewardsAcct.Data)
 	epochRewards.MustUnmarshalWithDecoder(decoder)
+
+	// Reward distribution is scheduled by block height, not slot. If the first
+	// slots of an epoch are skipped, the epoch-boundary bank can already be past
+	// FirstStakingRewardSlot while its block height is still one before the
+	// distribution start recorded in the freshly staged EpochRewards sysvar.
+	if currentBlockHeight < epochRewards.DistributionStartingBlockHeight {
+		return nil, nil
+	}
 
 	partitionIdx := currentBlockHeight - epochRewards.DistributionStartingBlockHeight
 

--- a/pkg/replay/rewards_empty_partition_test.go
+++ b/pkg/replay/rewards_empty_partition_test.go
@@ -29,7 +29,7 @@ func decodeEpochRewardsForTest(t *testing.T, data []byte) sealevel.SysvarEpochRe
 	return epochRewards
 }
 
-func TestEmptyRewardPartitionClosesEpochRewardsWithoutCapitalization(t *testing.T) {
+func TestSameBankRewardPartitionWaitsForStartingBlockHeight(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, os.MkdirAll(filepath.Join(dir, "accounts"), 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "largest_file_id"), make([]byte, 8), 0o644))
@@ -59,8 +59,18 @@ func TestEmptyRewardPartitionClosesEpochRewardsWithoutCapitalization(t *testing.
 		Data:     encodeEpochRewardsForTest(t, active),
 		Owner:    a.SysvarOwnerAddr,
 	}
+	// A skipped boundary slot can make epoch initialization and partition zero
+	// execute in one bank. AccountsDB still contains the previous epoch sysvar;
+	// distribution must consume the fresh same-bank write instead.
+	stale := active
+	stale.DistributionStartingBlockHeight = 1
+	stale.TotalRewards = 999
+	stale.DistributedRewards = 999
+	stale.Active = false
+	staleAccount := activeAccount.Clone()
+	staleAccount.Data = encodeEpochRewardsForTest(t, stale)
 	stored := make(chan struct{})
-	require.NoError(t, db.StoreAccounts([]*accounts.Account{activeAccount}, 10, func() { close(stored) }))
+	require.NoError(t, db.StoreAccounts([]*accounts.Account{staleAccount}, 10, func() { close(stored) }))
 	<-stored
 
 	distribution := &rewards.PartitionedRewardDistributionInfo{
@@ -69,13 +79,21 @@ func TestEmptyRewardPartitionClosesEpochRewardsWithoutCapitalization(t *testing.
 		NumRewardPartitionsRemaining: 1,
 	}
 	replayCtx := &ReplayCtx{Capitalization: 12345}
-	updated, parents := distributePartitionedEpochRewardsForSlot(db, nil, replayCtx, distribution, 11, 101)
+	updated, parents := distributePartitionedEpochRewardsForSlot(db, nil, []*accounts.Account{activeAccount}, replayCtx, distribution, 11, 100)
+
+	require.Equal(t, uint64(1), distribution.NumRewardPartitionsRemaining)
+	require.Equal(t, uint64(12345), replayCtx.Capitalization)
+	require.Empty(t, updated)
+	require.Empty(t, parents)
+
+	updated, parents = distributePartitionedEpochRewardsForSlot(db, nil, []*accounts.Account{activeAccount}, replayCtx, distribution, 11, 101)
 
 	require.Zero(t, distribution.NumRewardPartitionsRemaining)
 	require.Equal(t, uint64(12345), replayCtx.Capitalization)
 	require.Len(t, updated, 1)
 	require.Len(t, parents, 1)
 	require.True(t, decodeEpochRewardsForTest(t, parents[0].Data).Active)
+	require.Equal(t, active.TotalRewards, decodeEpochRewardsForTest(t, parents[0].Data).TotalRewards)
 
 	completed := decodeEpochRewardsForTest(t, updated[0].Data)
 	require.False(t, completed.Active)

--- a/pkg/sealevel/syscalls_cpi.go
+++ b/pkg/sealevel/syscalls_cpi.go
@@ -850,6 +850,16 @@ func updateCallerAccountRegion(vm sbpf.VM, execCtx *ExecutionCtx, callerAcct *Ca
 
 	writable := calleeAcct.DataCanBeChanged(execCtx.Features) == nil
 	if accountDataDirectMappingActive(execCtx) {
+		// A direct-mapped account can still reference the transaction's shared
+		// parent state here.  Keep the caller region read-only in that case so
+		// its existing OnWrite hook performs the first-write clone.  Marking the
+		// region writable would let the caller mutate the shared backing slice
+		// without setting TransactionAccounts.Touched, so the successful write
+		// would be omitted from publication and the accounts LtHash.
+		if calleeAcct.IndexInTransaction < uint64(len(calleeAcct.TxCtx.Accounts.Shared)) &&
+			calleeAcct.TxCtx.Accounts.Shared[calleeAcct.IndexInTransaction] {
+			writable = false
+		}
 		updater, ok := vm.(inputRegionDataUpdater)
 		if !ok {
 			return nil

--- a/pkg/sealevel/syscalls_cpi_0459_test.go
+++ b/pkg/sealevel/syscalls_cpi_0459_test.go
@@ -3,9 +3,11 @@ package sealevel
 import (
 	"testing"
 
+	"github.com/Overclock-Validator/mithril/pkg/accounts"
 	"github.com/Overclock-Validator/mithril/pkg/cu"
 	feat "github.com/Overclock-Validator/mithril/pkg/features"
 	"github.com/Overclock-Validator/mithril/pkg/sbpf"
+	"github.com/gagliardetto/solana-go"
 	"github.com/stretchr/testify/require"
 )
 
@@ -55,4 +57,71 @@ func TestTranslateSerializedAccountDataDirectMappingSkipsSerializedBytes(t *test
 	features.DisableFeature(feat.AccountDataDirectMapping)
 	_, err = translateSerializedAccountData(vm, execCtx, sbpf.VaddrInput+42, 1)
 	require.Error(t, err)
+}
+
+func TestUpdateCallerAccountRegionPreservesFirstWriteClone(t *testing.T) {
+	features := feat.NewFeaturesDefault()
+	features.EnableFeature(feat.VirtualAddressSpaceAdjustments, 0)
+	features.EnableFeature(feat.AccountDataDirectMapping, 0)
+
+	programKey := solana.PublicKey{1}
+	accountKey := solana.PublicKey{2}
+	parent := &accounts.Account{Key: accountKey, Owner: programKey, Lamports: 1, Data: []byte{7}}
+	program := &accounts.Account{Key: programKey, Executable: true, Lamports: 1}
+	txAccounts := NewTransactionAccountsFromRefs(
+		[]*accounts.Account{parent, program},
+		[]bool{true, true},
+	)
+	txCtx := NewTransactionCtx(*txAccounts, 4, 4)
+	instrCtx := &InstructionCtx{}
+	instrCtx.Configure(
+		[]uint64{1},
+		[]InstructionAccount{{
+			IndexInTransaction: 0,
+			IndexInCaller:      0,
+			IndexInCallee:      0,
+			IsWritable:         true,
+		}},
+		nil,
+	)
+	txCtx.InstructionTrace = []InstructionCtx{*instrCtx}
+	txCtx.InstructionStack = []uint64{0}
+	execCtx := &ExecutionCtx{Features: *features, TransactionContext: txCtx}
+
+	borrowed, err := instrCtx.BorrowInstructionAccount(txCtx, 0)
+	require.NoError(t, err)
+	data, writable, onWrite, err := directMappedAccountData(execCtx, borrowed, 1)
+	require.NoError(t, err)
+	require.False(t, writable)
+	require.NotNil(t, onWrite)
+
+	meter := cu.NewComputeMeter(1)
+	vm := sbpf.NewInterpreter(&sbpf.Program{TextVA: sbpf.VaddrProgram, Funcs: map[uint32]int64{}}, &sbpf.VMOpts{
+		Input:        []byte{0},
+		Context:      execCtx,
+		ComputeMeter: &meter,
+		InputRegions: []sbpf.InputRegion{{
+			Offset:               0,
+			RegionSize:           1,
+			AddressSpaceReserved: 1,
+			Writable:             writable,
+			AccountIndex:         0,
+			Data:                 data,
+			OnWrite:              onWrite,
+		}},
+	})
+	defer vm.Finish()
+
+	err = updateCallerAccountRegion(vm, execCtx, &CallerAccount{
+		OriginalDataLen: 1,
+		VmDataAddr:      sbpf.VaddrInput,
+	}, borrowed, false)
+	require.NoError(t, err)
+	borrowed.Drop()
+
+	require.NoError(t, vm.Write8(sbpf.VaddrInput, 9))
+	require.Equal(t, byte(7), parent.Data[0], "the shared parent account must remain immutable")
+	require.Equal(t, byte(9), txCtx.Accounts.Accounts[0].Data[0])
+	require.False(t, txCtx.Accounts.Shared[0])
+	require.True(t, txCtx.Accounts.Touched[0], "the direct-mapped write must be published")
 }


### PR DESCRIPTION
This PR fixes the following two issues I found as divergences when running mithril on the Alpenglow test cluster.

1) a rewards problem at epoch boundaries that occasionally manifested as a divergence
2) preserve COW after direct-mapped CPI