### PR TITLE
block production improvements

### DIFF
--- a/cmd/mithril/node/node.go
+++ b/cmd/mithril/node/node.go
@@ -29,10 +29,10 @@ import (
 	"github.com/Overclock-Validator/mithril/pkg/arena"
 	"github.com/Overclock-Validator/mithril/pkg/block"
 	"github.com/Overclock-Validator/mithril/pkg/blockprod"
+	"github.com/Overclock-Validator/mithril/pkg/blockprod/scheduler"
 	"github.com/Overclock-Validator/mithril/pkg/blockstream"
 	"github.com/Overclock-Validator/mithril/pkg/config"
 	consensusengine "github.com/Overclock-Validator/mithril/pkg/consensus"
-	"github.com/Overclock-Validator/mithril/pkg/forge"
 	"github.com/Overclock-Validator/mithril/pkg/global"
 	"github.com/Overclock-Validator/mithril/pkg/gossip"
 	"github.com/Overclock-Validator/mithril/pkg/lightbringer"
@@ -2681,7 +2681,9 @@ postBootstrap:
 		defer broadcaster.Close()
 
 		controller := blockprod.NewController()
-		topicSink := forge.NewSink(controller)
+		topicSink := scheduler.New(controller)
+		topicSink.Start(ctx)
+		defer topicSink.Stop()
 		tpuCfg := tpu.DefaultConfig()
 		tpuCfg.Identity = validatorIdentity
 		tpuCfg.ListenAddr = validatorTPUQUICBind

--- a/pkg/blockprod/bank.go
+++ b/pkg/blockprod/bank.go
@@ -238,6 +238,9 @@ func (b *WorkingBank) ForgeTransaction(tx *solana.Transaction, wireSize int) (Fo
 	if reason := b.reserveEntryBytesLocked(wireSize); reason != costmodel.ExceedNone {
 		return ForgeDroppedCost, reason
 	}
+	if err := fees.PayerCanFund(b.slotCtx, tx); err != nil {
+		return ForgeDroppedExecution, costmodel.ExceedNone
+	}
 
 	output := replay.LoadAndExecuteTransaction(replay.LoadAndExecuteTransactionInput{
 		SlotCtx:     b.slotCtx,

--- a/pkg/blockprod/bank.go
+++ b/pkg/blockprod/bank.go
@@ -242,11 +242,32 @@ func (b *WorkingBank) ForgeTransaction(tx *solana.Transaction, wireSize int) (Fo
 	b.numSigs += uint64(tx.Message.Header.NumRequiredSignatures)
 
 	b.costs.Record(cost)
+	execCU, loadedCost := actualExecutionUsage(output)
+	b.costs.Rebate(cost, execCU, loadedCost)
 	if flushed, batchBytes, didFlush := b.entries.Append(*tx, wireSize); didFlush {
 		b.entryHash = b.entries.CurrentEntryHash()
 		b.sink.OnEntryBatch(flushed, batchBytes)
 	}
 	return ForgeAccepted, costmodel.ExceedNone
+}
+
+func actualExecutionUsage(output replay.LoadAndExecuteTransactionOutput) (execCU, loadedCost uint64) {
+	execCtx := output.ExecCtx
+	if execCtx == nil {
+		return 0, 0
+	}
+	execCU = execCtx.ComputeMeter.Used()
+	if execCtx.TransactionContext == nil {
+		return execCU, 0
+	}
+	var loadedBytes uint32
+	for _, acct := range execCtx.TransactionContext.Accounts.Accounts {
+		if acct == nil || acct.IsDummy {
+			continue
+		}
+		loadedBytes += uint32(len(acct.Data))
+	}
+	return execCU, costmodel.LoadedAccountsDataSizeCost(loadedBytes)
 }
 
 // BufferedDropReason classifies why a buffered transaction should be discarded.

--- a/pkg/blockprod/bank.go
+++ b/pkg/blockprod/bank.go
@@ -61,6 +61,12 @@ func NewWorkingBank(cfg BankConfig) *WorkingBank {
 	if limits.BlockCost == 0 {
 		limits = costmodel.DefaultLimits()
 	}
+	if limits.MaxBatchBytes == 0 {
+		limits.MaxBatchBytes = costmodel.DefaultTargetBatchBytes
+	}
+	if limits.MaxEntryBytes == 0 {
+		limits.MaxEntryBytes = costmodel.DefaultPackEntryBytes()
+	}
 	sink := cfg.Sink
 	if sink == nil {
 		sink = NopBatchSink{}
@@ -161,6 +167,7 @@ func (r ForgeResult) String() string {
 func (b *WorkingBank) Forge(wire []byte) (ForgeResult, costmodel.ExceedReason) {
 	tx, err := solana.TransactionFromBytes(wire)
 	if err != nil {
+		b.RebateSchedule(len(wire))
 		return ForgeDroppedParse, costmodel.ExceedNone
 	}
 	return b.ForgeTransaction(tx, len(wire))
@@ -169,10 +176,12 @@ func (b *WorkingBank) Forge(wire []byte) (ForgeResult, costmodel.ExceedReason) {
 // ForgeTransaction executes and commits a parsed transaction.
 func (b *WorkingBank) ForgeTransaction(tx *solana.Transaction, wireSize int) (ForgeResult, costmodel.ExceedReason) {
 	if tx == nil {
+		b.RebateSchedule(wireSize)
 		return ForgeDroppedParse, costmodel.ExceedNone
 	}
 	messageHash, err := replay.TransactionMessageHash(tx)
 	if err != nil {
+		b.RebateSchedule(wireSize)
 		return ForgeDroppedParse, costmodel.ExceedNone
 	}
 	ancestorAlreadyProcessed := false
@@ -194,6 +203,7 @@ func (b *WorkingBank) ForgeTransaction(tx *solana.Transaction, wireSize int) (Fo
 		}
 		cost, err = costmodel.EstimateTransactionCost(tx, feats)
 		if err != nil {
+			b.RebateSchedule(wireSize)
 			return ForgeDroppedParse, costmodel.ExceedNone
 		}
 		cost.WireSize = wireSize
@@ -201,6 +211,12 @@ func (b *WorkingBank) ForgeTransaction(tx *solana.Transaction, wireSize int) (Fo
 
 	b.mu.Lock()
 	defer b.mu.Unlock()
+	included := false
+	defer func() {
+		if !included {
+			b.entries.rebateReserved(wireSize)
+		}
+	}()
 	if !b.accepting {
 		return ForgeDroppedNoLeader, costmodel.ExceedNone
 	}
@@ -217,6 +233,9 @@ func (b *WorkingBank) ForgeTransaction(tx *solana.Transaction, wireSize int) (Fo
 	}
 
 	if reason := b.costs.WouldExceed(cost); reason != costmodel.ExceedNone {
+		return ForgeDroppedCost, reason
+	}
+	if reason := b.reserveEntryBytesLocked(wireSize); reason != costmodel.ExceedNone {
 		return ForgeDroppedCost, reason
 	}
 
@@ -248,6 +267,7 @@ func (b *WorkingBank) ForgeTransaction(tx *solana.Transaction, wireSize int) (Fo
 		b.entryHash = b.entries.CurrentEntryHash()
 		b.sink.OnEntryBatch(flushed, batchBytes)
 	}
+	included = true
 	return ForgeAccepted, costmodel.ExceedNone
 }
 
@@ -298,6 +318,47 @@ func (b *WorkingBank) ClassifyBuffered(blockhash solana.Hash, messageHash [32]by
 	return BufferedKeep
 }
 
+// PrepareSchedule reserves entry bytes at schedule time. If the next
+// transaction would not fit in the current FEC set, the batch is
+// closed and shredded first. If the tx would then exceed the remaining
+// slot entry-byte budget, it is not reserved. A failed/unincludable
+// forge rebates the reservation.
+func (b *WorkingBank) PrepareSchedule(wireSize int) costmodel.ExceedReason {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if !b.accepting {
+		return costmodel.ExceedNone
+	}
+	return b.reserveEntryBytesLocked(wireSize)
+}
+
+// RebateSchedule releases a schedule-time entry-byte reservation.
+func (b *WorkingBank) RebateSchedule(wireSize int) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.entries.rebateReserved(wireSize)
+}
+
+func (b *WorkingBank) reserveEntryBytesLocked(wireSize int) costmodel.ExceedReason {
+	if b.entries.ReservedBytes() > 0 {
+		return costmodel.ExceedNone
+	}
+	if b.entries.wouldOverflowBatch(wireSize) {
+		b.flushEntriesLocked()
+	}
+	if !b.entries.reserve(wireSize) {
+		return costmodel.ExceedBatchBytes
+	}
+	return costmodel.ExceedNone
+}
+
+// EntryBytes is flushed plus pending plus reserved serialized entry bytes.
+func (b *WorkingBank) EntryBytes() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.entries.SlotBytes()
+}
+
 // FlushEntries emits any pending transactions as an entry batch.
 func (b *WorkingBank) FlushEntries() {
 	b.mu.Lock()
@@ -305,13 +366,15 @@ func (b *WorkingBank) FlushEntries() {
 	b.flushEntriesLocked()
 }
 
-// Freeze stops transaction admission and emits the final pending entry batch.
-// It waits for any forge already holding the bank lock, so every accepted
-// transaction is included before the footer bank hash is computed.
+// Freeze stops transaction admission and emits the leftover entry batch even
+// if it does not fill a FEC set. It waits for any forge already holding the
+// bank lock, so every accepted transaction is included before the footer
+// bank hash is computed. Last-in-slot is marked on the ending tick, not here.
 func (b *WorkingBank) Freeze() {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	b.accepting = false
+	b.entries.dropReservation()
 	b.flushEntriesLocked()
 }
 
@@ -320,6 +383,7 @@ func (b *WorkingBank) Freeze() {
 func (b *WorkingBank) Close() {
 	b.mu.Lock()
 	b.accepting = false
+	b.entries.dropReservation()
 	b.mu.Unlock()
 }
 

--- a/pkg/blockprod/bank.go
+++ b/pkg/blockprod/bank.go
@@ -171,9 +171,6 @@ func (b *WorkingBank) ForgeTransaction(tx *solana.Transaction, wireSize int) (Fo
 	if tx == nil {
 		return ForgeDroppedParse, costmodel.ExceedNone
 	}
-	if tx.IsVote() {
-		return ForgeDroppedVote, costmodel.ExceedNone
-	}
 	messageHash, err := replay.TransactionMessageHash(tx)
 	if err != nil {
 		return ForgeDroppedParse, costmodel.ExceedNone
@@ -250,6 +247,34 @@ func (b *WorkingBank) ForgeTransaction(tx *solana.Transaction, wireSize int) (Fo
 		b.sink.OnEntryBatch(flushed, batchBytes)
 	}
 	return ForgeAccepted, costmodel.ExceedNone
+}
+
+// BufferedDropReason classifies why a buffered transaction should be discarded.
+type BufferedDropReason int
+
+const (
+	BufferedKeep BufferedDropReason = iota
+	BufferedExpired
+	BufferedAlreadyProcessed
+)
+
+// ClassifyBuffered reports whether a buffered transaction is expired or already
+// processed relative to this bank.
+func (b *WorkingBank) ClassifyBuffered(blockhash solana.Hash, messageHash [32]byte) BufferedDropReason {
+	if rbh := sealevel.SysvarCache.RecentBlockHashes.Sysvar; rbh == nil || !rbh.IsBlockhashAgeValid(blockhash) {
+		return BufferedExpired
+	}
+	if b.ancestorStatuses != nil {
+		if ok, err := b.ancestorStatuses.ContainsMessage(blockhash, messageHash); err == nil && ok {
+			return BufferedAlreadyProcessed
+		}
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if _, seen := b.seenMessages[messageHash]; seen {
+		return BufferedAlreadyProcessed
+	}
+	return BufferedKeep
 }
 
 // FlushEntries emits any pending transactions as an entry batch.

--- a/pkg/blockprod/bank_test.go
+++ b/pkg/blockprod/bank_test.go
@@ -287,7 +287,8 @@ func TestWorkingBankConcurrentDuplicateMessageCommitsOnce(t *testing.T) {
 	payerAfter, err := env.SlotCtx.GetAccount(txfixture.PayerPubkey())
 	require.NoError(t, err)
 	assert.Equal(t, payerLamportsBefore-5_001, payerAfter.Lamports)
-	assert.Equal(t, expectedCost.Sum(), env.Bank.CostTracker().BlockCost())
+	assert.Less(t, env.Bank.CostTracker().BlockCost(), expectedCost.Sum())
+	assert.Greater(t, env.Bank.CostTracker().BlockCost(), expectedCost.SignatureCost)
 	feeInfo := env.Bank.TxFeeAccumulator()
 	assert.Equal(t, uint64(5_000), feeInfo.ExecutionFees)
 	assert.Zero(t, feeInfo.PriorityFees)
@@ -405,6 +406,27 @@ func TestWorkingBankRejectsStalePacketAfterFreeze(t *testing.T) {
 	assert.Equal(t, ForgeDroppedNoLeader, result)
 	assert.Equal(t, costmodel.ExceedNone, reason)
 	assert.Empty(t, env.Bank.ForgedTransactions())
+}
+
+func TestWorkingBankRebatesUnusedLoadedAccountsCost(t *testing.T) {
+	env := NewTestEnv(TestEnvConfig{})
+	defer env.Close()
+
+	wire := txfixture.MustSignedTransferWire(0)
+	tx, err := solana.TransactionFromBytes(wire)
+	require.NoError(t, err)
+	estimated, err := costmodel.EstimateTransactionCost(tx, env.SlotCtx.Features)
+	require.NoError(t, err)
+	require.Equal(t, uint64(16_384), estimated.LoadedAccountsDataSizeCost)
+
+	result, reason := env.Bank.Forge(wire)
+	require.Equal(t, ForgeAccepted, result)
+	require.Equal(t, costmodel.ExceedNone, reason)
+
+	got := env.Bank.CostTracker().BlockCost()
+	assert.Less(t, got, estimated.Sum())
+	assert.Less(t, got, estimated.LoadedAccountsDataSizeCost)
+	assert.Greater(t, got, estimated.SignatureCost)
 }
 
 func TestWorkingBankDropsWhenBlockCostExceeded(t *testing.T) {

--- a/pkg/blockprod/bank_test.go
+++ b/pkg/blockprod/bank_test.go
@@ -7,9 +7,11 @@ import (
 	b "github.com/Overclock-Validator/mithril/pkg/block"
 	"github.com/Overclock-Validator/mithril/pkg/costmodel"
 	"github.com/Overclock-Validator/mithril/pkg/replay"
+	"github.com/Overclock-Validator/mithril/pkg/sealevel"
 	"github.com/Overclock-Validator/mithril/pkg/tpu/txfixture"
 	"github.com/Overclock-Validator/mithril/pkg/turbine"
 	"github.com/gagliardetto/solana-go"
+	"github.com/gagliardetto/solana-go/programs/system"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -22,6 +24,126 @@ type captureSink struct {
 func (s *captureSink) OnEntryBatch(entries []turbine.Entry, batchBytes int) {
 	s.batches = append(s.batches, append([]turbine.Entry(nil), entries...))
 	s.bytes = append(s.bytes, batchBytes)
+}
+
+func setPayerLamports(t *testing.T, env *TestEnv, lamports uint64) {
+	t.Helper()
+	acct, err := env.SlotCtx.GetAccount(txfixture.PayerPubkey())
+	require.NoError(t, err)
+	acct.Lamports = lamports
+	require.NoError(t, env.SlotCtx.SetAccount(txfixture.PayerPubkey(), acct))
+}
+
+func TestWorkingBankDropsPayerThatCannotRemainRentExempt(t *testing.T) {
+	env := NewTestEnv(TestEnvConfig{})
+	defer env.Close()
+
+	rent := sealevel.NewDefaultRentSysvar()
+	rentMin := rent.MinimumBalance(0)
+	require.Equal(t, uint64(890880), rentMin)
+	setPayerLamports(t, env, rentMin+5000-1)
+
+	destBefore, err := env.SlotCtx.GetAccount(txfixture.DestPubkey())
+	require.NoError(t, err)
+	result, reason := env.Bank.Forge(txfixture.MustSignedTransferWire(0))
+	require.Equal(t, ForgeDroppedExecution, result)
+	require.Equal(t, costmodel.ExceedNone, reason)
+
+	destAfter, err := env.SlotCtx.GetAccount(txfixture.DestPubkey())
+	require.NoError(t, err)
+	assert.Equal(t, destBefore.Lamports, destAfter.Lamports)
+	assert.Empty(t, env.Bank.ForgedTransactions())
+	assert.Zero(t, env.Bank.CostTracker().BlockCost())
+	assert.Zero(t, env.Bank.EntryBuilder().PendingCount())
+}
+
+func TestWorkingBankStopsWhenPayerWouldFallBelowRent(t *testing.T) {
+	env := NewTestEnv(TestEnvConfig{})
+	defer env.Close()
+
+	rent := sealevel.NewDefaultRentSysvar()
+	rentMin := rent.MinimumBalance(0)
+	// One 1-lamport transfer plus its 5000-lamport fee, leaving exactly rent-exempt.
+	setPayerLamports(t, env, rentMin+5000+1)
+
+	destBefore, err := env.SlotCtx.GetAccount(txfixture.DestPubkey())
+	require.NoError(t, err)
+	result, reason := env.Bank.Forge(txfixture.MustSignedTransferWire(0))
+	require.Equal(t, ForgeAccepted, result)
+	require.Equal(t, costmodel.ExceedNone, reason)
+
+	result, reason = env.Bank.Forge(txfixture.MustSignedTransferWire(1))
+	require.Equal(t, ForgeDroppedExecution, result)
+	require.Equal(t, costmodel.ExceedNone, reason)
+
+	destAfter, err := env.SlotCtx.GetAccount(txfixture.DestPubkey())
+	require.NoError(t, err)
+	assert.Equal(t, destBefore.Lamports+1, destAfter.Lamports)
+	assert.Len(t, env.Bank.ForgedTransactions(), 1)
+}
+
+func mustSignedTransfer(t *testing.T, lamports uint64) *solana.Transaction {
+	t.Helper()
+	tx, err := solana.NewTransaction(
+		[]solana.Instruction{
+			system.NewTransferInstruction(lamports, txfixture.PayerPubkey(), txfixture.DestPubkey()).Build(),
+		},
+		txfixture.TestBlockhash(),
+		solana.TransactionPayer(txfixture.PayerPubkey()),
+	)
+	require.NoError(t, err)
+	payerKey := txfixture.PayerPrivateKey()
+	_, err = tx.Sign(func(key solana.PublicKey) *solana.PrivateKey {
+		if key.Equals(txfixture.PayerPubkey()) {
+			return &payerKey
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	return tx
+}
+
+func TestWorkingBankAcceptsTransferThatDrainsPayerToZero(t *testing.T) {
+	env := NewTestEnv(TestEnvConfig{})
+	defer env.Close()
+
+	const transfer = uint64(1_000_000)
+	setPayerLamports(t, env, 5000+transfer)
+
+	destBefore, err := env.SlotCtx.GetAccount(txfixture.DestPubkey())
+	require.NoError(t, err)
+	tx := mustSignedTransfer(t, transfer)
+	result, reason := env.Bank.ForgeTransaction(tx, 200)
+	require.Equal(t, ForgeAccepted, result)
+	require.Equal(t, costmodel.ExceedNone, reason)
+
+	payerAfter, err := env.SlotCtx.GetAccount(txfixture.PayerPubkey())
+	require.NoError(t, err)
+	destAfter, err := env.SlotCtx.GetAccount(txfixture.DestPubkey())
+	require.NoError(t, err)
+	assert.Zero(t, payerAfter.Lamports)
+	assert.Equal(t, destBefore.Lamports+transfer, destAfter.Lamports)
+}
+
+func TestWorkingBankDropsTransferThatLeavesPayerBelowRent(t *testing.T) {
+	env := NewTestEnv(TestEnvConfig{})
+	defer env.Close()
+
+	const leftover = uint64(100)
+	const transfer = uint64(1_000_000)
+	setPayerLamports(t, env, 5000+transfer+leftover)
+
+	destBefore, err := env.SlotCtx.GetAccount(txfixture.DestPubkey())
+	require.NoError(t, err)
+	tx := mustSignedTransfer(t, transfer)
+	result, reason := env.Bank.ForgeTransaction(tx, 200)
+	require.Equal(t, ForgeDroppedExecution, result)
+	require.Equal(t, costmodel.ExceedNone, reason)
+
+	destAfter, err := env.SlotCtx.GetAccount(txfixture.DestPubkey())
+	require.NoError(t, err)
+	assert.Equal(t, destBefore.Lamports, destAfter.Lamports)
+	assert.Empty(t, env.Bank.ForgedTransactions())
 }
 
 func TestWorkingBankForgesTransfer(t *testing.T) {

--- a/pkg/blockprod/bank_test.go
+++ b/pkg/blockprod/bank_test.go
@@ -441,6 +441,64 @@ func TestWorkingBankDropsWhenBlockCostExceeded(t *testing.T) {
 	assert.Equal(t, costmodel.ExceedBlockCost, reason)
 }
 
+func TestPrepareScheduleClosesFullFECBatch(t *testing.T) {
+	sink := &captureSink{}
+	limits := costmodel.DefaultLimits()
+	limits.MaxBatchBytes = 300
+	env := NewTestEnv(TestEnvConfig{Limits: limits, Sink: sink})
+	defer env.Close()
+
+	wire := txfixture.MustSignedTransferWire(0)
+	result, reason := env.Bank.Forge(wire)
+	require.Equal(t, ForgeAccepted, result)
+	require.Equal(t, costmodel.ExceedNone, reason)
+	require.Empty(t, sink.batches)
+	require.Equal(t, 1, env.Bank.EntryBuilder().PendingCount())
+
+	require.Equal(t, costmodel.ExceedNone, env.Bank.PrepareSchedule(200))
+	require.Len(t, sink.batches, 1)
+	require.Zero(t, env.Bank.EntryBuilder().PendingCount())
+}
+
+func TestPrepareScheduleReservesAndRebatesWhenNotIncluded(t *testing.T) {
+	env := NewTestEnv(TestEnvConfig{})
+	defer env.Close()
+
+	wire := txfixture.MustSignedTransferWire(0)
+	result, reason := env.Bank.Forge(wire)
+	require.Equal(t, ForgeAccepted, result)
+	require.Equal(t, costmodel.ExceedNone, reason)
+	included := env.Bank.EntryBytes()
+	require.Greater(t, included, 0)
+	require.Zero(t, env.Bank.EntryBuilder().ReservedBytes())
+
+	require.Equal(t, costmodel.ExceedNone, env.Bank.PrepareSchedule(len(wire)))
+	require.Greater(t, env.Bank.EntryBytes(), included)
+	require.Greater(t, env.Bank.EntryBuilder().ReservedBytes(), 0)
+
+	result, reason = env.Bank.Forge(wire)
+	require.Equal(t, ForgeDroppedAlreadyProcessed, result)
+	require.Equal(t, costmodel.ExceedNone, reason)
+	require.Equal(t, included, env.Bank.EntryBytes())
+	require.Zero(t, env.Bank.EntryBuilder().ReservedBytes())
+	require.Len(t, env.Bank.ForgedTransactions(), 1)
+}
+
+func TestPrepareScheduleRejectsSlotEntryBudget(t *testing.T) {
+	limits := costmodel.DefaultLimits()
+	limits.MaxEntryBytes = 80
+	env := NewTestEnv(TestEnvConfig{Limits: limits})
+	defer env.Close()
+
+	wire := txfixture.MustSignedTransferWire(0)
+	require.Equal(t, costmodel.ExceedBatchBytes, env.Bank.PrepareSchedule(len(wire)))
+	require.Zero(t, env.Bank.EntryBytes())
+	result, reason := env.Bank.Forge(wire)
+	assert.Equal(t, ForgeDroppedCost, result)
+	assert.Equal(t, costmodel.ExceedBatchBytes, reason)
+	assert.Empty(t, env.Bank.ForgedTransactions())
+}
+
 func TestWorkingBankFlushesOnBatchLimit(t *testing.T) {
 	sink := &captureSink{}
 	limits := costmodel.DefaultLimits()

--- a/pkg/blockprod/entry.go
+++ b/pkg/blockprod/entry.go
@@ -9,13 +9,19 @@ import (
 	"github.com/gagliardetto/solana-go"
 )
 
+// entryBatchOverheadBytes is the wincode prefix for a one-entry batch:
+// entry count, num_hashes, hash, and transaction count.
+const entryBatchOverheadBytes = 8 + 8 + 32 + 8
+
 // EntryBuilder accumulates forged transactions into Alpenglow-style entry batches.
 type EntryBuilder struct {
 	limits costmodel.Limits
 
-	pendingTxns []solana.Transaction
-	pendingWire int
-	entryHash   solana.Hash
+	pendingTxns   []solana.Transaction
+	pendingWire   int
+	flushedBytes  int
+	reservedBytes int
+	entryHash     solana.Hash
 }
 
 func NewEntryBuilder(limits costmodel.Limits, entryHash solana.Hash) *EntryBuilder {
@@ -33,8 +39,71 @@ func (b *EntryBuilder) PendingWireBytes() int {
 	return b.pendingWire
 }
 
-// Append adds a forged transaction. When the batch byte budget is exceeded it
-// returns the flushed entry batch and resets the pending buffer.
+func (b *EntryBuilder) FlushedBytes() int {
+	return b.flushedBytes
+}
+
+func (b *EntryBuilder) ReservedBytes() int {
+	return b.reservedBytes
+}
+
+// SlotBytes is flushed entry bytes plus the current pending entry and any
+// in-flight schedule reservation.
+func (b *EntryBuilder) SlotBytes() int {
+	pending := 0
+	if len(b.pendingTxns) > 0 {
+		pending = b.projectedBytes(0)
+	}
+	return b.flushedBytes + pending + b.reservedBytes
+}
+
+func (b *EntryBuilder) wouldOverflowBatch(nextWire int) bool {
+	return len(b.pendingTxns) > 0 && b.projectedBytes(nextWire) > int(b.limits.MaxBatchBytes)
+}
+
+func (b *EntryBuilder) wouldExceedSlot(nextWire int) bool {
+	maxEntry := int(b.limits.MaxEntryBytes)
+	if maxEntry <= 0 {
+		return false
+	}
+	return b.SlotBytes()+b.admitBytes(nextWire) > maxEntry
+}
+
+func (b *EntryBuilder) admitBytes(nextWire int) int {
+	if b.wouldOverflowBatch(nextWire) || len(b.pendingTxns) == 0 {
+		return entryBatchOverheadBytes + nextWire
+	}
+	return nextWire
+}
+
+func (b *EntryBuilder) reserve(wireSize int) bool {
+	if b.wouldExceedSlot(wireSize) {
+		return false
+	}
+	b.reservedBytes += b.admitBytes(wireSize)
+	return true
+}
+
+func (b *EntryBuilder) rebateReserved(wireSize int) {
+	b.consumeReserved(wireSize)
+}
+
+func (b *EntryBuilder) consumeReserved(wireSize int) {
+	n := b.admitBytes(wireSize)
+	if b.reservedBytes < n {
+		b.reservedBytes = 0
+		return
+	}
+	b.reservedBytes -= n
+}
+
+func (b *EntryBuilder) dropReservation() {
+	b.reservedBytes = 0
+}
+
+// Append adds a forged transaction. The pending entry is held until the next
+// transaction would overflow one FEC set. A short leftover is only emitted by
+// Flush (slot end / Freeze).
 func (b *EntryBuilder) Append(tx solana.Transaction, wireSize int) ([]turbine.Entry, int, bool) {
 	if wireSize <= 0 {
 		wire, err := tx.MarshalBinary()
@@ -44,11 +113,8 @@ func (b *EntryBuilder) Append(tx solana.Transaction, wireSize int) ([]turbine.En
 		wireSize = len(wire)
 	}
 
-	nextBytes, err := estimateBatchBytes(b.pendingTxns, tx)
-	if err != nil {
-		return nil, 0, false
-	}
-	if len(b.pendingTxns) > 0 && nextBytes > int(b.limits.MaxBatchBytes) {
+	b.consumeReserved(wireSize)
+	if b.wouldOverflowBatch(wireSize) {
 		flushed, batchBytes := b.flushLocked()
 		b.pendingTxns = append(b.pendingTxns[:0], tx)
 		b.pendingWire = wireSize
@@ -58,6 +124,10 @@ func (b *EntryBuilder) Append(tx solana.Transaction, wireSize int) ([]turbine.En
 	b.pendingTxns = append(b.pendingTxns, tx)
 	b.pendingWire += wireSize
 	return nil, 0, false
+}
+
+func (b *EntryBuilder) projectedBytes(nextWire int) int {
+	return entryBatchOverheadBytes + b.pendingWire + nextWire
 }
 
 // Flush emits the current pending transactions as a single PoH entry.
@@ -85,22 +155,10 @@ func (b *EntryBuilder) flushLocked() ([]turbine.Entry, int) {
 	if err != nil {
 		return nil, 0
 	}
+	b.flushedBytes += len(batchBytes)
 	b.pendingTxns = b.pendingTxns[:0]
 	b.pendingWire = 0
 	return entries, len(batchBytes)
-}
-
-func estimateBatchBytes(pending []solana.Transaction, next solana.Transaction) (int, error) {
-	txns := append(append([]solana.Transaction(nil), pending...), next)
-	entries := []turbine.Entry{{
-		NumHashes: 1,
-		Txns:      txns,
-	}}
-	out, err := marshalEntryBatchBytes(entries)
-	if err != nil {
-		return 0, err
-	}
-	return len(out), nil
 }
 
 func marshalEntryBatchBytes(entries []turbine.Entry) ([]byte, error) {

--- a/pkg/blockprod/entry_test.go
+++ b/pkg/blockprod/entry_test.go
@@ -1,0 +1,78 @@
+package blockprod
+
+import (
+	"testing"
+
+	"github.com/Overclock-Validator/mithril/pkg/costmodel"
+	"github.com/Overclock-Validator/mithril/pkg/tpu/txfixture"
+	"github.com/gagliardetto/solana-go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEntryBuilderHoldsUntilFECSetFull(t *testing.T) {
+	builder := NewEntryBuilder(costmodel.DefaultLimits(), solana.Hash{1})
+	limit := int(costmodel.DefaultTargetBatchBytes)
+
+	var flushedBytes int
+	var n int
+	for n = 0; n < 2000; n++ {
+		tx := mustTransferTx(t, uint64(n))
+		wire, err := tx.MarshalBinary()
+		require.NoError(t, err)
+		entries, batchBytes, didFlush := builder.Append(*tx, len(wire))
+		if !didFlush {
+			require.Nil(t, entries)
+			continue
+		}
+		require.Len(t, entries, 1)
+		require.NotEmpty(t, entries[0].Txns)
+		flushedBytes = batchBytes
+		break
+	}
+	require.Less(t, n, 2000, "should flush once the next tx would overflow one FEC set")
+	require.Greater(t, flushedBytes, limit/2)
+	require.LessOrEqual(t, flushedBytes, limit)
+	require.Greater(t, builder.PendingCount(), 0)
+}
+
+func TestEntryBuilderReservesAndRebatesSlotBytes(t *testing.T) {
+	builder := NewEntryBuilder(costmodel.DefaultLimits(), solana.Hash{1})
+	tx := mustTransferTx(t, 0)
+	wire, err := tx.MarshalBinary()
+	require.NoError(t, err)
+
+	require.True(t, builder.reserve(len(wire)))
+	require.Equal(t, entryBatchOverheadBytes+len(wire), builder.SlotBytes())
+	require.Equal(t, builder.SlotBytes(), builder.ReservedBytes())
+
+	builder.rebateReserved(len(wire))
+	require.Zero(t, builder.SlotBytes())
+	require.Zero(t, builder.ReservedBytes())
+}
+
+func TestEntryBuilderHoldsShortBatchUntilFlush(t *testing.T) {
+	builder := NewEntryBuilder(costmodel.DefaultLimits(), solana.Hash{1})
+	for i := 0; i < 8; i++ {
+		tx := mustTransferTx(t, uint64(i))
+		wire, err := tx.MarshalBinary()
+		require.NoError(t, err)
+		entries, _, didFlush := builder.Append(*tx, len(wire))
+		require.False(t, didFlush)
+		require.Nil(t, entries)
+	}
+	require.Equal(t, 8, builder.PendingCount())
+
+	entries, batchBytes := builder.Flush()
+	require.Len(t, entries, 1)
+	require.Len(t, entries[0].Txns, 8)
+	require.Greater(t, batchBytes, 0)
+	require.Less(t, batchBytes, int(costmodel.TypicalFECSetPayloadBytes))
+	require.Zero(t, builder.PendingCount())
+}
+
+func mustTransferTx(t *testing.T, seq uint64) *solana.Transaction {
+	t.Helper()
+	tx, err := solana.TransactionFromBytes(txfixture.MustSignedTransferWire(seq))
+	require.NoError(t, err)
+	return tx
+}

--- a/pkg/blockprod/leader.go
+++ b/pkg/blockprod/leader.go
@@ -79,41 +79,6 @@ type leaderSlotFailure struct {
 	detail string
 }
 
-// ShredSink shreds forged entry batches and broadcasts them via turbine.
-type ShredSink struct {
-	session *turbine.BroadcastSession
-	mu      sync.Mutex
-	err     error
-}
-
-func NewShredSink(session *turbine.BroadcastSession) *ShredSink {
-	return &ShredSink{session: session}
-}
-
-func (s *ShredSink) OnEntryBatch(entries []turbine.Entry, _ int) {
-	if s.session == nil || len(entries) == 0 {
-		return
-	}
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if s.err != nil {
-		return
-	}
-	if err := s.session.BroadcastEntryBatch(entries); err != nil {
-		s.err = err
-		mlog.Log.Warnf("blockprod shred broadcast entry batch failed: %v", err)
-	}
-}
-
-func (s *ShredSink) Err() error {
-	if s == nil {
-		return nil
-	}
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return s.err
-}
-
 // LeaderLoop activates forge when this validator is the scheduled leader.
 // RewardCertBuilder produces skip/notar reward certificates for block footers.
 type RewardCertBuilder interface {
@@ -752,6 +717,9 @@ func (l *LeaderLoop) abortActiveSlotLocked() {
 	if l.activeBank != nil {
 		l.activeBank.Close()
 	}
+	if l.activeSink != nil {
+		l.activeSink.Discard()
+	}
 	l.activeBank = nil
 	l.activeSess = nil
 	l.activeSink = nil
@@ -983,6 +951,7 @@ func (l *LeaderLoop) finishActiveSlotLocked() {
 		l.abortActiveSlotLocked()
 		return
 	}
+	l.activeSink.Wait()
 	if err := l.activeSink.Err(); err != nil {
 		l.failProductionWindowLocked(slot, leaderReasonEntryBroadcastFailed, err.Error())
 		l.abortActiveSlotLocked()
@@ -1060,6 +1029,8 @@ func (l *LeaderLoop) finishActiveSlotLocked() {
 		l.abortActiveSlotLocked()
 		return
 	}
+	// Ending tick is the last-in-slot shred. Mid-slot entry batches are only
+	// emitted when they fill a FEC set; Freeze already flushed any leftover.
 	if err := l.activeSess.BroadcastEndingTickLast(tickHash); err != nil {
 		l.failProductionWindowLocked(slot, leaderReasonEndingTickBroadcastFailed, err.Error())
 		l.abortActiveSlotLocked()

--- a/pkg/blockprod/leader.go
+++ b/pkg/blockprod/leader.go
@@ -1082,6 +1082,7 @@ func (l *LeaderLoop) finishActiveSlotLocked() {
 		producedBlock.HasAlpenglowLastChainedRoot = true
 		global.SetAlpenglowChainedMerkleRoot(slot, chained)
 	}
+	replay.RegisterLocalLeaderCommit(l.activeBank.SlotCtx())
 	if l.onBlock != nil {
 		handoffStartedAt := l.now()
 		l.onBlock(producedBlock)

--- a/pkg/blockprod/scheduler/buffer.go
+++ b/pkg/blockprod/scheduler/buffer.go
@@ -1,0 +1,246 @@
+package scheduler
+
+import (
+	"container/heap"
+	"sync"
+
+	"github.com/gagliardetto/solana-go"
+)
+
+// MaxBufferedTxns is the hard cap on cross-slot buffered transactions.
+const MaxBufferedTxns = 2 * 65536
+
+// entry is one buffered, scored transaction.
+type entry struct {
+	tx *solana.Transaction
+	// wire is an owned copy of the packet bytes. Parsed tx fields may alias it
+	// (solana-go decoder slices), so it must outlive any use of tx.
+	wire        []byte
+	wireSize    int
+	messageHash [32]byte
+	blockhash   solana.Hash
+	reward      uint64
+	seq         uint64
+	// skipGen matches Scheduler.bankGen when forge hit a slot-local reject
+	// (e.g. cost limit). The entry is retained for cross-slot retry.
+	skipGen uint64
+
+	alive  bool
+	maxIdx int
+	minIdx int
+}
+
+type maxHeap []*entry
+
+func (h maxHeap) Len() int { return len(h) }
+func (h maxHeap) Less(i, j int) bool {
+	if h[i].reward != h[j].reward {
+		return h[i].reward > h[j].reward
+	}
+	return h[i].seq < h[j].seq // older first on ties
+}
+func (h maxHeap) Swap(i, j int) {
+	h[i], h[j] = h[j], h[i]
+	h[i].maxIdx = i
+	h[j].maxIdx = j
+}
+func (h *maxHeap) Push(x any) {
+	e := x.(*entry)
+	e.maxIdx = len(*h)
+	*h = append(*h, e)
+}
+func (h *maxHeap) Pop() any {
+	old := *h
+	n := len(old)
+	e := old[n-1]
+	old[n-1] = nil
+	*h = old[:n-1]
+	e.maxIdx = -1
+	return e
+}
+
+type minHeap []*entry
+
+func (h minHeap) Len() int { return len(h) }
+func (h minHeap) Less(i, j int) bool {
+	if h[i].reward != h[j].reward {
+		return h[i].reward < h[j].reward
+	}
+	// Evict newer first when rewards tie so older buffered txs are retained.
+	return h[i].seq > h[j].seq
+}
+func (h minHeap) Swap(i, j int) {
+	h[i], h[j] = h[j], h[i]
+	h[i].minIdx = i
+	h[j].minIdx = j
+}
+func (h *minHeap) Push(x any) {
+	e := x.(*entry)
+	e.minIdx = len(*h)
+	*h = append(*h, e)
+}
+func (h *minHeap) Pop() any {
+	old := *h
+	n := len(old)
+	e := old[n-1]
+	old[n-1] = nil
+	*h = old[:n-1]
+	e.minIdx = -1
+	return e
+}
+
+// Buffer is a capacity-limited, reward-ordered transaction heap.
+type Buffer struct {
+	mu       sync.Mutex
+	capacity int
+	alive    int
+	byHash   map[[32]byte]*entry
+	max      maxHeap
+	min      minHeap
+}
+
+func NewBuffer(capacity int) *Buffer {
+	if capacity <= 0 {
+		capacity = MaxBufferedTxns
+	}
+	return &Buffer{
+		capacity: capacity,
+		byHash:   make(map[[32]byte]*entry),
+	}
+}
+
+func (b *Buffer) Len() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.alive
+}
+
+// InsertResult reports how an Insert attempt resolved.
+type InsertResult int
+
+const (
+	InsertAccepted InsertResult = iota
+	InsertDuplicate
+	InsertRejectedCapacity
+)
+
+// Insert adds e when not a duplicate. At capacity, the lowest-reward entry is
+// evicted if e has a strictly higher reward; otherwise e is rejected.
+func (b *Buffer) Insert(e *entry) (InsertResult, *entry) {
+	if e == nil || e.tx == nil {
+		return InsertRejectedCapacity, nil
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if _, exists := b.byHash[e.messageHash]; exists {
+		return InsertDuplicate, nil
+	}
+	var evicted *entry
+	if b.alive >= b.capacity {
+		min := b.peekMinAliveLocked()
+		if min == nil {
+			return InsertRejectedCapacity, nil
+		}
+		if e.reward <= min.reward {
+			return InsertRejectedCapacity, nil
+		}
+		evicted = b.popMinAliveLocked()
+	}
+	b.pushAliveLocked(e)
+	return InsertAccepted, evicted
+}
+
+// PopMax removes and returns the highest-reward alive entry.
+func (b *Buffer) PopMax() *entry {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.popMaxAliveLocked()
+}
+
+// Cleanup removes entries for which drop returns true. Returns the drop count.
+func (b *Buffer) Cleanup(drop func(*entry) bool) int {
+	if drop == nil {
+		return 0
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	var doomed []*entry
+	for _, e := range b.byHash {
+		if e.alive && drop(e) {
+			doomed = append(doomed, e)
+		}
+	}
+	for _, e := range doomed {
+		b.killLocked(e)
+	}
+	b.drainDeadLocked()
+	return len(doomed)
+}
+
+func (b *Buffer) pushAliveLocked(e *entry) {
+	e.alive = true
+	b.byHash[e.messageHash] = e
+	heap.Push(&b.max, e)
+	heap.Push(&b.min, e)
+	b.alive++
+}
+
+func (b *Buffer) killLocked(e *entry) {
+	if e == nil || !e.alive {
+		return
+	}
+	e.alive = false
+	delete(b.byHash, e.messageHash)
+	b.alive--
+}
+
+func (b *Buffer) popMaxAliveLocked() *entry {
+	for b.max.Len() > 0 {
+		e := heap.Pop(&b.max).(*entry)
+		if !e.alive {
+			continue
+		}
+		b.killLocked(e)
+		return e
+	}
+	return nil
+}
+
+func (b *Buffer) peekMinAliveLocked() *entry {
+	for b.min.Len() > 0 {
+		if b.min[0].alive {
+			return b.min[0]
+		}
+		heap.Pop(&b.min)
+	}
+	return nil
+}
+
+func (b *Buffer) popMinAliveLocked() *entry {
+	for b.min.Len() > 0 {
+		e := heap.Pop(&b.min).(*entry)
+		if !e.alive {
+			continue
+		}
+		b.killLocked(e)
+		return e
+	}
+	return nil
+}
+
+func (b *Buffer) drainDeadLocked() {
+	for b.max.Len() > 0 {
+		if b.max[0].alive {
+			break
+		}
+		heap.Pop(&b.max)
+	}
+	for b.min.Len() > 0 {
+		if b.min[0].alive {
+			break
+		}
+		heap.Pop(&b.min)
+	}
+}

--- a/pkg/blockprod/scheduler/buffer.go
+++ b/pkg/blockprod/scheduler/buffer.go
@@ -115,6 +115,13 @@ func (b *Buffer) Len() int {
 	return b.alive
 }
 
+func (b *Buffer) Capacity() int {
+	if b == nil || b.capacity <= 0 {
+		return MaxBufferedTxns
+	}
+	return b.capacity
+}
+
 // InsertResult reports how an Insert attempt resolved.
 type InsertResult int
 

--- a/pkg/blockprod/scheduler/buffer_test.go
+++ b/pkg/blockprod/scheduler/buffer_test.go
@@ -1,0 +1,81 @@
+package scheduler
+
+import (
+	"testing"
+
+	"github.com/gagliardetto/solana-go"
+	"github.com/stretchr/testify/require"
+)
+
+func testEntry(reward, seq uint64, hashByte byte) *entry {
+	var mh [32]byte
+	mh[0] = hashByte
+	return &entry{
+		tx:          &solana.Transaction{},
+		wireSize:    1,
+		messageHash: mh,
+		reward:      reward,
+		seq:         seq,
+	}
+}
+
+func TestBufferPopsHighestReward(t *testing.T) {
+	b := NewBuffer(8)
+	_, _ = b.Insert(testEntry(10, 1, 1))
+	_, _ = b.Insert(testEntry(50, 2, 2))
+	_, _ = b.Insert(testEntry(20, 3, 3))
+
+	require.Equal(t, uint64(50), b.PopMax().reward)
+	require.Equal(t, uint64(20), b.PopMax().reward)
+	require.Equal(t, uint64(10), b.PopMax().reward)
+	require.Nil(t, b.PopMax())
+}
+
+func TestBufferTieBreaksOlderFirst(t *testing.T) {
+	b := NewBuffer(8)
+	_, _ = b.Insert(testEntry(10, 1, 1))
+	_, _ = b.Insert(testEntry(10, 2, 2))
+	require.Equal(t, uint64(1), b.PopMax().seq)
+	require.Equal(t, uint64(2), b.PopMax().seq)
+}
+
+func TestBufferRejectsDuplicate(t *testing.T) {
+	b := NewBuffer(8)
+	res, _ := b.Insert(testEntry(10, 1, 1))
+	require.Equal(t, InsertAccepted, res)
+	res, _ = b.Insert(testEntry(99, 2, 1))
+	require.Equal(t, InsertDuplicate, res)
+	require.Equal(t, 1, b.Len())
+}
+
+func TestBufferEvictsLowestRewardAtCapacity(t *testing.T) {
+	b := NewBuffer(2)
+	res, _ := b.Insert(testEntry(10, 1, 1))
+	require.Equal(t, InsertAccepted, res)
+	res, _ = b.Insert(testEntry(20, 2, 2))
+	require.Equal(t, InsertAccepted, res)
+
+	res, evicted := b.Insert(testEntry(5, 3, 3))
+	require.Equal(t, InsertRejectedCapacity, res)
+	require.Nil(t, evicted)
+	require.Equal(t, 2, b.Len())
+
+	res, evicted = b.Insert(testEntry(30, 4, 4))
+	require.Equal(t, InsertAccepted, res)
+	require.NotNil(t, evicted)
+	require.Equal(t, uint64(10), evicted.reward)
+	require.Equal(t, 2, b.Len())
+
+	require.Equal(t, uint64(30), b.PopMax().reward)
+	require.Equal(t, uint64(20), b.PopMax().reward)
+}
+
+func TestBufferCleanup(t *testing.T) {
+	b := NewBuffer(8)
+	_, _ = b.Insert(testEntry(10, 1, 1))
+	_, _ = b.Insert(testEntry(20, 2, 2))
+	dropped := b.Cleanup(func(e *entry) bool { return e.messageHash[0] == 1 })
+	require.Equal(t, 1, dropped)
+	require.Equal(t, 1, b.Len())
+	require.Equal(t, byte(2), b.PopMax().messageHash[0])
+}

--- a/pkg/blockprod/scheduler/scheduler.go
+++ b/pkg/blockprod/scheduler/scheduler.go
@@ -249,6 +249,15 @@ func (s *Scheduler) drainLoop(ctx context.Context) {
 			continue
 		}
 
+		// Close a full FEC set, or refuse, before execute. Slot entry bytes are
+		// a schedule-time budget (shred-safe / SIMD-0525), like Firedancer pack.
+		if reason := bank.PrepareSchedule(e.wireSize); reason != costmodel.ExceedNone {
+			e.skipGen = s.bankGen
+			s.rebuffer(e)
+			s.recordForge(blockprod.ForgeDroppedCost, reason)
+			continue
+		}
+
 		// Prefer the owned wire so forge reparses from stable bytes even if the
 		// retained tx view was somehow mutated after buffering.
 		var result blockprod.ForgeResult

--- a/pkg/blockprod/scheduler/scheduler.go
+++ b/pkg/blockprod/scheduler/scheduler.go
@@ -62,6 +62,11 @@ type Scheduler struct {
 	stopOnce  sync.Once
 	cancel    context.CancelFunc
 	done      chan struct{}
+
+	// insertsSinceCleanup counts accepted Receive inserts. Cleanup walks the
+	// whole heap, so the drain loop does it once per capacity/5 inserts
+	// instead of before every pop.
+	insertsSinceCleanup atomic.Uint64
 }
 
 func New(banks BankSource) *Scheduler {
@@ -155,6 +160,9 @@ func (s *Scheduler) Receive(pkt packet.Packet) {
 		s.stats.DroppedCapacity++
 	}
 	s.mu.Unlock()
+	if result == InsertAccepted {
+		s.insertsSinceCleanup.Add(1)
+	}
 }
 
 // Cleanup drops expired / already-processed buffered txs using bank state.
@@ -184,6 +192,27 @@ func (s *Scheduler) Cleanup(bank *blockprod.WorkingBank) int {
 	return dropped
 }
 
+func cleanupInsertInterval(capacity int) uint64 {
+	n := uint64(capacity / 5)
+	if n == 0 {
+		n = 1
+	}
+	return n
+}
+
+// maybeCleanup walks the heap when enough new inserts have arrived.
+func (s *Scheduler) maybeCleanup(bank *blockprod.WorkingBank) int {
+	if bank == nil {
+		return 0
+	}
+	if s.insertsSinceCleanup.Load() < cleanupInsertInterval(s.buffer.Capacity()) {
+		return 0
+	}
+	dropped := s.Cleanup(bank)
+	s.insertsSinceCleanup.Store(0)
+	return dropped
+}
+
 func (s *Scheduler) drainLoop(ctx context.Context) {
 	defer close(s.done)
 	for {
@@ -199,7 +228,7 @@ func (s *Scheduler) drainLoop(ctx context.Context) {
 			continue
 		}
 
-		s.Cleanup(bank)
+		s.maybeCleanup(bank)
 
 		e, skipped := s.popSchedulable(s.bankGen)
 		for _, sk := range skipped {

--- a/pkg/blockprod/scheduler/scheduler.go
+++ b/pkg/blockprod/scheduler/scheduler.go
@@ -1,0 +1,333 @@
+package scheduler
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/Overclock-Validator/mithril/pkg/blockprod"
+	"github.com/Overclock-Validator/mithril/pkg/costmodel"
+	"github.com/Overclock-Validator/mithril/pkg/features"
+	"github.com/Overclock-Validator/mithril/pkg/tpu/packet"
+	"github.com/gagliardetto/solana-go"
+)
+
+// BankSource supplies the active leader working bank.
+type BankSource interface {
+	WorkingBank() *blockprod.WorkingBank
+}
+
+// Stats tracks scheduler buffer and forge outcomes.
+type Stats struct {
+	InPackets               uint64
+	InBytes                 uint64
+	Buffered                uint64
+	DroppedParse            uint64
+	DroppedVote             uint64
+	DroppedDuplicate        uint64
+	DroppedCapacity         uint64
+	EvictedCapacity         uint64
+	DroppedExpired          uint64
+	DroppedAlreadyProcessed uint64
+	Accepted                uint64
+	DroppedNoBank           uint64
+	DroppedCost             uint64
+	DroppedExecution        uint64
+	DroppedBlockCost        uint64
+	DroppedAccountCost      uint64
+	DroppedAllocCost        uint64
+	DroppedBatchBytes       uint64
+}
+
+// Scheduler buffers verified TPU transactions in a reward-ordered heap and
+// drains into the active WorkingBank when one is published.
+type Scheduler struct {
+	banks  BankSource
+	feats  *features.Features
+	buffer *Buffer
+
+	seq  atomic.Uint64
+	wake chan struct{}
+
+	mu    sync.Mutex
+	stats Stats
+
+	// bankGen increments whenever the drain loop observes a different WorkingBank
+	// pointer so cost-rejected txs can be retried in a later slot.
+	bankGen    uint64
+	activeBank *blockprod.WorkingBank
+
+	startOnce sync.Once
+	stopOnce  sync.Once
+	cancel    context.CancelFunc
+	done      chan struct{}
+}
+
+func New(banks BankSource) *Scheduler {
+	feats := features.NewFeaturesDefault()
+	return &Scheduler{
+		banks:  banks,
+		feats:  feats,
+		buffer: NewBuffer(MaxBufferedTxns),
+		wake:   make(chan struct{}, 1),
+		done:   make(chan struct{}),
+	}
+}
+
+// Start launches the bank-gated drain loop.
+func (s *Scheduler) Start(ctx context.Context) {
+	s.startOnce.Do(func() {
+		runCtx, cancel := context.WithCancel(ctx)
+		s.cancel = cancel
+		go s.drainLoop(runCtx)
+	})
+}
+
+// Stop cancels the drain loop and waits for it to exit.
+func (s *Scheduler) Stop() {
+	s.stopOnce.Do(func() {
+		if s.cancel == nil {
+			return
+		}
+		s.cancel()
+		<-s.done
+	})
+}
+
+func (s *Scheduler) Stats() Stats {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.stats
+}
+
+func (s *Scheduler) Buffered() int {
+	return s.buffer.Len()
+}
+
+// Receive scores and buffers a verified packet. Packets are always released.
+func (s *Scheduler) Receive(pkt packet.Packet) {
+	data := pkt.Data()
+	s.mu.Lock()
+	s.stats.InPackets++
+	s.stats.InBytes += uint64(len(data))
+	s.mu.Unlock()
+
+	// Packet buffers are pooled. Copy before Release — solana-go's decoder
+	// aliases instruction/signature slices into the source buffer, and the
+	// scheduler retains txs across slots.
+	wire := append([]byte(nil), data...)
+	pkt.Release()
+
+	tx, err := solana.TransactionFromBytes(wire)
+	if err != nil {
+		s.addStat(func(st *Stats) { st.DroppedParse++ })
+		return
+	}
+
+	reward, messageHash, err := scoreTransaction(tx, s.feats)
+	if err != nil {
+		s.addStat(func(st *Stats) { st.DroppedParse++ })
+		return
+	}
+
+	e := &entry{
+		tx:          tx,
+		wire:        wire,
+		wireSize:    len(wire),
+		messageHash: messageHash,
+		blockhash:   tx.Message.RecentBlockhash,
+		reward:      reward,
+		seq:         s.seq.Add(1),
+	}
+	result, evicted := s.buffer.Insert(e)
+	s.mu.Lock()
+	switch result {
+	case InsertAccepted:
+		s.stats.Buffered++
+		if evicted != nil {
+			s.stats.EvictedCapacity++
+		}
+		s.signal()
+	case InsertDuplicate:
+		s.stats.DroppedDuplicate++
+	default:
+		s.stats.DroppedCapacity++
+	}
+	s.mu.Unlock()
+}
+
+// Cleanup drops expired / already-processed buffered txs using bank state.
+func (s *Scheduler) Cleanup(bank *blockprod.WorkingBank) int {
+	if bank == nil {
+		return 0
+	}
+	var expired, already uint64
+	dropped := s.buffer.Cleanup(func(e *entry) bool {
+		switch bank.ClassifyBuffered(e.blockhash, e.messageHash) {
+		case blockprod.BufferedExpired:
+			expired++
+			return true
+		case blockprod.BufferedAlreadyProcessed:
+			already++
+			return true
+		default:
+			return false
+		}
+	})
+	if dropped > 0 {
+		s.mu.Lock()
+		s.stats.DroppedExpired += expired
+		s.stats.DroppedAlreadyProcessed += already
+		s.mu.Unlock()
+	}
+	return dropped
+}
+
+func (s *Scheduler) drainLoop(ctx context.Context) {
+	defer close(s.done)
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+		bank := s.banks.WorkingBank()
+		s.noteBank(bank)
+		if bank == nil {
+			if !s.wait(ctx, 5*time.Millisecond) {
+				return
+			}
+			continue
+		}
+
+		s.Cleanup(bank)
+
+		e, skipped := s.popSchedulable(s.bankGen)
+		for _, sk := range skipped {
+			s.rebuffer(sk)
+		}
+		if e == nil {
+			if !s.wait(ctx, time.Millisecond) {
+				return
+			}
+			continue
+		}
+
+		// Bank may have been cleared between the nil check and pop.
+		bank = s.banks.WorkingBank()
+		s.noteBank(bank)
+		if bank == nil {
+			s.rebuffer(e)
+			continue
+		}
+
+		// Prefer the owned wire so forge reparses from stable bytes even if the
+		// retained tx view was somehow mutated after buffering.
+		var result blockprod.ForgeResult
+		var reason costmodel.ExceedReason
+		if len(e.wire) > 0 {
+			result, reason = bank.Forge(e.wire)
+		} else {
+			result, reason = bank.ForgeTransaction(e.tx, e.wireSize)
+		}
+		switch result {
+		case blockprod.ForgeDroppedNoLeader:
+			s.rebuffer(e)
+		case blockprod.ForgeDroppedCost:
+			e.skipGen = s.bankGen
+			s.rebuffer(e)
+			s.recordForge(result, reason)
+		default:
+			s.recordForge(result, reason)
+		}
+	}
+}
+
+// popSchedulable pops the highest-reward entry that is not marked skip for gen.
+func (s *Scheduler) popSchedulable(gen uint64) (picked *entry, skipped []*entry) {
+	for {
+		e := s.buffer.PopMax()
+		if e == nil {
+			return nil, skipped
+		}
+		if e.skipGen == gen {
+			skipped = append(skipped, e)
+			continue
+		}
+		return e, skipped
+	}
+}
+
+func (s *Scheduler) noteBank(bank *blockprod.WorkingBank) {
+	if bank == s.activeBank {
+		return
+	}
+	s.activeBank = bank
+	s.bankGen++
+}
+
+func (s *Scheduler) rebuffer(e *entry) {
+	if res, _ := s.buffer.Insert(e); res != InsertAccepted {
+		s.addStat(func(st *Stats) { st.DroppedCapacity++ })
+	}
+}
+
+func (s *Scheduler) recordForge(result blockprod.ForgeResult, reason costmodel.ExceedReason) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	switch result {
+	case blockprod.ForgeAccepted:
+		s.stats.Accepted++
+	case blockprod.ForgeDroppedVote:
+		s.stats.DroppedVote++
+	case blockprod.ForgeDroppedParse:
+		s.stats.DroppedParse++
+	case blockprod.ForgeDroppedCost:
+		s.stats.DroppedCost++
+		s.recordCostDropLocked(reason)
+	case blockprod.ForgeDroppedExecution:
+		s.stats.DroppedExecution++
+	case blockprod.ForgeDroppedAlreadyProcessed:
+		s.stats.DroppedAlreadyProcessed++
+	default:
+		s.stats.DroppedNoBank++
+	}
+}
+
+func (s *Scheduler) recordCostDropLocked(reason costmodel.ExceedReason) {
+	switch reason {
+	case costmodel.ExceedBlockCost:
+		s.stats.DroppedBlockCost++
+	case costmodel.ExceedWritableAccountCost:
+		s.stats.DroppedAccountCost++
+	case costmodel.ExceedAllocatedDataSize:
+		s.stats.DroppedAllocCost++
+	case costmodel.ExceedBatchBytes:
+		s.stats.DroppedBatchBytes++
+	}
+}
+
+func (s *Scheduler) addStat(fn func(*Stats)) {
+	s.mu.Lock()
+	fn(&s.stats)
+	s.mu.Unlock()
+}
+
+func (s *Scheduler) signal() {
+	select {
+	case s.wake <- struct{}{}:
+	default:
+	}
+}
+
+func (s *Scheduler) wait(ctx context.Context, d time.Duration) bool {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-s.wake:
+		return true
+	case <-timer.C:
+		return true
+	}
+}

--- a/pkg/blockprod/scheduler/scheduler_test.go
+++ b/pkg/blockprod/scheduler/scheduler_test.go
@@ -1,0 +1,222 @@
+package scheduler
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Overclock-Validator/mithril/pkg/blockprod"
+	"github.com/Overclock-Validator/mithril/pkg/fees"
+	"github.com/Overclock-Validator/mithril/pkg/tpu/packet"
+	"github.com/Overclock-Validator/mithril/pkg/tpu/txfixture"
+	"github.com/gagliardetto/solana-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSchedulerBuffersWithoutBankAndDrainsWhenSet(t *testing.T) {
+	env := blockprod.NewTestEnv(blockprod.TestEnvConfig{})
+	defer env.Close()
+
+	controller := blockprod.NewController() // no bank yet
+	sched := New(controller)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	sched.Start(ctx)
+	defer sched.Stop()
+
+	wire := txfixture.MustSignedTransferWire(0)
+	sched.Receive(packet.Owned(wire))
+
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for sched.Buffered() == 0 && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	require.Equal(t, 1, sched.Buffered())
+	require.Equal(t, uint64(0), sched.Stats().Accepted)
+
+	controller.SetWorkingBank(env.Bank)
+
+	deadline = time.Now().Add(2 * time.Second)
+	for sched.Stats().Accepted == 0 && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	require.Equal(t, uint64(1), sched.Stats().Accepted)
+	require.Equal(t, 0, sched.Buffered())
+	require.Len(t, env.Bank.ForgedTransactions(), 1)
+}
+
+func TestSchedulerRetainsAcrossBankClear(t *testing.T) {
+	controller := blockprod.NewController()
+	sched := New(controller)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	sched.Start(ctx)
+	defer sched.Stop()
+
+	sched.Receive(packet.Owned(txfixture.MustSignedTransferWire(1)))
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for sched.Buffered() == 0 && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	require.Equal(t, 1, sched.Buffered())
+
+	// No bank published yet — buffer must survive until a later slot.
+	time.Sleep(50 * time.Millisecond)
+	require.Equal(t, 1, sched.Buffered())
+	require.Equal(t, uint64(0), sched.Stats().Accepted)
+
+	env := blockprod.NewTestEnv(blockprod.TestEnvConfig{})
+	defer env.Close()
+	controller.SetWorkingBank(env.Bank)
+
+	deadline = time.Now().Add(2 * time.Second)
+	for sched.Stats().Accepted == 0 && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	require.Equal(t, uint64(1), sched.Stats().Accepted)
+}
+
+func TestSchedulerCleanupDropsExpired(t *testing.T) {
+	env := blockprod.NewTestEnv(blockprod.TestEnvConfig{})
+	defer env.Close()
+
+	sched := New(env.Controller)
+	wire := txfixture.MustSignedTransferWire(2)
+	tx, err := solana.TransactionFromBytes(wire)
+	require.NoError(t, err)
+	reward, mh, err := scoreTransaction(tx, sched.feats)
+	require.NoError(t, err)
+
+	// Force an expired blockhash while keeping a unique message hash.
+	expired := solana.Hash{0xee}
+	e := &entry{
+		tx:          tx,
+		wireSize:    len(wire),
+		messageHash: mh,
+		blockhash:   expired,
+		reward:      reward,
+		seq:         1,
+	}
+	res, _ := sched.buffer.Insert(e)
+	require.Equal(t, InsertAccepted, res)
+
+	dropped := sched.Cleanup(env.Bank)
+	require.Equal(t, 1, dropped)
+	require.Equal(t, 0, sched.Buffered())
+	assert.Equal(t, uint64(1), sched.Stats().DroppedExpired)
+}
+
+func TestSchedulerDropsUnparseable(t *testing.T) {
+	sched := New(blockprod.NewController())
+	sched.Receive(packet.Owned([]byte{0x00, 0x01}))
+	assert.Equal(t, uint64(1), sched.Stats().DroppedParse)
+}
+
+func TestScoreTransferLeaderReward(t *testing.T) {
+	wire := txfixture.MustSignedTransferWire(3)
+	tx, err := solana.TransactionFromBytes(wire)
+	require.NoError(t, err)
+	sched := New(blockprod.NewController())
+	reward, _, err := scoreTransaction(tx, sched.feats)
+	require.NoError(t, err)
+
+	// 1 signature → 5000 execution fee → 2500 unburned; no priority fee.
+	want := fees.LeaderReward(&fees.TxFeeInfo{ExecutionFee: 5000, PriorityFee: 0, TotalFee: 5000})
+	require.Equal(t, want, reward)
+	require.Equal(t, uint64(2500), reward)
+}
+
+func TestSchedulerDrainsHighestRewardFirst(t *testing.T) {
+	env := blockprod.NewTestEnv(blockprod.TestEnvConfig{})
+	defer env.Close()
+
+	controller := blockprod.NewController()
+	sched := New(controller)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	sched.Start(ctx)
+	defer sched.Stop()
+
+	low := txfixture.MustSignedTransferWire(10)
+	high := txfixture.MustSignedTransferWire(11)
+
+	// Insert low first, then high with artificially higher reward via direct buffer.
+	sched.Receive(packet.Owned(low))
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for sched.Buffered() < 1 && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	txHigh, err := solana.TransactionFromBytes(high)
+	require.NoError(t, err)
+	_, mh, err := scoreTransaction(txHigh, sched.feats)
+	require.NoError(t, err)
+	res, _ := sched.buffer.Insert(&entry{
+		tx:          txHigh,
+		wireSize:    len(high),
+		messageHash: mh,
+		blockhash:   txHigh.Message.RecentBlockhash,
+		reward:      1_000_000,
+		seq:         99,
+	})
+	require.Equal(t, InsertAccepted, res)
+	sched.signal()
+
+	controller.SetWorkingBank(env.Bank)
+	deadline = time.Now().Add(2 * time.Second)
+	for len(env.Bank.ForgedTransactions()) < 2 && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	forged := env.Bank.ForgedTransactions()
+	require.Len(t, forged, 2)
+
+	// First forged must be the high-reward tx (seq 11 transfer).
+	highTx, err := solana.TransactionFromBytes(high)
+	require.NoError(t, err)
+	require.Equal(t, highTx.Signatures[0], forged[0].Signatures[0])
+}
+
+func TestMaxBufferedTxnsConstant(t *testing.T) {
+	require.Equal(t, 2*65536, MaxBufferedTxns)
+}
+
+func TestSchedulerCopiesPooledPacketBytes(t *testing.T) {
+	sched := New(blockprod.NewController())
+	pool := packet.NewPool(1)
+	buf, idx, ok := pool.Acquire()
+	require.True(t, ok)
+
+	wire := txfixture.MustSignedTransferWire(42)
+	require.LessOrEqual(t, len(wire), len(buf))
+	copy(buf, wire)
+	pkt := packet.FromPool(pool, buf, len(wire), idx)
+
+	sched.Receive(pkt)
+	require.Equal(t, 1, sched.Buffered())
+
+	// Recycle the pool slot and overwrite it. Buffered wire/tx must stay intact.
+	buf2, idx2, ok := pool.Acquire()
+	require.True(t, ok)
+	require.Equal(t, idx, idx2)
+	for i := range buf2 {
+		buf2[i] = 0xff
+	}
+	pool.Release(idx2)
+
+	e := sched.buffer.PopMax()
+	require.NotNil(t, e)
+	require.Equal(t, wire, e.wire)
+
+	// Re-parse and verify the buffered transaction still has a valid signature.
+	tx, err := solana.TransactionFromBytes(e.wire)
+	require.NoError(t, err)
+	require.Equal(t, e.tx.Signatures[0], tx.Signatures[0])
+}
+
+func TestClassifyBufferedExpired(t *testing.T) {
+	env := blockprod.NewTestEnv(blockprod.TestEnvConfig{})
+	defer env.Close()
+	require.Equal(t, blockprod.BufferedExpired, env.Bank.ClassifyBuffered(solana.Hash{0x01}, [32]byte{}))
+	require.Equal(t, blockprod.BufferedKeep, env.Bank.ClassifyBuffered(txfixture.TestBlockhash(), [32]byte{0xab}))
+}

--- a/pkg/blockprod/scheduler/scheduler_test.go
+++ b/pkg/blockprod/scheduler/scheduler_test.go
@@ -107,6 +107,43 @@ func TestSchedulerCleanupDropsExpired(t *testing.T) {
 	assert.Equal(t, uint64(1), sched.Stats().DroppedExpired)
 }
 
+func TestSchedulerMaybeCleanupAfterInsertInterval(t *testing.T) {
+	env := blockprod.NewTestEnv(blockprod.TestEnvConfig{})
+	defer env.Close()
+
+	sched := New(env.Controller)
+	wire := txfixture.MustSignedTransferWire(4)
+	tx, err := solana.TransactionFromBytes(wire)
+	require.NoError(t, err)
+	reward, mh, err := scoreTransaction(tx, sched.feats)
+	require.NoError(t, err)
+
+	res, _ := sched.buffer.Insert(&entry{
+		tx:          tx,
+		wireSize:    len(wire),
+		messageHash: mh,
+		blockhash:   solana.Hash{0xee},
+		reward:      reward,
+		seq:         1,
+	})
+	require.Equal(t, InsertAccepted, res)
+	require.Equal(t, 1, sched.Buffered())
+
+	interval := cleanupInsertInterval(sched.buffer.Capacity())
+	require.Equal(t, uint64(MaxBufferedTxns/5), interval)
+
+	sched.insertsSinceCleanup.Store(interval - 1)
+	require.Equal(t, 0, sched.maybeCleanup(env.Bank))
+	require.Equal(t, 1, sched.Buffered())
+	require.Equal(t, interval-1, sched.insertsSinceCleanup.Load())
+
+	sched.insertsSinceCleanup.Store(interval)
+	require.Equal(t, 1, sched.maybeCleanup(env.Bank))
+	require.Equal(t, 0, sched.Buffered())
+	require.Equal(t, uint64(0), sched.insertsSinceCleanup.Load())
+	assert.Equal(t, uint64(1), sched.Stats().DroppedExpired)
+}
+
 func TestSchedulerDropsUnparseable(t *testing.T) {
 	sched := New(blockprod.NewController())
 	sched.Receive(packet.Owned([]byte{0x00, 0x01}))

--- a/pkg/blockprod/scheduler/scheduler_test.go
+++ b/pkg/blockprod/scheduler/scheduler_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/Overclock-Validator/mithril/pkg/blockprod"
+	"github.com/Overclock-Validator/mithril/pkg/costmodel"
 	"github.com/Overclock-Validator/mithril/pkg/fees"
 	"github.com/Overclock-Validator/mithril/pkg/tpu/packet"
 	"github.com/Overclock-Validator/mithril/pkg/tpu/txfixture"
@@ -212,6 +213,30 @@ func TestSchedulerDrainsHighestRewardFirst(t *testing.T) {
 	highTx, err := solana.TransactionFromBytes(high)
 	require.NoError(t, err)
 	require.Equal(t, highTx.Signatures[0], forged[0].Signatures[0])
+}
+
+func TestSchedulerSkipsWhenSlotEntryBytesExceeded(t *testing.T) {
+	envLimits := costmodel.DefaultLimits()
+	envLimits.MaxEntryBytes = 80
+	env := blockprod.NewTestEnv(blockprod.TestEnvConfig{Limits: envLimits})
+	defer env.Close()
+
+	sched := New(env.Controller)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	sched.Start(ctx)
+	defer sched.Stop()
+
+	sched.Receive(packet.Owned(txfixture.MustSignedTransferWire(0)))
+	deadline := time.Now().Add(2 * time.Second)
+	for sched.Stats().DroppedCost == 0 && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	require.Equal(t, uint64(1), sched.Stats().DroppedCost)
+	require.Equal(t, uint64(1), sched.Stats().DroppedBatchBytes)
+	require.Equal(t, uint64(0), sched.Stats().Accepted)
+	require.Equal(t, 1, sched.Buffered())
+	require.Empty(t, env.Bank.ForgedTransactions())
 }
 
 func TestMaxBufferedTxnsConstant(t *testing.T) {

--- a/pkg/blockprod/scheduler/score.go
+++ b/pkg/blockprod/scheduler/score.go
@@ -1,0 +1,46 @@
+package scheduler
+
+import (
+	"fmt"
+
+	"github.com/Overclock-Validator/mithril/pkg/features"
+	"github.com/Overclock-Validator/mithril/pkg/fees"
+	"github.com/Overclock-Validator/mithril/pkg/replay"
+	"github.com/Overclock-Validator/mithril/pkg/sealevel"
+	"github.com/gagliardetto/solana-go"
+)
+
+func scoreTransaction(tx *solana.Transaction, feats *features.Features) (reward uint64, messageHash [32]byte, err error) {
+	if tx == nil {
+		return 0, messageHash, fmt.Errorf("nil transaction")
+	}
+	messageHash, err = replay.TransactionMessageHash(tx)
+	if err != nil {
+		return 0, messageHash, err
+	}
+	instrs, err := instructionsForScoring(tx)
+	if err != nil {
+		return 0, messageHash, err
+	}
+	limits, err := sealevel.ComputeBudgetExecuteInstructions(instrs, feats)
+	if err != nil {
+		return 0, messageHash, err
+	}
+	feeInfo := fees.CalculateTxFees(tx, instrs, limits, feats)
+	return fees.LeaderReward(feeInfo), messageHash, nil
+}
+
+func instructionsForScoring(tx *solana.Transaction) ([]sealevel.Instruction, error) {
+	out := make([]sealevel.Instruction, 0, len(tx.Message.Instructions))
+	for _, compiled := range tx.Message.Instructions {
+		programID, err := tx.ResolveProgramIDIndex(compiled.ProgramIDIndex)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, sealevel.Instruction{
+			ProgramId: programID,
+			Data:      compiled.Data,
+		})
+	}
+	return out, nil
+}

--- a/pkg/blockprod/shred_sink.go
+++ b/pkg/blockprod/shred_sink.go
@@ -1,0 +1,143 @@
+package blockprod
+
+import (
+	"sync"
+
+	"github.com/Overclock-Validator/mithril/pkg/mlog"
+	"github.com/Overclock-Validator/mithril/pkg/turbine"
+	"github.com/gagliardetto/solana-go"
+)
+
+// ShredSink shreds forged entry batches and broadcasts them via turbine.
+// OnEntryBatch only enqueues; a dedicated goroutine shreds in FIFO order so
+// forge can keep packing. Wait drains the queue before footer/ending-tick
+// so the chained merkle state stays sequential.
+type ShredSink struct {
+	broadcast func([]turbine.Entry) error
+
+	mu      sync.Mutex
+	cond    *sync.Cond
+	queue   [][]turbine.Entry
+	err     error
+	busy    bool
+	closed  bool
+	discard bool
+	exited  bool
+}
+
+func NewShredSink(session *turbine.BroadcastSession) *ShredSink {
+	s := &ShredSink{}
+	if session != nil {
+		s.broadcast = session.BroadcastEntryBatch
+	}
+	s.cond = sync.NewCond(&s.mu)
+	go s.loop()
+	return s
+}
+
+func (s *ShredSink) OnEntryBatch(entries []turbine.Entry, _ int) {
+	if s == nil || s.broadcast == nil || len(entries) == 0 {
+		return
+	}
+	job := cloneEntries(entries)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed || s.err != nil {
+		return
+	}
+	s.queue = append(s.queue, job)
+	s.cond.Signal()
+}
+
+func (s *ShredSink) Err() error {
+	if s == nil {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.err
+}
+
+// Wait blocks until every enqueued batch has been shredded (or dropped).
+func (s *ShredSink) Wait() {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for !s.exited && (s.busy || len(s.queue) > 0) {
+		s.cond.Wait()
+	}
+}
+
+// Discard stops the worker and drops any batches not yet shredded.
+func (s *ShredSink) Discard() {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	if !s.exited {
+		s.discard = true
+		s.closed = true
+		s.queue = nil
+		s.cond.Broadcast()
+		for !s.exited {
+			s.cond.Wait()
+		}
+	}
+	s.mu.Unlock()
+}
+
+func (s *ShredSink) loop() {
+	for {
+		s.mu.Lock()
+		for len(s.queue) == 0 && !s.closed {
+			s.cond.Wait()
+		}
+		if len(s.queue) == 0 {
+			s.exited = true
+			s.busy = false
+			s.cond.Broadcast()
+			s.mu.Unlock()
+			return
+		}
+		job := s.queue[0]
+		s.queue[0] = nil
+		s.queue = s.queue[1:]
+		discard := s.discard
+		broadcast := s.broadcast
+		s.busy = true
+		s.mu.Unlock()
+
+		if !discard && broadcast != nil {
+			if err := broadcast(job); err != nil {
+				s.mu.Lock()
+				if s.err == nil {
+					s.err = err
+					mlog.Log.Warnf("blockprod shred broadcast entry batch failed: %v", err)
+				}
+				s.queue = nil
+				s.mu.Unlock()
+			}
+		}
+
+		s.mu.Lock()
+		s.busy = false
+		if len(s.queue) == 0 {
+			s.cond.Broadcast()
+		}
+		s.mu.Unlock()
+	}
+}
+
+func cloneEntries(entries []turbine.Entry) []turbine.Entry {
+	out := make([]turbine.Entry, len(entries))
+	for i, e := range entries {
+		out[i] = turbine.Entry{
+			NumHashes: e.NumHashes,
+			Hash:      e.Hash,
+			Txns:      append([]solana.Transaction(nil), e.Txns...),
+		}
+	}
+	return out
+}

--- a/pkg/blockprod/shred_sink_test.go
+++ b/pkg/blockprod/shred_sink_test.go
@@ -1,0 +1,121 @@
+package blockprod
+
+import (
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/Overclock-Validator/mithril/pkg/turbine"
+	"github.com/gagliardetto/solana-go"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestShredSink(broadcast func([]turbine.Entry) error) *ShredSink {
+	s := &ShredSink{broadcast: broadcast}
+	s.cond = sync.NewCond(&s.mu)
+	go s.loop()
+	return s
+}
+
+func TestShredSinkOnEntryBatchDoesNotBlockOnBroadcast(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	s := newTestShredSink(func([]turbine.Entry) error {
+		close(started)
+		<-release
+		return nil
+	})
+	defer s.Discard()
+
+	done := make(chan struct{})
+	go func() {
+		s.OnEntryBatch([]turbine.Entry{{NumHashes: 1}}, 0)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("OnEntryBatch blocked on broadcast")
+	}
+	<-started
+	close(release)
+	s.Wait()
+}
+
+func TestShredSinkWaitDrainsFIFO(t *testing.T) {
+	var order []uint64
+	var mu sync.Mutex
+	s := newTestShredSink(func(entries []turbine.Entry) error {
+		mu.Lock()
+		order = append(order, entries[0].NumHashes)
+		mu.Unlock()
+		time.Sleep(5 * time.Millisecond)
+		return nil
+	})
+	defer s.Discard()
+
+	s.OnEntryBatch([]turbine.Entry{{NumHashes: 1, Hash: solana.Hash{1}}}, 0)
+	s.OnEntryBatch([]turbine.Entry{{NumHashes: 2, Hash: solana.Hash{2}}}, 0)
+	s.OnEntryBatch([]turbine.Entry{{NumHashes: 3, Hash: solana.Hash{3}}}, 0)
+	s.Wait()
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Equal(t, []uint64{1, 2, 3}, order)
+}
+
+func TestShredSinkDiscardDropsQueuedBatches(t *testing.T) {
+	var started atomic.Int32
+	firstEntered := make(chan struct{})
+	release := make(chan struct{})
+	s := newTestShredSink(func([]turbine.Entry) error {
+		if started.Add(1) == 1 {
+			close(firstEntered)
+		}
+		<-release
+		return nil
+	})
+
+	s.OnEntryBatch([]turbine.Entry{{NumHashes: 1}}, 0)
+	s.OnEntryBatch([]turbine.Entry{{NumHashes: 2}}, 0)
+	<-firstEntered
+
+	done := make(chan struct{})
+	go func() {
+		s.Discard()
+		close(done)
+	}()
+	for {
+		s.mu.Lock()
+		dropped := s.closed && len(s.queue) == 0
+		s.mu.Unlock()
+		if dropped {
+			break
+		}
+		time.Sleep(time.Millisecond)
+	}
+	close(release)
+	<-done
+	require.Equal(t, int32(1), started.Load())
+}
+
+func TestShredSinkBroadcastErrorStopsQueue(t *testing.T) {
+	var started atomic.Int32
+	s := newTestShredSink(func([]turbine.Entry) error {
+		n := started.Add(1)
+		if n == 1 {
+			return errors.New("shred failed")
+		}
+		return nil
+	})
+	defer s.Discard()
+
+	s.OnEntryBatch([]turbine.Entry{{NumHashes: 1}}, 0)
+	s.OnEntryBatch([]turbine.Entry{{NumHashes: 2}}, 0)
+	s.Wait()
+	require.EqualError(t, s.Err(), "shred failed")
+	require.Equal(t, int32(1), started.Load())
+}

--- a/pkg/blockstream/block_source.go
+++ b/pkg/blockstream/block_source.go
@@ -101,7 +101,8 @@ type BlockSourceOpts struct {
 	PrewarmBlocks []*b.Block
 	// LocalBlocks carries fully frozen blocks from this node's producer. The
 	// source owns the consumer for exactly its own lifetime, avoiding stale
-	// consumers across a replay/fork-recovery restart.
+	// consumers across a replay/fork-recovery restart. Replay adopts the
+	// producer SlotCtx for these slots and does not re-execute them.
 	LocalBlocks <-chan *b.Block
 	// DisableRPCBlockFetch (config block.rpc_fallback=false): a live-shred
 	// source NEVER fetches blocks over RPC — shreds via turbine + repair are
@@ -2995,8 +2996,8 @@ func (bs *BlockSource) emitOrderedBlocks() {
 							}
 						}
 					} else if blk.FromLocalProduction {
-						// Local production is an authoritative input to replay, not a
-						// source handoff away from the turbine stream.
+						// Local production is sequenced into replay so it can adopt
+						// the producer SlotCtx; it is not a source handoff.
 					} else if repairingSlot {
 						bs.clearLiveRepairSlot(blk.Slot)
 						mlog.Log.Infof("BLOCK SOURCE STATUS: missing streamed slot recovered via RPC at slot %d; staying on %s stream", blk.Slot, bs.liveShredStreamName())
@@ -3502,8 +3503,8 @@ func (bs *BlockSource) DownloadInitialBlocks() {
 }
 
 // InjectLocalBlock queues a fully frozen locally produced block through the
-// same ordered emitter used by network blocks. Replay and forkchoice remain the
-// only path that can accept its state.
+// same ordered emitter used by network blocks so replay can adopt the
+// already-mutated producer SlotCtx in slot order.
 func (bs *BlockSource) InjectLocalBlock(blk *b.Block) bool {
 	if bs == nil || blk == nil {
 		return false

--- a/pkg/costmodel/costmodel_test.go
+++ b/pkg/costmodel/costmodel_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/Overclock-Validator/mithril/pkg/features"
+	"github.com/Overclock-Validator/mithril/pkg/sealevel"
 	"github.com/Overclock-Validator/mithril/pkg/tpu/txfixture"
 	"github.com/gagliardetto/solana-go"
 	"github.com/stretchr/testify/assert"
@@ -62,6 +63,35 @@ func TestCostTrackerWritableAccountLimit(t *testing.T) {
 	}
 
 	assert.Equal(t, ExceedWritableAccountCost, tracker.WouldExceed(cost))
+}
+
+func TestLoadedAccountsDataSizeCostProtocolPages(t *testing.T) {
+	assert.Equal(t, uint64(0), loadedAccountsDataSizeCost(0))
+	assert.Equal(t, uint64(HeapCost), loadedAccountsDataSizeCost(1))
+	assert.Equal(t, uint64(HeapCost), loadedAccountsDataSizeCost(AccountDataCostPageSize))
+	assert.Equal(t, uint64(2*HeapCost), loadedAccountsDataSizeCost(AccountDataCostPageSize+1))
+
+	defaultLimitPages := uint64(sealevel.MaxLoadedAccountsDataSizeBytes) / AccountDataCostPageSize
+	assert.Equal(t, defaultLimitPages*HeapCost, loadedAccountsDataSizeCost(sealevel.MaxLoadedAccountsDataSizeBytes))
+	assert.Equal(t, uint64(16_384), loadedAccountsDataSizeCost(sealevel.MaxLoadedAccountsDataSizeBytes))
+}
+
+func TestWritableAccountLimitAllowsManyDefaultLoadedSizeTxs(t *testing.T) {
+	tracker := NewCostTracker(DefaultLimits())
+	payer := txfixture.PayerPubkey()
+	cost := TransactionCost{
+		SignatureCost:              SignatureCost,
+		WriteLockCost:              WriteLockUnits,
+		ProgramsExecutionCost:      450,
+		LoadedAccountsDataSizeCost: loadedAccountsDataSizeCost(sealevel.MaxLoadedAccountsDataSizeBytes),
+		WritableAccounts:           []solana.PublicKey{payer},
+	}
+
+	for i := 0; i < 6; i++ {
+		require.Equal(t, ExceedNone, tracker.WouldExceed(cost), "tx %d should fit under the 24M writable-account cap", i+1)
+		tracker.Record(cost)
+	}
+	assert.LessOrEqual(t, tracker.WritableAccountCost(payer), uint64(MaxWritableAccountUnits))
 }
 
 func TestCostTrackerAcceptsUnderLimits(t *testing.T) {

--- a/pkg/costmodel/costmodel_test.go
+++ b/pkg/costmodel/costmodel_test.go
@@ -94,6 +94,56 @@ func TestWritableAccountLimitAllowsManyDefaultLoadedSizeTxs(t *testing.T) {
 	assert.LessOrEqual(t, tracker.WritableAccountCost(payer), uint64(MaxWritableAccountUnits))
 }
 
+func TestCostTrackerRebateDropsUnusedLoadedAndExec(t *testing.T) {
+	tracker := NewCostTracker(DefaultLimits())
+	payer := txfixture.PayerPubkey()
+	estimated := TransactionCost{
+		SignatureCost:              SignatureCost,
+		WriteLockCost:              WriteLockUnits,
+		DataBytesCost:              7,
+		ProgramsExecutionCost:      450,
+		LoadedAccountsDataSizeCost: loadedAccountsDataSizeCost(sealevel.MaxLoadedAccountsDataSizeBytes),
+		WritableAccounts:           []solana.PublicKey{payer},
+	}
+	actualExec := uint64(150)
+	actualLoaded := loadedAccountsDataSizeCost(200)
+
+	require.Equal(t, ExceedNone, tracker.WouldExceed(estimated))
+	tracker.Record(estimated)
+	assert.Equal(t, estimated.Sum(), tracker.BlockCost())
+	tracker.Rebate(estimated, actualExec, actualLoaded)
+
+	want := estimated.SignatureCost + estimated.WriteLockCost + estimated.DataBytesCost + actualExec + actualLoaded
+	assert.Equal(t, want, tracker.BlockCost())
+	assert.Equal(t, want, tracker.WritableAccountCost(payer))
+	assert.Less(t, tracker.BlockCost(), estimated.Sum())
+}
+
+func TestCostTrackerRebateAllowsManySamePayerDefaultLoadedTxs(t *testing.T) {
+	tracker := NewCostTracker(DefaultLimits())
+	payer := txfixture.PayerPubkey()
+	estimated := TransactionCost{
+		SignatureCost:              SignatureCost,
+		WriteLockCost:              WriteLockUnits,
+		DataBytesCost:              7,
+		ProgramsExecutionCost:      450,
+		LoadedAccountsDataSizeCost: loadedAccountsDataSizeCost(sealevel.MaxLoadedAccountsDataSizeBytes),
+		WritableAccounts:           []solana.PublicKey{payer},
+	}
+	actualExec := uint64(150)
+	actualLoaded := loadedAccountsDataSizeCost(200)
+	actualSum := estimated.SignatureCost + estimated.WriteLockCost + estimated.DataBytesCost + actualExec + actualLoaded
+
+	const n = 2000
+	for i := 0; i < n; i++ {
+		require.Equal(t, ExceedNone, tracker.WouldExceed(estimated), "tx %d should fit after rebates", i+1)
+		tracker.Record(estimated)
+		tracker.Rebate(estimated, actualExec, actualLoaded)
+	}
+	assert.Equal(t, actualSum*n, tracker.BlockCost())
+	assert.Less(t, tracker.WritableAccountCost(payer), uint64(MaxWritableAccountUnits))
+}
+
 func TestCostTrackerAcceptsUnderLimits(t *testing.T) {
 	tracker := NewCostTracker(DefaultLimits())
 	tx := mustParseTransferTx(t, 1)

--- a/pkg/costmodel/costmodel_test.go
+++ b/pkg/costmodel/costmodel_test.go
@@ -144,6 +144,17 @@ func TestCostTrackerRebateAllowsManySamePayerDefaultLoadedTxs(t *testing.T) {
 	assert.Less(t, tracker.WritableAccountCost(payer), uint64(MaxWritableAccountUnits))
 }
 
+func TestPackEntryBytesMaxProtocolBindsAtDefaultShreds(t *testing.T) {
+	shredSafe := PackEntryBytesMax(DefaultMaxDataShredsPerSlot, EntryHeaderBytes+PacketDataSize)
+	require.Greater(t, shredSafe, uint64(DefaultMaxEntryBytesPerSlot))
+	require.Equal(t, uint64(DefaultMaxEntryBytesPerSlot-EntryHeaderBytes), DefaultPackEntryBytes())
+}
+
+func TestPackEntryBytesMaxRejectsMicroblockLargerThanWatermark(t *testing.T) {
+	wmark := uint64(FECSetsPerBatch)*uint64(TypicalFECSetPayloadBytes) - 8
+	assert.Zero(t, PackEntryBytesMax(DefaultMaxDataShredsPerSlot, wmark))
+}
+
 func TestCostTrackerAcceptsUnderLimits(t *testing.T) {
 	tracker := NewCostTracker(DefaultLimits())
 	tx := mustParseTransferTx(t, 1)

--- a/pkg/costmodel/entry_bytes.go
+++ b/pkg/costmodel/entry_bytes.go
@@ -1,0 +1,40 @@
+package costmodel
+
+// PackEntryBytesMax is the shred-safe entry-byte bound: we close a batch when
+// the next microblock would not fit in one FEC set, so padding is at most one
+// microblock. The slot cap is still min(this, SIMD-0525), decided at schedule
+// time like Firedancer pack.
+//
+// https://github.com/firedancer-io/firedancer/pull/10791
+func PackEntryBytesMax(slotMaxDataShreds, maxMicroblock uint64) uint64 {
+	c := uint64(TypicalFECSetPayloadBytes)
+	wmark := uint64(FECSetsPerBatch)*c - 8
+	if maxMicroblock >= wmark {
+		return 0
+	}
+	fecSets := slotMaxDataShreds / DataShredsPerFECSet
+	first := (8 + maxMicroblock + c - 1) / c
+	if first < 1 {
+		first = 1
+	}
+	const lastFEC = 2 // leftover plus resigned ending tick
+	if fecSets < first+lastFEC {
+		return 0
+	}
+	middle := fecSets - first - lastFEC
+	minBatch := wmark - maxMicroblock
+	return middle * minBatch
+}
+
+// DefaultPackEntryBytes is min(shred-safe, SIMD-0525) minus one ending tick.
+func DefaultPackEntryBytes() uint64 {
+	shredSafe := PackEntryBytesMax(DefaultMaxDataShredsPerSlot, EntryHeaderBytes+PacketDataSize)
+	cap := uint64(DefaultMaxEntryBytesPerSlot)
+	if shredSafe > 0 && shredSafe < cap {
+		cap = shredSafe
+	}
+	if cap > EntryHeaderBytes {
+		cap -= EntryHeaderBytes
+	}
+	return cap
+}

--- a/pkg/costmodel/limits.go
+++ b/pkg/costmodel/limits.go
@@ -4,12 +4,12 @@ package costmodel
 const (
 	ComputeUnitToUSRatio = 30
 
-	SignatureCost            = ComputeUnitToUSRatio * 24  // 720
+	SignatureCost            = ComputeUnitToUSRatio * 24 // 720
 	Secp256k1VerifyCost      = ComputeUnitToUSRatio * 223
 	Ed25519VerifyStrictCost  = ComputeUnitToUSRatio * 80
 	Secp256r1VerifyCost      = ComputeUnitToUSRatio * 160
-	WriteLockUnits           = ComputeUnitToUSRatio * 10 // 300
-	InstructionDataBytesCost = 140 / ComputeUnitToUSRatio  // ~4 CU per byte
+	WriteLockUnits           = ComputeUnitToUSRatio * 10  // 300
+	InstructionDataBytesCost = 140 / ComputeUnitToUSRatio // ~4 CU per byte
 
 	// Loaded-accounts data size is charged in 32KiB pages at the protocol heap cost (8 CU/page).
 	AccountDataCostPageSize = 32 * 1024
@@ -24,9 +24,25 @@ const (
 
 	// DefaultMaxDataShredsPerSlot matches agave DEFAULT_MAX_DATA_SHREDS_PER_SLOT.
 	DefaultMaxDataShredsPerSlot = 32 * 1024
-	// TypicalDataShredPayloadBytes is the usable data bytes per entry-batch target.
+	// SIMD-0525 max_entry_bytes_per_slot at the 400ms / 32,768-shred baseline.
+	DefaultMaxEntryBytesPerSlot = 20 * 1024 * 1024
+	PacketDataSize              = 1232
+	// EntryHeaderBytes is the Agave/Firedancer 48-byte entry header used for
+	// pack byte accounting and the reserved ending-tick.
+	EntryHeaderBytes = 48
+
+	// TypicalDataShredPayloadBytes is chained-merkle unsigned data capacity
+	// for one shred: 1203 - 88 - 32 - 6*20.
 	TypicalDataShredPayloadBytes = 963
-	DefaultTargetBatchBytes      = 2 * TypicalDataShredPayloadBytes
+	// DataShredsPerFECSet matches turbine's 32:32 erasure batch.
+	DataShredsPerFECSet = 32
+	// FECSetsPerBatch is the close watermark: hold until one FEC set is full.
+	FECSetsPerBatch = 1
+	// TypicalFECSetPayloadBytes is one full unsigned FEC set.
+	TypicalFECSetPayloadBytes = DataShredsPerFECSet * TypicalDataShredPayloadBytes
+	// DefaultTargetBatchBytes is one FEC set. A short leftover is only
+	// emitted at slot end (Freeze / ending tick).
+	DefaultTargetBatchBytes = FECSetsPerBatch * TypicalFECSetPayloadBytes
 )
 
 // Limits configures per-slot cost and size budgets.
@@ -35,6 +51,7 @@ type Limits struct {
 	WritableAccountCost    uint64
 	AllocatedDataSizeDelta uint64
 	MaxBatchBytes          uint64
+	MaxEntryBytes          uint64
 }
 
 func DefaultLimits() Limits {
@@ -43,5 +60,6 @@ func DefaultLimits() Limits {
 		WritableAccountCost:    MaxWritableAccountUnits,
 		AllocatedDataSizeDelta: MaxBlockAccountsDataSizeDelta,
 		MaxBatchBytes:          DefaultTargetBatchBytes,
+		MaxEntryBytes:          DefaultPackEntryBytes(),
 	}
 }

--- a/pkg/costmodel/limits.go
+++ b/pkg/costmodel/limits.go
@@ -11,6 +11,10 @@ const (
 	WriteLockUnits           = ComputeUnitToUSRatio * 10 // 300
 	InstructionDataBytesCost = 140 / ComputeUnitToUSRatio  // ~4 CU per byte
 
+	// Loaded-accounts data size is charged in 32KiB pages at the protocol heap cost (8 CU/page).
+	AccountDataCostPageSize = 32 * 1024
+	HeapCost                = 8
+
 	MaxBlockUnitsSIMD0256 = 60_000_000
 	MaxBlockUnitsSIMD0286 = 100_000_000
 

--- a/pkg/costmodel/tracker.go
+++ b/pkg/costmodel/tracker.go
@@ -89,3 +89,42 @@ func (t *CostTracker) Record(cost TransactionCost) {
 	}
 	t.allocatedDataSizeDelta += cost.AllocatedAccountsDataSize
 }
+
+// Rebate replaces reserved execution and loaded-accounts cost with the actual
+// usage. Signature, write-lock, and instruction-data costs are left as recorded.
+func (t *CostTracker) Rebate(estimated TransactionCost, actualExec, actualLoaded uint64) {
+	estimatedUsage := estimated.ProgramsExecutionCost + estimated.LoadedAccountsDataSizeCost
+	actualUsage := actualExec + actualLoaded
+	if actualUsage == estimatedUsage {
+		return
+	}
+	if actualUsage < estimatedUsage {
+		t.adjustUsage(estimated.WritableAccounts, estimatedUsage-actualUsage, false)
+		return
+	}
+	t.adjustUsage(estimated.WritableAccounts, actualUsage-estimatedUsage, true)
+}
+
+func (t *CostTracker) adjustUsage(writable []solana.PublicKey, delta uint64, add bool) {
+	if delta == 0 {
+		return
+	}
+	if add {
+		t.blockCost += delta
+		for _, pk := range writable {
+			t.perWritableAccountCost[pk] += delta
+		}
+		return
+	}
+	t.blockCost = satSub(t.blockCost, delta)
+	for _, pk := range writable {
+		t.perWritableAccountCost[pk] = satSub(t.perWritableAccountCost[pk], delta)
+	}
+}
+
+func satSub(v, delta uint64) uint64 {
+	if v < delta {
+		return 0
+	}
+	return v - delta
+}

--- a/pkg/costmodel/transaction_cost.go
+++ b/pkg/costmodel/transaction_cost.go
@@ -26,7 +26,7 @@ func (c TransactionCost) Sum() uint64 {
 		c.LoadedAccountsDataSizeCost
 }
 
-// EstimateTransactionCost approximates agave CostModel::calculate_cost for a parsed tx.
+// EstimateTransactionCost applies the protocol cost model to a parsed transaction.
 func EstimateTransactionCost(tx *solana.Transaction, feats *features.Features) (TransactionCost, error) {
 	if tx == nil {
 		return TransactionCost{}, nil
@@ -39,7 +39,7 @@ func EstimateTransactionCost(tx *solana.Transaction, feats *features.Features) (
 
 	limits, err := sealevel.ComputeBudgetExecuteInstructions(instrs, feats)
 	if err != nil {
-		// Agave treats compute-budget parse failure as zero execution cost (tx won't execute).
+		// A compute-budget parse failure yields zero execution cost; the transaction will not execute.
 		return TransactionCost{
 			SignatureCost: signatureCost(tx),
 			WriteLockCost: writeLockCost(countWriteLocks(tx)),
@@ -80,9 +80,8 @@ func instructionDataCost(tx *solana.Transaction) uint64 {
 }
 
 func loadedAccountsDataSizeCost(bytes uint32) uint64 {
-	const pageSize = 32 * 1024
-	pages := (uint64(bytes) + pageSize - 1) / pageSize
-	return pages * sealevel.DefaultInstructionComputeUnitLimit / 100 // coarse page cost
+	pages := (uint64(bytes) + AccountDataCostPageSize - 1) / AccountDataCostPageSize
+	return pages * HeapCost
 }
 
 func countWriteLocks(tx *solana.Transaction) uint64 {

--- a/pkg/costmodel/transaction_cost.go
+++ b/pkg/costmodel/transaction_cost.go
@@ -84,6 +84,11 @@ func loadedAccountsDataSizeCost(bytes uint32) uint64 {
 	return pages * HeapCost
 }
 
+// LoadedAccountsDataSizeCost is the protocol page charge for loaded account bytes.
+func LoadedAccountsDataSizeCost(bytes uint32) uint64 {
+	return loadedAccountsDataSizeCost(bytes)
+}
+
 func countWriteLocks(tx *solana.Transaction) uint64 {
 	return uint64(len(writableAccounts(tx)))
 }

--- a/pkg/fees/fees.go
+++ b/pkg/fees/fees.go
@@ -110,7 +110,7 @@ func CalculateTxFees(tx *solana.Transaction, instrs []sealevel.Instruction, comp
 }
 
 // TODO: implement new fee model
-func CalculateAndDeductTxFees(tx *solana.Transaction, txMeta *rpc.TransactionMeta, instrs []sealevel.Instruction, transactionAccts *sealevel.TransactionAccounts, computeBudgetLimits *sealevel.ComputeBudgetLimits, f *features.Features, isSimulation bool) (*TxFeeInfo, uint64, error) {
+func CalculateAndDeductTxFees(tx *solana.Transaction, txMeta *rpc.TransactionMeta, instrs []sealevel.Instruction, transactionAccts *sealevel.TransactionAccounts, computeBudgetLimits *sealevel.ComputeBudgetLimits, f *features.Features, rent sealevel.SysvarRent, isSimulation bool) (*TxFeeInfo, uint64, error) {
 	feePayerAcct, err := transactionAccts.GetAccount(feePayerIdx)
 	if err != nil {
 		if isSimulation {
@@ -152,8 +152,8 @@ func CalculateAndDeductTxFees(tx *solana.Transaction, txMeta *rpc.TransactionMet
 	totalTxFee := safemath.SaturatingAddU64(baseTxFee, priorityFee)
 	feeInfo := &TxFeeInfo{ExecutionFee: baseTxFee, PriorityFee: priorityFee, TotalFee: totalTxFee}
 
-	if feePayerAcct.Lamports < totalTxFee {
-		return feeInfo, 0, sealevel.InstrErrInsufficientFunds
+	if err := ValidateFeePayer(feePayerAcct, totalTxFee, rent); err != nil {
+		return feeInfo, 0, err
 	}
 	////mlog.Log.Debugf("feePayerAcct.Lamports=%d totalTxFee=%d", feePayerAcct.Lamports, totalTxFee)
 

--- a/pkg/fees/fees.go
+++ b/pkg/fees/fees.go
@@ -72,6 +72,16 @@ func (txFeeAccumulator *TxFeeInfoAccumulator) Add(txFeeInfo *TxFeeInfo) {
 	}
 }
 
+// LeaderReward is the lamports credited to the slot leader for a transaction:
+// full priority fee plus the unburned half of the signature (execution) fee.
+func LeaderReward(feeInfo *TxFeeInfo) uint64 {
+	if feeInfo == nil {
+		return 0
+	}
+	unburnedSigFee := feeInfo.ExecutionFee - feeInfo.ExecutionFee/2
+	return safemath.SaturatingAddU64(feeInfo.PriorityFee, unburnedSigFee)
+}
+
 func CalculateTxFees(tx *solana.Transaction, instrs []sealevel.Instruction, computeBudgetLimits *sealevel.ComputeBudgetLimits, f *features.Features) *TxFeeInfo {
 	numSignatures := uint64(tx.Message.Header.NumRequiredSignatures)
 	secp256r1PrecompiledEnabled := f.IsActive(features.EnableSecp256r1Precompile)

--- a/pkg/fees/fees_test.go
+++ b/pkg/fees/fees_test.go
@@ -30,6 +30,7 @@ func TestCalculateAndDeductTxFees_Simulation_ReturnsErrorWithoutPanic(t *testing
 			emptyTransactionAccounts(),
 			&sealevel.ComputeBudgetLimits{},
 			features.NewFeaturesDefault(),
+			sealevel.NewDefaultRentSysvar(),
 			true,
 		)
 		assert.Nil(t, fee)
@@ -44,6 +45,7 @@ func TestCalculateAndDeductTxFees_BlockReplay_PanicsOnMissingFeePayer(t *testing
 			emptyTransactionAccounts(),
 			&sealevel.ComputeBudgetLimits{},
 			features.NewFeaturesDefault(),
+			sealevel.NewDefaultRentSysvar(),
 			false,
 		)
 	})
@@ -64,6 +66,7 @@ func TestCalculateAndDeductTxFees_BlockReplay_PanicMessageContainsContext(t *tes
 		emptyTransactionAccounts(),
 		&sealevel.ComputeBudgetLimits{},
 		features.NewFeaturesDefault(),
+		sealevel.NewDefaultRentSysvar(),
 		false,
 	)
 }

--- a/pkg/fees/leader_reward_test.go
+++ b/pkg/fees/leader_reward_test.go
@@ -1,0 +1,42 @@
+package fees
+
+import "testing"
+
+func TestLeaderReward(t *testing.T) {
+	tests := []struct {
+		name string
+		info TxFeeInfo
+		want uint64
+	}{
+		{
+			name: "sig fee only",
+			info: TxFeeInfo{ExecutionFee: 5000, PriorityFee: 0, TotalFee: 5000},
+			want: 2500,
+		},
+		{
+			name: "odd sig fee rounds down burn half",
+			info: TxFeeInfo{ExecutionFee: 5001, PriorityFee: 0, TotalFee: 5001},
+			want: 2501, // 5001 - 5001/2
+		},
+		{
+			name: "priority plus unburned sig",
+			info: TxFeeInfo{ExecutionFee: 5000, PriorityFee: 12_000, TotalFee: 17_000},
+			want: 14_500,
+		},
+		{
+			name: "nil",
+			want: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var info *TxFeeInfo
+			if tt.name != "nil" {
+				info = &tt.info
+			}
+			if got := LeaderReward(info); got != tt.want {
+				t.Fatalf("LeaderReward() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/fees/payer.go
+++ b/pkg/fees/payer.go
@@ -1,0 +1,137 @@
+package fees
+
+import (
+	"errors"
+
+	"github.com/Overclock-Validator/mithril/pkg/accounts"
+	a "github.com/Overclock-Validator/mithril/pkg/addresses"
+	"github.com/Overclock-Validator/mithril/pkg/features"
+	"github.com/Overclock-Validator/mithril/pkg/sealevel"
+	"github.com/gagliardetto/solana-go"
+)
+
+// NonceStateSize is Agave's solana_nonce::state::State::size().
+const NonceStateSize = 80
+
+var (
+	ErrFeePayerNotFound         = errors.New("account not found")
+	ErrInvalidAccountForFee     = errors.New("invalid account for fee")
+	ErrInsufficientFundsForFee  = sealevel.InstrErrInsufficientFunds
+	ErrInsufficientFundsForRent = errors.New("insufficient funds for rent")
+)
+
+const (
+	systemAccountKindSystem = iota
+	systemAccountKindNonce
+)
+
+// RentForSlot returns the bank-local Rent sysvar, then the process cache,
+// then Agave's default (890880 lamports for a 0-byte account).
+func RentForSlot(slotCtx *sealevel.SlotCtx) sealevel.SysvarRent {
+	if slotCtx != nil {
+		if bankSysvars := slotCtx.BankSysvars(); bankSysvars != nil {
+			if rent, ok := bankSysvars.Rent(); ok {
+				return rent
+			}
+		}
+	}
+	if sealevel.SysvarCache.Rent.Sysvar != nil {
+		return *sealevel.SysvarCache.Rent.Sysvar
+	}
+	return sealevel.NewDefaultRentSysvar()
+}
+
+// ValidateFeePayer matches Agave svm::account_loader::validate_fee_payer
+// without mutating the account: the payer must exist, be a system or nonce
+// account, and cover the fee (plus the nonce rent reserve). A rent-exempt
+// system payer may be drained to zero, but must not be left with a
+// nonzero balance below the exemption minimum.
+func ValidateFeePayer(payer *accounts.Account, fee uint64, rent sealevel.SysvarRent) error {
+	if payer == nil || payer.Lamports == 0 {
+		return ErrFeePayerNotFound
+	}
+	kind, ok := systemAccountKind(payer)
+	if !ok {
+		return ErrInvalidAccountForFee
+	}
+	minBalance := uint64(0)
+	if kind == systemAccountKindNonce {
+		minBalance = rent.MinimumBalance(NonceStateSize)
+	}
+	if payer.Lamports < minBalance || payer.Lamports-minBalance < fee {
+		return ErrInsufficientFundsForFee
+	}
+	post := payer.Lamports - fee
+	if kind == systemAccountKindSystem && post != 0 && rent.IsExempt(payer.Lamports, 0) && !rent.IsExempt(post, 0) {
+		return ErrInsufficientFundsForRent
+	}
+	return nil
+}
+
+// PayerCanFund reports whether the current in-slot fee payer can pay this
+// transaction's fee and still satisfy ValidateFeePayer. It does not execute.
+func PayerCanFund(slotCtx *sealevel.SlotCtx, tx *solana.Transaction) error {
+	if tx == nil || len(tx.Message.AccountKeys) == 0 {
+		return ErrFeePayerNotFound
+	}
+	payer, err := loadPayer(slotCtx, tx.Message.AccountKeys[0])
+	if err != nil {
+		return ErrFeePayerNotFound
+	}
+	feats := features.NewFeaturesDefault()
+	if slotCtx != nil && slotCtx.Features != nil {
+		feats = slotCtx.Features
+	}
+	instrs, err := feeInstructions(tx)
+	if err != nil {
+		return err
+	}
+	limits, err := sealevel.ComputeBudgetExecuteInstructions(instrs, feats)
+	if err != nil {
+		return err
+	}
+	feeInfo := CalculateTxFees(tx, instrs, limits, feats)
+	return ValidateFeePayer(payer, feeInfo.TotalFee, RentForSlot(slotCtx))
+}
+
+func loadPayer(slotCtx *sealevel.SlotCtx, pk solana.PublicKey) (*accounts.Account, error) {
+	if slotCtx == nil {
+		return nil, ErrFeePayerNotFound
+	}
+	if acct, err := slotCtx.GetAccountShared(pk); err == nil && acct != nil {
+		return acct, nil
+	}
+	if slotCtx.UnrootedRead == nil && slotCtx.AccountsDb == nil {
+		return nil, ErrFeePayerNotFound
+	}
+	return slotCtx.GetAccountFromAccountsDb(pk)
+}
+
+func feeInstructions(tx *solana.Transaction) ([]sealevel.Instruction, error) {
+	out := make([]sealevel.Instruction, 0, len(tx.Message.Instructions))
+	for _, compiled := range tx.Message.Instructions {
+		programID, err := tx.ResolveProgramIDIndex(compiled.ProgramIDIndex)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, sealevel.Instruction{
+			ProgramId: programID,
+			Data:      compiled.Data,
+		})
+	}
+	return out, nil
+}
+
+func systemAccountKind(acct *accounts.Account) (int, bool) {
+	if acct.Owner != a.SystemProgramAddr {
+		return 0, false
+	}
+	if len(acct.Data) == 0 {
+		return systemAccountKindSystem, true
+	}
+	nonceState, err := sealevel.UnmarshalNonceStateVersions(acct.Data)
+	if err != nil || !nonceState.State().IsInitialized {
+		return 0, false
+	}
+	return systemAccountKindNonce, true
+}

--- a/pkg/fees/payer_test.go
+++ b/pkg/fees/payer_test.go
@@ -1,0 +1,92 @@
+package fees
+
+import (
+	"testing"
+
+	"github.com/Overclock-Validator/mithril/pkg/accounts"
+	"github.com/Overclock-Validator/mithril/pkg/addresses"
+	"github.com/Overclock-Validator/mithril/pkg/sealevel"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateFeePayer_SystemRentExemptRemainder(t *testing.T) {
+	rent := sealevel.NewDefaultRentSysvar()
+	rentMin := rent.MinimumBalance(0)
+	require.Equal(t, uint64(890880), rentMin)
+	const fee = uint64(5000)
+
+	systemPayer := func(lamports uint64) *accounts.Account {
+		return &accounts.Account{
+			Owner:    addresses.SystemProgramAddr,
+			Lamports: lamports,
+		}
+	}
+
+	assert.NoError(t, ValidateFeePayer(systemPayer(rentMin+fee), fee, rent))
+	assert.ErrorIs(t, ValidateFeePayer(systemPayer(rentMin+fee-1), fee, rent), ErrInsufficientFundsForRent)
+	assert.ErrorIs(t, ValidateFeePayer(systemPayer(fee-1), fee, rent), ErrInsufficientFundsForFee)
+	assert.ErrorIs(t, ValidateFeePayer(systemPayer(0), fee, rent), ErrFeePayerNotFound)
+	assert.ErrorIs(t, ValidateFeePayer(nil, fee, rent), ErrFeePayerNotFound)
+}
+
+func TestValidateFeePayer_RejectsNonSystemOwner(t *testing.T) {
+	rent := sealevel.NewDefaultRentSysvar()
+	err := ValidateFeePayer(&accounts.Account{
+		Owner:    addresses.VoteProgramAddr,
+		Lamports: 10_000_000,
+	}, 5000, rent)
+	assert.ErrorIs(t, err, ErrInvalidAccountForFee)
+}
+
+func TestValidateFeePayer_NonceKeepsNonceRent(t *testing.T) {
+	rent := sealevel.NewDefaultRentSysvar()
+	nonceMin := rent.MinimumBalance(NonceStateSize)
+	const fee = uint64(5000)
+
+	nonceState := sealevel.NonceStateVersions{
+		Type: sealevel.NonceVersionCurrent,
+		Current: sealevel.NonceData{
+			IsInitialized: true,
+		},
+	}
+	data, err := nonceState.Marshal()
+	require.NoError(t, err)
+	require.Equal(t, NonceStateSize, len(data))
+
+	payer := &accounts.Account{
+		Owner:    addresses.SystemProgramAddr,
+		Lamports: nonceMin + fee - 1,
+		Data:     data,
+	}
+	assert.ErrorIs(t, ValidateFeePayer(payer, fee, rent), ErrInsufficientFundsForFee)
+
+	payer.Lamports = nonceMin + fee
+	assert.NoError(t, ValidateFeePayer(payer, fee, rent))
+}
+
+func TestValidateFeePayer_RentPayingSystemMaySpendToZero(t *testing.T) {
+	rent := sealevel.NewDefaultRentSysvar()
+	const fee = uint64(5000)
+	// Already below the 0-byte rent-exempt minimum; Agave allows the fee
+	// as long as lamports >= fee (min_balance is 0 for system accounts).
+	assert.NoError(t, ValidateFeePayer(&accounts.Account{
+		Owner:    addresses.SystemProgramAddr,
+		Lamports: fee,
+	}, fee, rent))
+}
+
+func TestValidateFeePayer_RentExemptSystemMaySpendToZero(t *testing.T) {
+	rent := sealevel.NewDefaultRentSysvar()
+	rentMin := rent.MinimumBalance(0)
+	systemPayer := func(lamports uint64) *accounts.Account {
+		return &accounts.Account{
+			Owner:    addresses.SystemProgramAddr,
+			Lamports: lamports,
+		}
+	}
+
+	assert.NoError(t, ValidateFeePayer(systemPayer(rentMin), rentMin, rent))
+	assert.NoError(t, ValidateFeePayer(systemPayer(^uint64(0)), ^uint64(0), rent))
+	assert.ErrorIs(t, ValidateFeePayer(systemPayer(rentMin), rentMin-1, rent), ErrInsufficientFundsForRent)
+}

--- a/pkg/global/global_ctx.go
+++ b/pkg/global/global_ctx.go
@@ -381,6 +381,30 @@ func LeaderForSlot(slot uint64) (solana.PublicKey, bool) {
 	return solana.PublicKey{}, false
 }
 
+// NextSlotForLeader returns the earliest scheduled slot at or after from
+// for identity across installed epoch schedules.
+func NextSlotForLeader(identity solana.PublicKey, from uint64) (uint64, bool) {
+	instance.leaderScheduleMutex.RLock()
+	defer instance.leaderScheduleMutex.RUnlock()
+
+	if instance.leaderSchedule != nil {
+		return instance.leaderSchedule.NextSlotForLeader(identity, from)
+	}
+	var best uint64
+	found := false
+	for _, schedule := range instance.leaderSchedules {
+		slot, ok := schedule.NextSlotForLeader(identity, from)
+		if !ok {
+			continue
+		}
+		if !found || slot < best {
+			best = slot
+			found = true
+		}
+	}
+	return best, found
+}
+
 // LeaderForSlotWithVoteAccount returns the coherent node and vote-account pair
 // sampled for slot by a locally built vote-keyed schedule. Compatibility
 // schedules built from node-keyed RPC data return false.

--- a/pkg/global/leader_schedule_test.go
+++ b/pkg/global/leader_schedule_test.go
@@ -67,3 +67,26 @@ func TestEpochLeaderScheduleConcurrentReadsAndReplacement(t *testing.T) {
 		t.Fatalf("replacement lost the epoch schedule")
 	}
 }
+
+func TestNextSlotForLeaderAcrossEpochs(t *testing.T) {
+	SetLeaderSchedule(nil)
+	t.Cleanup(func() { SetLeaderSchedule(nil) })
+
+	ours := testLeader(7)
+	other := testLeader(8)
+	SetLeaderScheduleForEpoch(1, testLeaderSchedule(ours, 100))
+	SetLeaderScheduleForEpoch(2, leaderschedule.NewLeaderScheduleFromKeyedSlots(
+		map[solana.PublicKey][]uint64{ours: {0}, other: {1}},
+		200,
+	))
+
+	if slot, ok := NextSlotForLeader(ours, 100); !ok || slot != 100 {
+		t.Fatalf("got slot=%d ok=%t, want 100", slot, ok)
+	}
+	if slot, ok := NextSlotForLeader(ours, 102); !ok || slot != 200 {
+		t.Fatalf("got slot=%d ok=%t, want 200", slot, ok)
+	}
+	if _, ok := NextSlotForLeader(ours, 201); ok {
+		t.Fatalf("expected no later slot for ours")
+	}
+}

--- a/pkg/leaderschedule/leader_schedule.go
+++ b/pkg/leaderschedule/leader_schedule.go
@@ -337,6 +337,26 @@ func (ls *LeaderSchedule) LeaderForSlot(slot uint64) (solana.PublicKey, bool) {
 	return leader.nodePubkey, true
 }
 
+// NextSlotForLeader returns the earliest scheduled slot at or after from
+// whose node identity is identity.
+func (ls *LeaderSchedule) NextSlotForLeader(identity solana.PublicKey, from uint64) (uint64, bool) {
+	if ls == nil {
+		return 0, false
+	}
+	var best uint64
+	found := false
+	for slot, leader := range ls.lsMap {
+		if leader.nodePubkey != identity || slot < from {
+			continue
+		}
+		if !found || slot < best {
+			best = slot
+			found = true
+		}
+	}
+	return best, found
+}
+
 // LeaderForSlotWithVoteAccount returns the coherent node and vote-account pair
 // selected by the vote-keyed schedule. Schedules constructed from node-keyed
 // RPC data do not have the vote account and return false.

--- a/pkg/leaderschedule/leader_vote_account_test.go
+++ b/pkg/leaderschedule/leader_vote_account_test.go
@@ -71,3 +71,30 @@ func TestNodeKeyedScheduleHasNoVoteAccountProvenance(t *testing.T) {
 	_, _, ok = schedule.LeaderForSlotWithVoteAccount(101)
 	require.False(t, ok)
 }
+
+func TestNextSlotForLeader(t *testing.T) {
+	ours := solana.PublicKey{1}
+	other := solana.PublicKey{2}
+	schedule := NewLeaderScheduleFromKeyedSlots(
+		map[solana.PublicKey][]uint64{
+			ours:  {0, 1, 10},
+			other: {2, 3},
+		},
+		100,
+	)
+
+	slot, ok := schedule.NextSlotForLeader(ours, 100)
+	require.True(t, ok)
+	require.Equal(t, uint64(100), slot)
+
+	slot, ok = schedule.NextSlotForLeader(ours, 101)
+	require.True(t, ok)
+	require.Equal(t, uint64(101), slot)
+
+	slot, ok = schedule.NextSlotForLeader(ours, 102)
+	require.True(t, ok)
+	require.Equal(t, uint64(110), slot)
+
+	_, ok = schedule.NextSlotForLeader(ours, 111)
+	require.False(t, ok)
+}

--- a/pkg/replay/alpenglow_engine.go
+++ b/pkg/replay/alpenglow_engine.go
@@ -145,9 +145,9 @@ func applyAlpenglowFooterClock(slotCtx *sealevel.SlotCtx, block *b.Block, epochS
 
 // applyAlpenglowFooterClockLocal performs the same deterministic slot-state
 // update without publishing it globally. Block production freezes a candidate
-// before that candidate re-enters ordered replay; updating SysvarCache there
-// would make replay mistake the candidate's Clock for its parent Clock and omit
-// the Clock delta from AccountsLtHash.
+// before ordered adopt publishes the cache; updating SysvarCache at freeze
+// would make the next load mistake the candidate's Clock for its parent Clock
+// and omit the Clock delta from AccountsLtHash.
 func applyAlpenglowFooterClockLocal(slotCtx *sealevel.SlotCtx, block *b.Block, epochSchedule *sealevel.SysvarEpochSchedule) error {
 	return applyAlpenglowFooterClockWithCache(slotCtx, block, epochSchedule, false)
 }

--- a/pkg/replay/block.go
+++ b/pkg/replay/block.go
@@ -118,6 +118,17 @@ func GenerateRunID() string {
 	return hex.EncodeToString(b)
 }
 
+func identityFromTurbineKey(priv ed25519.PrivateKey) solana.PublicKey {
+	if len(priv) != ed25519.PrivateKeySize {
+		return solana.PublicKey{}
+	}
+	pub, ok := priv.Public().(ed25519.PublicKey)
+	if !ok {
+		return solana.PublicKey{}
+	}
+	return solana.PublicKeyFromBytes(pub)
+}
+
 // IsCommitInProgress returns true if we're in the critical commit window.
 // Used by panic recovery to determine if AccountsDB may be corrupted.
 func IsCommitInProgress() bool {
@@ -1668,6 +1679,7 @@ func ReplayBlocks(
 	}
 	// Fresh vote/stake dirty watermark for this run (gates the in-loop unwind).
 	resetVoteStakeDirty()
+	nextLeader := newNextLeaderCursor(identityFromTurbineKey(turbineIdentity))
 	// Create bankhash log file
 	bankhashLogPath := fmt.Sprintf("%s/bankhash.log", acctsDbPath)
 	bankhashLogFile, bankhashLogErr := os.OpenFile(bankhashLogPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
@@ -2713,7 +2725,7 @@ func ReplayBlocks(
 			// arrivals (leader sent something but the slot never became full).
 			// Full detail (wait) stays in logs.
 			partialShreds, repairedShreds, _, _ := blockStream.TurbineShredObservation(block.Slot)
-			mlog.Log.InfofPrecise("%s", buildSkippedStatsLine(block.Slot, leaderStr, partialShreds, repairedShreds))
+			mlog.Log.InfofPrecise("%s", appendNextLeaderHint(buildSkippedStatsLine(block.Slot, leaderStr, partialShreds, repairedShreds), nextLeader.hint(block.Slot)))
 			if partialShreds > 0 {
 				windowSkippedWithShreds++
 			}
@@ -3175,7 +3187,7 @@ func ReplayBlocks(
 			readySecsLine = float64(block.ShredFullNanos-neededAt.UnixNano()) / 1e9
 			asmSecsLine = float64(block.ShredFullNanos-block.ShredFirstNanos) / 1e9
 		}
-		mlog.Log.InfofPrecise("%s", buildSlotStatsLine(block.Slot, leaderStr, txnCount, totalCU, execMsLine, hasShreds, readySecsLine, asmSecsLine, block.RepairedShreds))
+		mlog.Log.InfofPrecise("%s", appendNextLeaderHint(buildSlotStatsLine(block.Slot, leaderStr, txnCount, totalCU, execMsLine, hasShreds, readySecsLine, asmSecsLine, block.RepairedShreds), nextLeader.hint(block.Slot)))
 		// Full detail (wait, vote split) stays in file logs for debugging.
 		var voteTxCount int
 		for _, tx := range block.Transactions {

--- a/pkg/replay/block.go
+++ b/pkg/replay/block.go
@@ -83,8 +83,8 @@ type BlockFetchOpts struct {
 	// ShredSpoolDir: on-disk verified-shred spool shared by prewarm and the
 	// block source (empty = disabled).
 	ShredSpoolDir string
-	// LocalBlocks carries fully frozen blocks produced by this validator. They
-	// enter the normal ordered block source and are re-executed by ProcessBlock.
+	// LocalBlocks carries fully frozen blocks produced by this validator. Replay
+	// adopts the already-mutated leader SlotCtx and does not re-execute.
 	LocalBlocks          <-chan *b.Block
 	LocalLeaderForSlot   func(slot uint64) bool
 	GossipClient         *gossip.Client
@@ -2916,7 +2916,11 @@ func ReplayBlocks(
 		if lastSlotCtx != nil {
 			parentBankSysvars = lastSlotCtx.BankSysvars()
 		}
-		lastSlotCtx, err = ProcessBlock(acctsDb, block, epochSchedule, txParallelism, dbgOpts, persistedHashes, unrootedTailState, transactionStatuses, alpenglowClock, parentBankSysvars)
+		if block.FromLocalProduction {
+			lastSlotCtx, err = adoptLocalLeaderBlock(block, unrootedTailState, transactionStatuses, persistedHashes)
+		} else {
+			lastSlotCtx, err = ProcessBlock(acctsDb, block, epochSchedule, txParallelism, dbgOpts, persistedHashes, unrootedTailState, transactionStatuses, alpenglowClock, parentBankSysvars)
+		}
 		processBlockEnd := time.Now()
 		metrics.GlobalBlockReplay.ProcessBlock.AddTiming(processBlockEnd.Sub(processBlockStart))
 		if err != nil {

--- a/pkg/replay/chain_state.go
+++ b/pkg/replay/chain_state.go
@@ -128,6 +128,7 @@ func InitChainTip(acctsLtHash *lthash.LtHash, f *features.Features, prevNumSigs 
 // ResetChainTip invalidates producer parent state while replay is rewinding or
 // restarting. The next successfully replayed block installs a fresh snapshot.
 func ResetChainTip() {
+	ResetLocalLeaderCommits()
 	InitChainTip(nil, nil, 0, solana.Hash{})
 }
 

--- a/pkg/replay/leader_finalize.go
+++ b/pkg/replay/leader_finalize.go
@@ -15,9 +15,10 @@ import (
 )
 
 // CommitLeaderInput contains the state required to freeze a locally forged bank.
-// Despite the historical name, CommitLeaderSlot is deliberately in-memory only:
-// the resulting block must still pass through ProcessBlock and the fork-aware
-// WorkingSet before any state can become durable.
+// CommitLeaderSlot is in-memory only: it mutates the producer SlotCtx and
+// computes the footer bank hash. Replay adopts that SlotCtx; it does not
+// re-execute the block. Durable promotion still goes through the fork-aware
+// WorkingSet after the slot is observed.
 type CommitLeaderInput struct {
 	AcctsDb                 *accountsdb.AccountsDb
 	SlotCtx                 *sealevel.SlotCtx
@@ -91,6 +92,7 @@ func PrepareLeaderSlotSysvars(slotCtx *sealevel.SlotCtx, block *b.Block, alpengl
 
 // CommitLeaderSlot freezes a forged bank and computes the footer bank hash. It
 // does not write AccountsDB, update global replay progress, or bypass forkchoice.
+// Replay later adopts the returned SlotCtx instead of running ProcessBlock.
 func CommitLeaderSlot(in CommitLeaderInput) (*sealevel.SlotCtx, error) {
 	if in.AcctsDb == nil || in.SlotCtx == nil || in.Block == nil {
 		return nil, fmt.Errorf("missing leader finalization input")
@@ -122,10 +124,10 @@ func CommitLeaderSlot(in CommitLeaderInput) (*sealevel.SlotCtx, error) {
 		if err := validateAlpenglowFooterNanosecondClock(slotCtx, block); err != nil {
 			return nil, err
 		}
-		// This is a speculative producer bank until the forged block passes
-		// through ordered replay. Keep its Clock slot-local: publishing it to the
+		// This is a speculative producer bank until the forged block is adopted
+		// in slot order. Keep its Clock slot-local: publishing it to the
 		// global replay cache here would replace the true parent Clock before
-		// ProcessBlock loads the block and would produce a different LtHash.
+		// the next network block loads and would produce a different LtHash.
 		if err := applyAlpenglowFooterClockLocal(slotCtx, block, epochSchedule); err != nil {
 			return nil, err
 		}

--- a/pkg/replay/local_leader.go
+++ b/pkg/replay/local_leader.go
@@ -1,0 +1,121 @@
+package replay
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/Overclock-Validator/mithril/pkg/accounts"
+	b "github.com/Overclock-Validator/mithril/pkg/block"
+	"github.com/Overclock-Validator/mithril/pkg/global"
+	"github.com/Overclock-Validator/mithril/pkg/sealevel"
+	"github.com/gagliardetto/solana-go"
+)
+
+// LocalLeaderCommit is the already-mutated producer bank for a slot this
+// validator forged. Replay adopts it instead of running ProcessBlock.
+type LocalLeaderCommit struct {
+	SlotCtx *sealevel.SlotCtx
+}
+
+var (
+	localLeaderMu      sync.Mutex
+	localLeaderCommits = map[uint64]LocalLeaderCommit{}
+)
+
+// RegisterLocalLeaderCommit publishes a frozen producer SlotCtx for ordered adopt.
+func RegisterLocalLeaderCommit(slotCtx *sealevel.SlotCtx) {
+	if slotCtx == nil {
+		return
+	}
+	localLeaderMu.Lock()
+	localLeaderCommits[slotCtx.Slot] = LocalLeaderCommit{SlotCtx: slotCtx}
+	localLeaderMu.Unlock()
+}
+
+// TakeLocalLeaderCommit removes and returns the registered commit for slot.
+func TakeLocalLeaderCommit(slot uint64) (LocalLeaderCommit, bool) {
+	localLeaderMu.Lock()
+	defer localLeaderMu.Unlock()
+	commit, ok := localLeaderCommits[slot]
+	if ok {
+		delete(localLeaderCommits, slot)
+	}
+	return commit, ok
+}
+
+// ResetLocalLeaderCommits drops unpublished producer banks (rewind / restart).
+func ResetLocalLeaderCommits() {
+	localLeaderMu.Lock()
+	localLeaderCommits = map[uint64]LocalLeaderCommit{}
+	localLeaderMu.Unlock()
+}
+
+// adoptLocalLeaderBlock installs a locally forged SlotCtx as the replay tip.
+// It does not re-execute transactions, verify signatures, or publish into the
+// process-global sysvar cache. The next ProcessBlock reads parent sysvars from
+// lastSlotCtx.BankSysvars().
+func adoptLocalLeaderBlock(
+	block *b.Block,
+	tail unrootedState,
+	transactionStatuses *TransactionStatusCache,
+	persistedHashes *persistedTracker,
+) (*sealevel.SlotCtx, error) {
+	if block == nil {
+		return nil, fmt.Errorf("adopt local leader block: nil block")
+	}
+	commit, ok := TakeLocalLeaderCommit(block.Slot)
+	if !ok || commit.SlotCtx == nil {
+		return nil, fmt.Errorf("adopt local leader block: missing producer SlotCtx for slot %d", block.Slot)
+	}
+	slotCtx := commit.SlotCtx
+	if slotCtx.BankSysvars() == nil {
+		return nil, fmt.Errorf("adopt local leader block: missing bank sysvars for slot %d", block.Slot)
+	}
+	modified := collectAdoptAccounts(slotCtx, block)
+	bankhash := append([]byte(nil), slotCtx.FinalBankhash...)
+	if tail != nil {
+		tail.Add(slotCtx.Slot, modified, bankhash)
+	}
+	if persistedHashes != nil {
+		persistedHashes.Set(block.Slot, bankhash)
+	}
+	if err := transactionStatuses.CommitBlock(block); err != nil {
+		return nil, fmt.Errorf("adopt local leader block slot %d: %w", block.Slot, err)
+	}
+	global.IncrTransactionCount(uint64(len(block.Transactions)))
+	return slotCtx, nil
+}
+
+func collectAdoptAccounts(slotCtx *sealevel.SlotCtx, block *b.Block) []*accounts.Account {
+	seen := make(map[solana.PublicKey]struct{}, len(slotCtx.ModifiedAccts)+8)
+	out := make([]*accounts.Account, 0, len(slotCtx.ModifiedAccts)+8)
+	add := func(acct *accounts.Account) {
+		if acct == nil {
+			return
+		}
+		if _, ok := seen[acct.Key]; ok {
+			return
+		}
+		seen[acct.Key] = struct{}{}
+		out = append(out, acct)
+	}
+	for key := range slotCtx.ModifiedAccts {
+		acct, err := slotCtx.GetAccount(key)
+		if err == nil {
+			add(acct)
+		}
+	}
+	if block != nil {
+		for _, acct := range block.EpochUpdatedAccts {
+			if acct == nil {
+				continue
+			}
+			current, err := slotCtx.GetAccount(acct.Key)
+			if err != nil {
+				current = acct
+			}
+			add(current)
+		}
+	}
+	return out
+}

--- a/pkg/replay/local_leader_test.go
+++ b/pkg/replay/local_leader_test.go
@@ -1,0 +1,82 @@
+package replay
+
+import (
+	"testing"
+
+	"github.com/Overclock-Validator/mithril/pkg/accounts"
+	b "github.com/Overclock-Validator/mithril/pkg/block"
+	"github.com/Overclock-Validator/mithril/pkg/sealevel"
+	"github.com/gagliardetto/solana-go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRegisterTakeLocalLeaderCommit(t *testing.T) {
+	t.Cleanup(ResetLocalLeaderCommits)
+	slotCtx := &sealevel.SlotCtx{Slot: 7, FinalBankhash: []byte{1, 2, 3}}
+	RegisterLocalLeaderCommit(slotCtx)
+
+	got, ok := TakeLocalLeaderCommit(7)
+	require.True(t, ok)
+	require.Same(t, slotCtx, got.SlotCtx)
+
+	_, ok = TakeLocalLeaderCommit(7)
+	require.False(t, ok)
+}
+
+func TestResetChainTipDropsLocalLeaderCommits(t *testing.T) {
+	t.Cleanup(ResetChainTip)
+	RegisterLocalLeaderCommit(&sealevel.SlotCtx{Slot: 9})
+	ResetChainTip()
+	_, ok := TakeLocalLeaderCommit(9)
+	require.False(t, ok)
+}
+
+func TestAdoptLocalLeaderBlockUsesProducerSlotCtx(t *testing.T) {
+	t.Cleanup(ResetLocalLeaderCommits)
+
+	key := solana.PublicKey{0x11}
+	acct := &accounts.Account{Key: key, Lamports: 42, Data: []byte{9}}
+	slotCtx := &sealevel.SlotCtx{
+		Slot:          20,
+		Accounts:      accounts.NewMemAccounts(),
+		ModifiedAccts: map[solana.PublicKey]bool{key: true},
+		FinalBankhash: append([]byte{8}, make([]byte, 31)...),
+	}
+	require.NoError(t, slotCtx.SetAccount(key, acct))
+	bankSysvars, err := sealevel.NewBankSysvars(20, &accounts.Account{
+		Key:      sealevel.SysvarClockAddr,
+		Lamports: 1,
+		Data:     (&sealevel.SysvarClock{Slot: 20}).MustMarshal(),
+	})
+	require.NoError(t, err)
+	require.NoError(t, slotCtx.PublishBankSysvars(bankSysvars))
+	RegisterLocalLeaderCommit(slotCtx)
+
+	block := &b.Block{Slot: 20, ParentSlot: 19, FromLocalProduction: true}
+	persisted := &persistedTracker{}
+	got, err := adoptLocalLeaderBlock(block, nil, NewTransactionStatusCache(), persisted)
+	require.NoError(t, err)
+	require.Same(t, slotCtx, got)
+
+	slot, hash := persisted.Get()
+	require.Equal(t, uint64(20), slot)
+	require.Equal(t, slotCtx.FinalBankhash, hash)
+
+	_, ok := TakeLocalLeaderCommit(20)
+	require.False(t, ok, "adopt must consume the registered SlotCtx")
+}
+
+func TestAdoptLocalLeaderBlockFailsClosedWithoutCommit(t *testing.T) {
+	t.Cleanup(ResetLocalLeaderCommits)
+	_, err := adoptLocalLeaderBlock(&b.Block{Slot: 3, FromLocalProduction: true}, nil, NewTransactionStatusCache(), nil)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "missing producer SlotCtx")
+}
+
+func TestAdoptLocalLeaderBlockFailsClosedWithoutBankSysvars(t *testing.T) {
+	t.Cleanup(ResetLocalLeaderCommits)
+	RegisterLocalLeaderCommit(&sealevel.SlotCtx{Slot: 4})
+	_, err := adoptLocalLeaderBlock(&b.Block{Slot: 4, FromLocalProduction: true}, nil, NewTransactionStatusCache(), nil)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "missing bank sysvars")
+}

--- a/pkg/replay/simulate_fixtures_test.go
+++ b/pkg/replay/simulate_fixtures_test.go
@@ -42,7 +42,7 @@ const (
 	fixtureOOBProgram = "AT2SwP5wteXeZK5dcicARe9tPzofzhoUDRBgMS+By+o8CwEidmOMyFLPlqDk1AY8PP0dk5u9zkBCCAhiRXRfVQIBAAABm5dS3l4ndvoMPGwAgbDa2etV4ba8GhFmzEEoWLnQUzIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFjAAA="
 
 	// Tx with no instructions. Should pass sanitize and proceed to
-	// fee-payer balance check; payer has 0 SOL → InsufficientFundsForFee.
+	// fee-payer balance check; payer has 0 SOL → AccountNotFound
 	fixtureNoInstructions = "AUoD9kRSzxiTCsWNc0tek1JI5Capj2LNsTI0MTUTYwuF15j7urkfyWvnyPQ87UHzaMHkChQ3TA7CBhuNwmojVgUBAAABm5dS3l4ndvoMPGwAgbDa2etV4ba8GhFmzEEoWLnQUzIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 
 	// Self-transfer: fee payer also receives.
@@ -153,7 +153,7 @@ func TestSimulateFixture_OOBProgram(t *testing.T) {
 func TestSimulateFixture_NoInstructions(t *testing.T) {
 	out := runSimulateFixture(t, fixtureNoInstructions)
 	require.NotNil(t, out.ProcessingResult.TransactionError)
-	assert.Equal(t, TransactionErrorInsufficientFundsForFee, out.ProcessingResult.TransactionError.ErrorType)
+	assert.Equal(t, TransactionErrorAccountNotFound, out.ProcessingResult.TransactionError.ErrorType)
 }
 
 // Same caveat as MissingAccount: with no AccountsDb the System Program

--- a/pkg/replay/summary_stats.go
+++ b/pkg/replay/summary_stats.go
@@ -2,10 +2,14 @@ package replay
 
 import (
 	"fmt"
+	"math"
 	"os"
 	"sort"
 	"strconv"
 	"strings"
+
+	"github.com/Overclock-Validator/mithril/pkg/global"
+	"github.com/gagliardetto/solana-go"
 )
 
 // Terminal replay stats for the Alpenglow/native-shred path. Terminology
@@ -97,6 +101,70 @@ const (
 	dashExec = "  --  "
 	dashEff  = "   --      "
 )
+
+// nextLeaderCursor caches the next scheduled slot for this node's identity
+// so the per-slot line can show a countdown without rescanning every slot.
+type nextLeaderCursor struct {
+	identity solana.PublicKey
+	next     uint64
+	ok       bool
+	lookup   func(solana.PublicKey, uint64) (uint64, bool)
+}
+
+func newNextLeaderCursor(identity solana.PublicKey) *nextLeaderCursor {
+	if identity.IsZero() {
+		return nil
+	}
+	return &nextLeaderCursor{identity: identity}
+}
+
+func (c *nextLeaderCursor) hint(slot uint64) string {
+	if c == nil || c.identity.IsZero() {
+		return ""
+	}
+	lookup := c.lookup
+	if lookup == nil {
+		lookup = global.NextSlotForLeader
+	}
+	if !c.ok || slot > c.next {
+		c.next, c.ok = lookup(c.identity, slot)
+	}
+	if !c.ok {
+		return ""
+	}
+	if slot == c.next {
+		return "ours"
+	}
+	if slot < c.next {
+		return fmt.Sprintf("next %d ~%s", c.next, formatSlotETA(c.next-slot))
+	}
+	return ""
+}
+
+func appendNextLeaderHint(line, hint string) string {
+	if hint == "" {
+		return line
+	}
+	return line + " | " + hint
+}
+
+// formatSlotETA renders remaining Alpenglow slots (200ms) as a short timer.
+func formatSlotETA(slots uint64) string {
+	ms := slots * 200
+	switch {
+	case ms < 1000:
+		return fmt.Sprintf("%dms", ms)
+	case ms < 60_000:
+		sec := float64(ms) / 1000
+		if sec < 10 {
+			return fmt.Sprintf("%.1fs", sec)
+		}
+		return fmt.Sprintf("%.0fs", math.Round(sec))
+	default:
+		totalSec := (ms + 500) / 1000
+		return fmt.Sprintf("%dm%02ds", totalSec/60, totalSec%60)
+	}
+}
 
 // buildSlotStatsLine renders the per-slot terminal line. The shreds segment is
 // omitted for blocks that did not come from shreds (never fabricated). Value

--- a/pkg/replay/summary_stats_test.go
+++ b/pkg/replay/summary_stats_test.go
@@ -3,6 +3,7 @@ package replay
 import (
 	"testing"
 
+	"github.com/gagliardetto/solana-go"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -21,6 +22,38 @@ func TestPercentileHelpers(t *testing.T) {
 	// Empty inputs are zeros, never a panic.
 	assert.Equal(t, 0.0, medianF(nil))
 	assert.Equal(t, 0.0, maxF(nil))
+}
+
+func TestFormatSlotETA(t *testing.T) {
+	assert.Equal(t, "200ms", formatSlotETA(1))
+	assert.Equal(t, "1.0s", formatSlotETA(5))
+	assert.Equal(t, "23s", formatSlotETA(117))
+	assert.Equal(t, "1m00s", formatSlotETA(300))
+	assert.Equal(t, "1m30s", formatSlotETA(450))
+}
+
+func TestNextLeaderHint(t *testing.T) {
+	var identity solana.PublicKey
+	identity[0] = 7
+	lookup := func(_ solana.PublicKey, from uint64) (uint64, bool) {
+		if from <= 110 {
+			return 110, true
+		}
+		if from <= 200 {
+			return 200, true
+		}
+		return 0, false
+	}
+	c := &nextLeaderCursor{identity: identity, lookup: lookup}
+
+	assert.Equal(t, "next 110 ~1.0s", c.hint(105))
+	assert.Equal(t, "ours", c.hint(110))
+	assert.Equal(t, "next 200 ~18s", c.hint(111))
+	assert.Equal(t, "", c.hint(201))
+	assert.Equal(t, "", newNextLeaderCursor(solana.PublicKey{}).hint(1))
+	assert.Equal(t,
+		"slot 1 | leader abcd...xyz | ours",
+		appendNextLeaderHint("slot 1 | leader abcd...xyz", "ours"))
 }
 
 func TestFormatHelpers(t *testing.T) {

--- a/pkg/replay/transaction_processing_pure.go
+++ b/pkg/replay/transaction_processing_pure.go
@@ -1,6 +1,7 @@
 package replay
 
 import (
+	"errors"
 	"math"
 	"time"
 
@@ -226,15 +227,29 @@ func LoadAndExecuteTransaction(input LoadAndExecuteTransactionInput) LoadAndExec
 		}
 	}
 
-	// Calculate and deduct fees
+	// Calculate and deduct fees. RentForSlot supplies the exemption
+	// minimum so a rent-exempt payer is rejected before instructions run.
 	start = time.Now()
-	txFeeInfo, _, err := fees.CalculateAndDeductTxFees(tx, input.TxMeta, instrs, &execCtx.TransactionContext.Accounts, computeBudgetLimits, slotCtx.Features, input.IsSimulation)
+	txFeeInfo, _, err := fees.CalculateAndDeductTxFees(tx, input.TxMeta, instrs, &execCtx.TransactionContext.Accounts, computeBudgetLimits, slotCtx.Features, fees.RentForSlot(slotCtx), input.IsSimulation)
 	if err != nil {
+		errType := TransactionErrorInsufficientFundsForFee
+		var accountIndex *uint8
+		switch {
+		case errors.Is(err, fees.ErrFeePayerNotFound):
+			errType = TransactionErrorAccountNotFound
+		case errors.Is(err, fees.ErrInvalidAccountForFee):
+			errType = TransactionErrorInvalidAccountForFee
+		case errors.Is(err, fees.ErrInsufficientFundsForRent):
+			errType = TransactionErrorInsufficientFundsForRent
+			zero := uint8(0)
+			accountIndex = &zero
+		}
 		out := LoadAndExecuteTransactionOutput{
 			ProcessingResult: TransactionProcessingResult{
 				TransactionError: &TransactionError{
-					ErrorType:        TransactionErrorInsufficientFundsForFee,
+					ErrorType:        errType,
 					InstructionError: err,
+					AccountIndex:     accountIndex,
 				},
 			},
 			ExecCtx:             execCtx,


### PR DESCRIPTION
_**1. Naive greedy TPU scheduler instead of immediate-or-drop**_ (main feature)

other improvements:
2. Replay adopts locally produced leader banks (no re-execute of our own slots)
3. Loaded-accounts cost is 32 KiB pages at 8 CU/page, not the old incorrect value (block production estimate)
4. Scheduler heap cleanup every capacity/5 inserts, not before every pop
5. Slot stats show next-leader-window countdown (ours / next N ~eta)
6. Rebate unused execution CU and loaded-accounts CU after successful forge
7. Shred/broadcast entry batches on a dedicated thread
8. Hold entries until one FEC set is full; leftover flushes at slot end
9. Reserve slot entry bytes at schedule time; rebate if the tx is not included
10. fix fee payer check