### PR TITLE
rpc: add getGenesisHash

### DIFF
--- a/cmd/mithril/node/node.go
+++ b/cmd/mithril/node/node.go
@@ -2516,7 +2516,7 @@ postBootstrap:
 	if rpcPort < 0 || rpcPort > 65535 {
 		klog.Fatalf("invalid port: %d", rpcPort)
 	} else if rpcPort != 0 {
-		rpcServer = rpcserver.NewRpcServer(accountsDb, uint16(rpcPort), epochScheduleFromState(mithrilState))
+		rpcServer = rpcserver.NewRpcServer(accountsDb, uint16(rpcPort), epochScheduleFromState(mithrilState), solana.MustHashFromBase58(networkGenesisHash))
 		rpcServer.Start()
 		mlog.Log.Infof("Started RPC server on port %d", rpcPort)
 	}

--- a/go.mod
+++ b/go.mod
@@ -118,7 +118,7 @@ require (
 	github.com/dgryski/go-sip13 v0.0.0-20200911182023-62edffca9245
 	github.com/ethereum/go-ethereum v1.15.12-0.20250620111820-f26b5653e8bf
 	github.com/fatih/color v1.18.0 // indirect
-	github.com/filecoin-project/go-jsonrpc v0.8.0
+	github.com/filecoin-project/go-jsonrpc v0.10.2
 	github.com/gagliardetto/treeout v0.1.4 // indirect
 	github.com/gammazero/deque v1.0.0
 	github.com/go-logr/logr v1.4.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -99,8 +99,8 @@ github.com/ethereum/go-ethereum v1.15.12-0.20250620111820-f26b5653e8bf h1:JcGe2d
 github.com/ethereum/go-ethereum v1.15.12-0.20250620111820-f26b5653e8bf/go.mod h1:ngYIvmMAYdo4sGW9cGzLvSsPGhDOOzL0jK5S5iXpj0g=
 github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
 github.com/fatih/color v1.18.0/go.mod h1:4FelSpRwEGDpQ12mAdzqdOukCy4u8WUtOY6lkT/6HfU=
-github.com/filecoin-project/go-jsonrpc v0.8.0 h1:2yqlN3Vd8Gx5UtA3fib7tQu2aW1cSOJt253LEBWExo4=
-github.com/filecoin-project/go-jsonrpc v0.8.0/go.mod h1:p8WGOwQGYbFugSdK7qKIGhhb1VVcQ2rtBLdEiik1QWI=
+github.com/filecoin-project/go-jsonrpc v0.10.2 h1:Lk1IE43n1KUuOanvD5Pl2t3zX+3B6Ed4kaP0KSWn68k=
+github.com/filecoin-project/go-jsonrpc v0.10.2/go.mod h1:U4dFi7TqMb1t5Fp5sTfiF1rX+cPrK/C/q4twXYNxyss=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=

--- a/pkg/rpcserver/get_genesis_hash.go
+++ b/pkg/rpcserver/get_genesis_hash.go
@@ -1,0 +1,26 @@
+package rpcserver
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+
+	"github.com/filecoin-project/go-jsonrpc"
+)
+
+// GetGenesisHash returns the cluster identity established at startup.
+func (rpcServer *RpcServer) GetGenesisHash(ctx context.Context, p jsonrpc.RawParams) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	if len(p) != 0 {
+		params, err := jsonrpc.DecodeParams[[]json.RawMessage](p)
+		if err != nil || len(params) != 0 {
+			return "", &InvalidParamsError{Message: "getGenesisHash does not accept parameters"}
+		}
+	}
+	if rpcServer.genesisHash == "" {
+		return "", errors.New("genesis hash is not configured")
+	}
+	return rpcServer.genesisHash, nil
+}

