### PR TITLE
sealevel: implement sol_remaining_compute_units  syscall

### DIFF
--- a/pkg/features/gates.go
+++ b/pkg/features/gates.go
@@ -27,6 +27,7 @@ var DedupeConfigProgramSigners = FeatureGate{Name: "DedupeConfigProgramSigners",
 var Ed25519PrecompileVerifyStrict = FeatureGate{Name: "Ed25519PrecompileVerifyStrict", Address: base58.MustDecodeFromString("ed9tNscbWLYBooxWA7FE2B5KHWs8A6sxfY8EzezEcoo")}
 var AbortOnInvalidCurve = FeatureGate{Name: "AbortOnInvalidCurve", Address: base58.MustDecodeFromString("FuS3FPfJDKSNot99ECLXtp3rueq36hMNStJkPJwWodLh")}
 var Blake3SyscallEnabled = FeatureGate{Name: "Blake3SyscallEnabled", Address: base58.MustDecodeFromString("HTW2pSyErTj4BV6KBM9NZ9VBUJVxt7sacNWcf76wtzb3")}
+var RemainingComputeUnitsSyscallEnabled = FeatureGate{Name: "RemainingComputeUnitsSyscallEnabled", Address: base58.MustDecodeFromString("5TuppMutoyzhUSfuYdhgzD47F92GL1g89KpCZQKqedxP")}
 var Curve25519SyscallEnabled = FeatureGate{Name: "Curve25519SyscallEnabled", Address: base58.MustDecodeFromString("7rcw5UtqgDTBBv2EcynNfYckgdAaH1MAsCjKgXMkN7Ri")}
 var SimplifyAltBn128SyscallErrorCodes = FeatureGate{Name: "SimplityAltBn128SyscallErrorCodes", Address: base58.MustDecodeFromString("JDn5q3GBeqzvUa7z67BbmVHVdE3EbUAjvFep3weR3jxX")}
 var EnableAltbn128CompressionSyscall = FeatureGate{Name: "EnableAltbn128CompressionSyscall", Address: base58.MustDecodeFromString("EJJewYSddEEtSZHiqugnvhQHiWyZKjkFDQASd7oKSagn")}
@@ -115,7 +116,7 @@ var AllFeatureGates = []FeatureGate{StopTruncatingStringsInSyscalls, EnableParti
 	CommissionUpdatesOnlyAllowedInFirstHalfOfEpoch, TimelyVoteCredits, ReduceStakeWarmupCooldown,
 	StakeRaiseMinimumDelegationTo1Sol, StakeRedelegateInstruction, RequireRentExemptSplitDestination,
 	DeprecateExecutableMetaUpdateInBpfLoader, RelaxAuthoritySignerCheckForLookupTableCreation, DedupeConfigProgramSigners,
-	Ed25519PrecompileVerifyStrict, AbortOnInvalidCurve, Blake3SyscallEnabled, Curve25519SyscallEnabled, SimplifyAltBn128SyscallErrorCodes,
+	Ed25519PrecompileVerifyStrict, AbortOnInvalidCurve, Blake3SyscallEnabled, RemainingComputeUnitsSyscallEnabled, Curve25519SyscallEnabled, SimplifyAltBn128SyscallErrorCodes,
 	EnableAltbn128CompressionSyscall, EnableAltBn128Syscall, DisableFeesSysvar, DisableRentFeesCollection, DeprecateUnusedLegacyVotePlumbing,
 	RewardFullPriorityFee, StakeMinimumDelegationForRewards, MoveStakeAndMoveLamportsIxs, GetSysvarSyscallEnabled,
 	AddNewReservedAccountKeys, EnableSecp256r1Precompile, FixAltBn128MultiplicationInputLength, EnableTowerSyncIx, SkipRentRewrites,

--- a/pkg/replay/remaining_compute_units_test.go
+++ b/pkg/replay/remaining_compute_units_test.go
@@ -1,0 +1,108 @@
+package replay
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"math"
+	"sync"
+	"testing"
+
+	"github.com/Overclock-Validator/mithril/pkg/accounts"
+	"github.com/Overclock-Validator/mithril/pkg/accountsdb"
+	"github.com/Overclock-Validator/mithril/pkg/addresses"
+	"github.com/Overclock-Validator/mithril/pkg/features"
+	"github.com/Overclock-Validator/mithril/pkg/sbpf"
+	"github.com/Overclock-Validator/mithril/pkg/sealevel"
+	"github.com/Overclock-Validator/mithril/pkg/tpu/txfixture"
+	"github.com/gagliardetto/solana-go"
+	"github.com/gagliardetto/solana-go/programs/system"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRemainingComputeUnitsPreservesSuccessfulNonceAdvance(t *testing.T) {
+	slotCtx, cleanup := newCommitTestSlotCtx()
+	defer cleanup()
+	slotCtx.Features.EnableFeature(features.RemainingComputeUnitsSyscallEnabled, 0)
+	slotCtx.Features.EnableFeature(features.DisableAccountLoaderSpecialCase, 0)
+	slotCtx.Features.EnableFeature(features.RemoveAccountsDeltaHash, 0)
+	slotCtx.AccountsDb = &accountsdb.AccountsDb{}
+	slotCtx.AccountsDb.InitCaches()
+	t.Cleanup(slotCtx.AccountsDb.ProgramCache.Close)
+	t.Cleanup(slotCtx.AccountsDb.VoteAcctCache.Close)
+	t.Cleanup(slotCtx.AccountsDb.CommonAcctsCache.Close)
+
+	payer := txfixture.PayerPubkey()
+	nonceKey := solana.PublicKey{0xD6}
+	programKey := solana.PublicKey{0xD7}
+	initialNonce := [32]byte{0xAA}
+	nonceState := sealevel.NonceStateVersions{
+		Type: sealevel.NonceVersionCurrent,
+		Current: sealevel.NonceData{
+			IsInitialized: true,
+			Authority:     payer,
+			DurableNonce:  initialNonce,
+			FeeCalculator: sealevel.FeeCalculator{LamportsPerSignature: 5000},
+		},
+	}
+	nonceData, err := nonceState.Marshal()
+	require.NoError(t, err)
+	require.NoError(t, slotCtx.SetAccount(nonceKey, &accounts.Account{
+		Key: nonceKey, Lamports: 10_000_000, Owner: addresses.SystemProgramAddr,
+		Data: nonceData, RentEpoch: math.MaxUint64,
+	}))
+	require.NoError(t, slotCtx.SetAccount(sealevel.SysvarRecentBlockHashesAddr, &accounts.Account{
+		Key: sealevel.SysvarRecentBlockHashesAddr, Lamports: 42_706_560,
+		Owner: addresses.SysvarOwnerAddr, RentEpoch: math.MaxUint64,
+		Data: sealevel.SysvarCache.RecentBlockHashes.Sysvar.MustMarshal(),
+	}))
+	require.NoError(t, slotCtx.SetAccount(addresses.BpfLoader2Addr, &accounts.Account{
+		Key: addresses.BpfLoader2Addr, Lamports: 1, Owner: addresses.NativeLoaderAddr,
+		Executable: true, RentEpoch: math.MaxUint64,
+	}))
+	require.NoError(t, slotCtx.SetAccount(programKey, &accounts.Account{
+		Key: programKey, Lamports: 1_000_000, Owner: addresses.BpfLoader2Addr,
+		Executable: true, RentEpoch: math.MaxUint64,
+	}))
+
+	// A cached SBF program keeps this regression independent of an external ELF:
+	// call sol_remaining_compute_units; mov64 r0, 0; exit.
+	text := []sbpf.Slot{
+		sbpf.Slot(sbpf.OpCall) | sbpf.Slot(sbpf.SymbolHash("sol_remaining_compute_units"))<<32,
+		sbpf.Slot(sbpf.OpMov64Imm),
+		sbpf.Slot(sbpf.OpExit),
+	}
+	textBytes := make([]byte, len(text)*sbpf.SlotSize)
+	for i, instruction := range text {
+		binary.LittleEndian.PutUint64(textBytes[i*sbpf.SlotSize:], uint64(instruction))
+	}
+	program := &sbpf.Program{Text: text, TextBytes: textBytes, TextVA: sbpf.VaddrProgram}
+	require.NoError(t, program.Verify())
+	slotCtx.AccountsDb.AddProgramToCache(programKey, &accountsdb.ProgramCacheEntry{Program: program})
+
+	tx, err := solana.NewTransaction([]solana.Instruction{
+		system.NewAdvanceNonceAccountInstruction(nonceKey, solana.SysVarRecentBlockHashesPubkey, payer).Build(),
+		solana.NewInstruction(programKey, nil, nil),
+	}, solana.Hash(txfixture.TestBlockhash()), solana.TransactionPayer(payer))
+	require.NoError(t, err)
+	payerPrivateKey := txfixture.PayerPrivateKey()
+	_, err = tx.Sign(func(key solana.PublicKey) *solana.PrivateKey {
+		if key == payer {
+			return &payerPrivateKey
+		}
+		return nil
+	})
+	require.NoError(t, err)
+
+	var sigverify sync.WaitGroup
+	feeInfo, _, err := ProcessTransaction(slotCtx, &sigverify, tx, nil, nil, nil, false)
+	sigverify.Wait()
+	require.NoError(t, err)
+	require.Equal(t, uint64(5000), feeInfo.TotalFee)
+	nonceAfter, err := slotCtx.GetAccount(nonceKey)
+	require.NoError(t, err)
+	decoded, err := sealevel.UnmarshalNonceStateVersions(nonceAfter.Data)
+	require.NoError(t, err)
+	expectedNonce := sha256.Sum256(append([]byte("DURABLE_NONCE"), slotCtx.LastBlockhash[:]...))
+	require.Equal(t, expectedNonce, decoded.State().DurableNonce)
+	require.Contains(t, slotCtx.ModifiedAccts, nonceKey)
+}

--- a/pkg/sealevel/syscalls.go
+++ b/pkg/sealevel/syscalls.go
@@ -14,6 +14,7 @@ const (
 	hash_sol_log_64_                           = 0x5c2a3178
 	hash_sol_log_pubkey                        = 0x7ef088ca
 	hash_sol_log_compute_units_                = 0x52ba5096
+	hash_sol_remaining_compute_units           = 0xedef5aee
 	hash_sol_log_data                          = 0x7317b434
 	hash_sol_sha256                            = 0x11f49d86
 	hash_sol_keccak256                         = 0xd7793abb
@@ -64,6 +65,9 @@ func Syscalls(ft *features.Features, isDeploy bool, h uint32) (f sbpf.Syscall, o
 		f = SyscallLogPubkey
 	case hash_sol_log_compute_units_:
 		f = SyscallLogCUs
+	case hash_sol_remaining_compute_units:
+		f = SyscallRemainingComputeUnits
+		ok = ft.IsActive(features.RemainingComputeUnitsSyscallEnabled)
 	case hash_sol_log_data:
 		f = SyscallLogData
 	case hash_sol_sha256:

--- a/pkg/sealevel/syscalls_compute.go
+++ b/pkg/sealevel/syscalls_compute.go
@@ -1,0 +1,18 @@
+package sealevel
+
+import (
+	"github.com/Overclock-Validator/mithril/pkg/cu"
+	"github.com/Overclock-Validator/mithril/pkg/sbpf"
+)
+
+// SyscallRemainingComputeUnitsImpl returns the balance after charging the syscall,
+// matching Agave's sol_remaining_compute_units runtime behavior.
+func SyscallRemainingComputeUnitsImpl(vm sbpf.VM) (uint64, error) {
+	execCtx := executionCtx(vm)
+	if err := execCtx.ComputeMeter.Consume(cu.CUSyscallBaseCost); err != nil {
+		return syscallCuErr()
+	}
+	return syscallSuccess(execCtx.ComputeMeter.Remaining())
+}
+
+var SyscallRemainingComputeUnits = sbpf.SyscallFunc0(SyscallRemainingComputeUnitsImpl)

--- a/pkg/sealevel/syscalls_compute_test.go
+++ b/pkg/sealevel/syscalls_compute_test.go
@@ -1,0 +1,85 @@
+package sealevel
+
+import (
+	"testing"
+
+	"github.com/Overclock-Validator/mithril/pkg/cu"
+	"github.com/Overclock-Validator/mithril/pkg/features"
+	"github.com/Overclock-Validator/mithril/pkg/sbpf"
+	"github.com/Overclock-Validator/mithril/pkg/sbpf/sbpfver"
+	"github.com/gagliardetto/solana-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRemainingComputeUnitsRegistration(t *testing.T) {
+	const name = "sol_remaining_compute_units"
+	assert.Equal(t, uint32(0xedef5aee), sbpf.SymbolHash(name))
+	assert.Equal(t, "5TuppMutoyzhUSfuYdhgzD47F92GL1g89KpCZQKqedxP", solana.PublicKey(features.RemainingComputeUnitsSyscallEnabled.Address).String())
+	assert.Contains(t, features.AllFeatureGates, features.RemainingComputeUnitsSyscallEnabled)
+
+	ft := features.NewFeaturesDefault()
+	for _, deploy := range []bool{false, true} {
+		_, ok := Syscalls(ft, deploy, sbpf.SymbolHash(name))
+		assert.False(t, ok)
+	}
+	ft.EnableFeature(features.RemainingComputeUnitsSyscallEnabled, 0)
+	for _, deploy := range []bool{false, true} {
+		syscall, ok := Syscalls(ft, deploy, sbpf.SymbolHash(name))
+		require.True(t, ok)
+		require.NotNil(t, syscall)
+	}
+}
+
+func TestRemainingComputeUnitsChargesBeforeReturning(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		budget uint64
+		want   uint64
+		fail   bool
+	}{
+		{name: "remaining", budget: 1_000, want: 900},
+		{name: "exact cost", budget: 100, want: 0},
+		{name: "insufficient", budget: 99, fail: true},
+		{name: "empty", budget: 0, fail: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := &ExecutionCtx{ComputeMeter: cu.NewComputeMeter(tc.budget)}
+			vm := sbpf.NewInterpreter(&sbpf.Program{}, &sbpf.VMOpts{Context: ctx, ComputeMeter: &ctx.ComputeMeter})
+			defer vm.Finish()
+			remaining, err := SyscallRemainingComputeUnits.Invoke(vm, 0, 0, 0, 0, 0)
+			if tc.fail {
+				require.ErrorIs(t, err, InstrErrComputationalBudgetExceeded)
+				assert.Zero(t, ctx.ComputeMeter.Remaining())
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tc.want, remaining)
+				assert.Equal(t, tc.want, ctx.ComputeMeter.Remaining())
+			}
+		})
+	}
+}
+
+func TestRemainingComputeUnitsInterpreterCall(t *testing.T) {
+	ft := features.NewFeaturesDefault()
+	ft.EnableFeature(features.RemainingComputeUnitsSyscallEnabled, 0)
+	for _, version := range []sbpfver.SbpfVersion{{Version: sbpfver.SbpfVersionV0}, {Version: sbpfver.SbpfVersionV3}} {
+		ctx := &ExecutionCtx{ComputeMeter: cu.NewComputeMeter(1_000)}
+		program := &sbpf.Program{
+			SbpfVersion: version,
+			Text: []sbpf.Slot{
+				sbpf.Slot(sbpf.OpCall) | sbpf.Slot(uint64(0xedef5aee)<<32),
+				sbpf.Slot(sbpf.OpExit),
+			},
+		}
+		vm := sbpf.NewInterpreter(program, &sbpf.VMOpts{
+			Context: ctx, ComputeMeter: &ctx.ComputeMeter,
+			Syscalls: func(hash uint32) (sbpf.Syscall, bool) { return Syscalls(ft, false, hash) },
+		})
+		ret, _, err := vm.Run()
+		vm.Finish()
+		require.NoError(t, err)
+		assert.Equal(t, uint64(899), ret, "call instruction and syscall are charged before the observed balance")
+		assert.Equal(t, uint64(898), ctx.ComputeMeter.Remaining(), "exit is charged after the observed balance")
+	}
+}

--- a/pkg/sealevel/syscalls_gen/main.go
+++ b/pkg/sealevel/syscalls_gen/main.go
@@ -23,6 +23,7 @@ func main() {
 		{"sol_log_64_", "SyscallLog64", ""},
 		{"sol_log_pubkey", "SyscallLogPubkey", ""},
 		{"sol_log_compute_units_", "SyscallLogCUs", ""},
+		{"sol_remaining_compute_units", "SyscallRemainingComputeUnits", "ft.IsActive(features.RemainingComputeUnitsSyscallEnabled)"},
 		{"sol_log_data", "SyscallLogData", ""},
 		{"sol_sha256", "SyscallSha256", ""},
 		{"sol_keccak256", "SyscallKeccak256", ""},


### PR DESCRIPTION
We were missing the `sol_remaining_compute_units` syscall. Implement it here, with some tests.