--- a/pkg/rpcserver/get_genesis_hash_test.go
+++ b/pkg/rpcserver/get_genesis_hash_test.go
@@ -1,0 +1,92 @@
+package rpcserver
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Overclock-Validator/mithril/pkg/sealevel"
+	"github.com/filecoin-project/go-jsonrpc"
+	"github.com/gagliardetto/solana-go"
+	solanarpc "github.com/gagliardetto/solana-go/rpc"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetGenesisHashHTTP(t *testing.T) {
+	for _, cluster := range []string{"cluster-a", "cluster-b"} {
+		t.Run(cluster, func(t *testing.T) {
+			hash := solana.Hash(sha256.Sum256([]byte(cluster)))
+			server := NewRpcServer(nil, 0, &sealevel.SysvarEpochSchedule{}, hash)
+			// Serve on httptest's loopback listener without starting cluster discovery.
+			require.NoError(t, server.listener.Close())
+			endpoint := httptest.NewServer(server)
+			t.Cleanup(endpoint.Close)
+
+			got, err := solanarpc.New(endpoint.URL).GetGenesisHash(t.Context())
+			require.NoError(t, err)
+			require.Equal(t, hash, got)
+
+			for _, test := range []struct {
+				name, params string
+				invalid      bool
+			}{
+				{name: "omitted"},
+				{name: "empty", params: `,"params":[]`},
+				{name: "null", params: `,"params":null`},
+				{name: "argument", params: `,"params":[true]`, invalid: true},
+				{name: "object", params: `,"params":{}`, invalid: true},
+				{name: "scalar", params: `,"params":1`, invalid: true},
+			} {
+				t.Run(test.name, func(t *testing.T) {
+					request := fmt.Sprintf(`{"jsonrpc":"2.0","id":7,"method":"getGenesisHash"%s}`, test.params)
+					response, err := endpoint.Client().Post(endpoint.URL, "application/json", strings.NewReader(request))
+					require.NoError(t, err)
+					defer response.Body.Close()
+					var result struct {
+						JSONRPC string                `json:"jsonrpc"`
+						ID      int                   `json:"id"`
+						Result  string                `json:"result"`
+						Error   *jsonrpc.JSONRPCError `json:"error"`
+					}
+					require.NoError(t, json.NewDecoder(response.Body).Decode(&result))
+					require.Equal(t, "2.0", result.JSONRPC)
+					require.Equal(t, 7, result.ID)
+					if test.invalid {
+						require.NotNil(t, result.Error)
+						require.EqualValues(t, -32602, result.Error.Code)
+						require.Empty(t, result.Result)
+					} else {
+						require.Equal(t, http.StatusOK, response.StatusCode)
+						require.Nil(t, result.Error)
+						require.Equal(t, hash.String(), result.Result)
+					}
+				})
+			}
+
+			request := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`[{"jsonrpc":"2.0","id":1,"method":"getGenesisHash"},{"jsonrpc":"2.0","id":2,"method":"getGenesisHash","params":[]}]`))
+			response := httptest.NewRecorder()
+			server.ServeHTTP(response, request)
+			require.Equal(t, http.StatusOK, response.Code)
+			require.JSONEq(t, fmt.Sprintf(`[{"jsonrpc":"2.0","id":1,"result":%q},{"jsonrpc":"2.0","id":2,"result":%q}]`, hash.String(), hash.String()), response.Body.String())
+		})
+	}
+}
+
+func TestGetGenesisHashUnavailableAndCanceled(t *testing.T) {
+	server := &RpcServer{}
+	got, err := server.GetGenesisHash(t.Context(), nil)
+	require.Error(t, err)
+	require.Empty(t, got)
+
+	server.genesisHash = solana.Hash{1}.String()
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	got, err = server.GetGenesisHash(ctx, nil)
+	require.ErrorIs(t, err, context.Canceled)
+	require.Empty(t, got)
+}

--- a/pkg/rpcserver/rpcserver.go
+++ b/pkg/rpcserver/rpcserver.go
@@ -30,6 +30,7 @@ type RpcServer struct {
 	epochSchedule *sealevel.SysvarEpochSchedule
 	slotCtx       *sealevel.SlotCtx
 	slotCtxMu     sync.RWMutex
+	genesisHash   string
 
 	leaderTPUCacheMu         sync.RWMutex
 	leaderTPUByIdentity      map[solana.PublicKey]tpuEndpoint
@@ -51,14 +52,15 @@ var supportedRPCMethods = map[string]struct{}{
 	"getBankHash":         {},
 	"getBlockHeight":      {},
 	"getEpochInfo":        {},
+	"getGenesisHash":      {},
 	"getLatestBlockhash":  {},
 	"sendTransaction":     {},
 	"simulateTransaction": {},
 }
 
-func NewRpcServer(acctsDb *accountsdb.AccountsDb, port uint16, epochSchedule *sealevel.SysvarEpochSchedule) *RpcServer {
+func NewRpcServer(acctsDb *accountsdb.AccountsDb, port uint16, epochSchedule *sealevel.SysvarEpochSchedule, genesisHash solana.Hash) *RpcServer {
 	var err error
-	rpcServer := &RpcServer{}
+	rpcServer := &RpcServer{genesisHash: genesisHash.String()}
 
 	addrStr := fmt.Sprintf("0.0.0.0:%d", port)
 	rpcServer.listener, err = net.Listen("tcp", addrStr)

--- a/pkg/rpcserver/websocket_test.go
+++ b/pkg/rpcserver/websocket_test.go
@@ -1,0 +1,95 @@
+package rpcserver
+
+import (
+	"bufio"
+	"crypto/rand"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Overclock-Validator/mithril/pkg/global"
+	"github.com/Overclock-Validator/mithril/pkg/sealevel"
+	"github.com/gagliardetto/solana-go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWebSocketControlValidation(t *testing.T) {
+	for _, method := range []string{"xrpc.cancel", "xrpc.ch.val", "xrpc.ch.close"} {
+		t.Run(method, func(t *testing.T) {
+			server := NewRpcServer(nil, 0, &sealevel.SysvarEpochSchedule{}, solana.Hash{1})
+			require.NoError(t, server.listener.Close())
+			endpoint := httptest.NewServer(server)
+			t.Cleanup(endpoint.Close)
+
+			conn, err := net.DialTimeout("tcp", strings.TrimPrefix(endpoint.URL, "http://"), 5*time.Second)
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, conn.Close()) })
+			require.NoError(t, conn.SetDeadline(time.Now().Add(10*time.Second)))
+
+			// A valid RPC body passes the probe filter before the WebSocket upgrade.
+			call := `{"jsonrpc":"2.0","id":7,"method":"getBlockHeight","params":[]}`
+			req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, endpoint.URL, strings.NewReader(call))
+			require.NoError(t, err)
+			req.Header.Set("Connection", "Upgrade")
+			req.Header.Set("Upgrade", "websocket")
+			req.Header.Set("Sec-WebSocket-Version", "13")
+			req.Header.Set("Sec-WebSocket-Key", "MDEyMzQ1Njc4OWFiY2RlZg==")
+			require.NoError(t, req.Write(conn))
+			reader := bufio.NewReader(conn)
+			response, err := http.ReadResponse(reader, req)
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, response.Body.Close()) })
+			require.Equal(t, http.StatusSwitchingProtocols, response.StatusCode)
+
+			for _, test := range []struct{ name, params string }{
+				{"empty", `,"params":[]`},
+				{"omitted", ""},
+				{"null", `,"params":null`},
+				{"object", `,"params":{}`},
+				{"scalar", `,"params":1`},
+				{"array_id", `,"params":[[]]`},
+				{"object_id", `,"params":[{}]`},
+				{"channel_without_value", `,"params":[0]`},
+				{"invalid_channel", `,"params":[{},null]`},
+			} {
+				t.Run(test.name, func(t *testing.T) {
+					require.NoError(t, conn.SetDeadline(time.Now().Add(10*time.Second)))
+					writeTestWebSocketText(t, conn, fmt.Sprintf(`{"jsonrpc":"2.0","method":%q%s}`, method, test.params))
+					writeTestWebSocketText(t, conn, call)
+
+					// The next RPC response proves the control frame was processed without a crash.
+					var header [2]byte
+					_, err := io.ReadFull(reader, header[:])
+					require.NoError(t, err)
+					require.Equal(t, byte(0x81), header[0], "expected a complete text frame")
+					require.Less(t, int(header[1]), 126, "expected a short, unmasked response")
+					payload := make([]byte, int(header[1]))
+					_, err = io.ReadFull(reader, payload)
+					require.NoError(t, err)
+					require.JSONEq(t, fmt.Sprintf(`{"jsonrpc":"2.0","id":7,"result":%d}`, global.BlockHeight()), string(payload))
+				})
+			}
+		})
+	}
+}
+
+// writeTestWebSocketText writes a short, masked client frame over the upgraded connection.
+func writeTestWebSocketText(t *testing.T, conn net.Conn, payload string) {
+	t.Helper()
+	require.Less(t, len(payload), 126)
+	var mask [4]byte
+	_, err := rand.Read(mask[:])
+	require.NoError(t, err)
+	frame := append([]byte{0x81, 0x80 | byte(len(payload))}, mask[:]...)
+	for i := range len(payload) {
+		frame = append(frame, payload[i]^mask[i%len(mask)])
+	}
+	n, err := conn.Write(frame)
+	require.NoError(t, err)
+	require.Equal(t, len(frame), n)
+}


### PR DESCRIPTION
## Summary

Add `getGenesisHash` using the cluster genesis hash resolved during startup.

- Return the Base58-encoded hash for individual and batch requests.
- Accept omitted, empty, or null parameters and reject unexpected arguments.
- Add tests for different cluster identities, SDK/HTTP calls, and cancellation.
- Update go-jsonrpc to v0.10.2 to prevent crashes from malformed WebSocket control messages, with regression coverage.

## Validation

- RPC and node tests passed with the race detector.
- WebSocket regression checks and upstream go-jsonrpc tests passed.
- go vet and the macOS CLI build passed.
- Before the dependency update, macOS/Linux builds and a full-node Alpenglow snapshot test passed. getGenesisHash matched Agave and the generated genesis file, including while the seed RPC was paused.

Bootstrap and consensus behavior are unchanged. The full repository test suite and Mithril-only cluster consensus were not validated.
